### PR TITLE
Address twelve findings from 2026-05 adversarial review (0.2.0)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# MAINTAINER: replace <MAINTAINER> with the GitHub handle or team that should
+# review every change. Multiple owners can be listed space-separated.
+* @MAINTAINER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,27 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
-      - name: Install test dependency
-        run: python -m pip install --upgrade pip pytest
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest ruff
 
       - name: Run tests
         run: python -m pytest -q
+
+      - name: Run ruff lint
+        run: python -m ruff check .
 
       - name: Compile Python files
         run: python -m py_compile tools/ng.py tools/ng_validate.py docs/03-worked-examples/ai-agent-tool-permissions/reference/workspace_guard.py
@@ -41,3 +48,53 @@ jobs:
           while IFS= read -r packet; do
             python tools/ng.py validate "$packet"
           done < <(find docs/03-worked-examples -path '*/.nuclear/changes/*' -type d -prune -print)
+
+  wheel-smoke:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build wheel
+        run: python -m build --wheel --outdir dist
+
+      - name: Install wheel into clean venv
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/wheel-smoke-venv
+          /tmp/wheel-smoke-venv/bin/pip install --upgrade pip
+          /tmp/wheel-smoke-venv/bin/pip install dist/*.whl
+
+      - name: Smoke-test installed CLI outside source tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          NG=/tmp/wheel-smoke-venv/bin/nuclear-grade
+          WORK=$(mktemp -d)
+          cd "$WORK"
+          "$NG" init .
+          "$NG" new my-quick --mode quick
+          "$NG" new my-std --mode standard
+          "$NG" new my-cm --mode cm
+          "$NG" new my-gp --mode golden-path
+          LIST_OUTPUT=$("$NG" list)
+          echo "$LIST_OUTPUT"
+          echo "$LIST_OUTPUT" | grep -q "Skills:"
+          echo "$LIST_OUTPUT" | grep -q "questioning-attitude"
+          echo "$LIST_OUTPUT" | grep -q "ng-question.md"
+          set +e
+          "$NG" validate .nuclear/changes/my-quick
+          rc=$?
+          set -e
+          [ "$rc" -eq 1 ]
+          echo "wheel-smoke OK"

--- a/.nuclear/changes/review-findings-2026-05/basis.md
+++ b/.nuclear/changes/review-findings-2026-05/basis.md
@@ -1,0 +1,93 @@
+# Basis
+
+## Change context
+
+- Slug: review-findings-2026-05
+- Scope: Address the twelve findings from the 2026-05 adversarial review.
+- Outcome to protect: Repo claims (rigor, questioning attitude, controlled change) remain credible after upgrade to 0.2.0.
+
+## Need and scope
+
+The 2026-05 adversarial review surfaced twelve actionable findings against `nuclear-grade-context-engineering`. Six are critical-to-high (F1, F2, F3, F4, F8, F9). The repo's positioning depends on rigor and a questioning attitude; the front-door demo failing red without framing, the installed wheel being functionally broken, and the prohibited-claims detector being trivially evaded all undermine the thesis the repo sells. This packet records the coordinated fix.
+
+## Protected and unacceptable outcomes
+
+| Concern | Protected outcome | Unacceptable outcome |
+|---|---|---|
+| Front-door credibility | A new reader runs the 60-second demo and reads framing that explains why `FAILED` is expected. | A reader assumes the project is broken and bounces. |
+| Installed wheel | `pip install` followed by `nuclear-grade new` works in a clean environment. | The wheel is functionally inert outside the repo. |
+| Overclaiming detector | Paraphrased compliance claims (see code-block corpus below) fail validation. | Paraphrases evade the rule and ship in downstream packets. |
+| Mode discipline | Every packet declares Quick or Standard explicitly. | Mode is inferred silently from file presence, masking authorial intent. |
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Evidence planned |
+|---|---|---|
+| C-001 | The README and QUICKSTART frame the 60-second demo so the expected `FAILED` is read as intended, not as breakage. | Diff of `README.md` and `QUICKSTART.md`; manual readthrough. |
+| C-002 | A wheel built from this repo, installed into a clean venv, can run `nuclear-grade init`, `new --mode quick`, `new --mode standard`, `new --mode cm`, `new --mode golden-path`, `list`, and `validate` end to end. | New `wheel-smoke` CI job; `tests/test_packaging.py` archive-content assertion. |
+| C-003 | The validator rejects paraphrased compliance claims (see code block below) while still allowing legitimate "inspired by" / "does not claim" prose. | New paraphrase-battery tests in `tests/test_ng_validate.py`. |
+| C-004 | The validator requires every packet's `risk.md` to declare `- **Mode:** Quick` or `- **Mode:** Standard` under a `## Selected mode` heading. A `nuclear-grade migrate` helper inserts that line for legacy packets. | New `tests/test_ng_validate.py` missing-mode case; new `tests/test_ng_cli.py` migrate case. |
+| C-005 | `nuclear-grade new` supports `--mode cm` and `--mode golden-path`, scaffolding all five files for each mode. | New `tests/test_ng_cli.py` scaffolding tests. |
+| C-006 | CI runs on Python 3.11 and 3.12 and includes a `ruff` lint step. | Diff of `.github/workflows/ci.yml`; CI green on both legs. |
+| C-007 | The unfilled-prompt detector matches labels longer than 80 characters. | New `tests/test_ng_validate.py` long-label case. |
+| C-008 | The README and `results-summary.md` describe the worked-example evidence as "tested" and the comparison as "author-judged," not as "validated" without qualification. | Diff of `README.md:19`, `README.md:151`, and `docs/03-worked-examples/skill-workflow-comparison/results-summary.md` banner. |
+| C-009 | `CHANGELOG.md` has one Unreleased section above a stamped `[0.2.0] - 2026-05-27` entry with Breaking / Added / Fixed / Changed subsections. | Diff of `CHANGELOG.md`. |
+| C-010 | The repo carries a `CITATION.cff` (CFF 1.2) and a `.github/CODEOWNERS` (placeholder for maintainer handle). | Files exist; doctor passes. |
+| C-011 | `docs/04-adoption/report-swot-gap-remediation.md` marks the proposed-but-not-present files as such so a reader cannot mistake them for current refs. | Diff of the file. |
+| C-012 | `pyproject.toml` uses the `hatchling` build backend with `force-include` mapping top-level `templates/`, `skills/`, and `commands/` into `nuclear_grade/_bundled/` at wheel-build time. Version is `0.2.0`. | Diff of `pyproject.toml`; built wheel archive contains the expected paths. |
+
+## Paraphrase test corpus (examples that must fail validation)
+
+```
+meets NQA-1 requirements
+fully ASME qualified
+conforms to IEEE 829
+satisfies 10 CFR 50 Appendix B
+implements quality assurance per NQA-1
+audited to NRC standards
+regulator-approved
+```
+
+Allowed-by-boundary corpus:
+
+```
+inspired by NQA-1 concepts
+influenced by ASME structure, not aligned with it
+we do not claim IEEE conformance
+this repo is not NRC compliant
+no formal V&V is implied
+```
+
+## Assumptions, constraints, and invalidation triggers
+
+- Assumption: `hatchling` `force-include` produces files reachable from a `pip install`-ed package via `importlib.resources` or direct `__file__`-relative path. Invalidation trigger: wheel-smoke job cannot find `_bundled/templates/quick/risk.md`.
+- Assumption: All seven existing repo packets already declare `## Selected mode` (confirmed during pre-flight). Invalidation trigger: a packet without it is found mid-build.
+- Constraint: No em dashes or en dashes in any new written content (style preference).
+- Constraint: 0.2.0 version bump because the validator's new Mode requirement breaks downstream packets that did not previously declare a mode.
+
+## Acceptance scenarios
+
+- A maintainer runs `pip install dist/nuclear_grade-0.2.0-py3-none-any.whl` in a fresh venv outside the source tree, then `nuclear-grade init .` followed by `nuclear-grade new demo --mode cm`. Five CM files appear in `.nuclear/changes/demo/`.
+- A downstream user upgrading from 0.1.0 runs `nuclear-grade migrate .nuclear/changes/old-packet`. The packet's `risk.md` gains a `## Selected mode` section. Subsequent `validate` passes that rule.
+- A reviewer pastes one of the corpus phrases above into a packet basis. `validate` reports a prohibited compliance claim with the offending phrase named in the message.
+
+## Required links
+
+- Packet: `.nuclear/changes/review-findings-2026-05/`
+- `risk.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Twelve claims C-001 through C-012 are mapped to plan steps in `plan.md`.
+- Each claim has an evidence row in `verification.md`.
+- `trace.md` is populated end to end.
+- Ship decision is recorded in `ship.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade packet inspired by the public graded-rigor, configuration-management, and software-assurance concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/review-findings-2026-05/plan.md
+++ b/.nuclear/changes/review-findings-2026-05/plan.md
@@ -1,0 +1,76 @@
+# Plan
+
+## Change context
+
+- Slug: review-findings-2026-05
+- Mode: Standard
+- Owner: maintainer
+
+## Build sequence
+
+Three layers (tooling, content, hygiene) with regression tests added before each substantive code change so each fix has a verifiable definition of done.
+
+1. **Packet skeleton.** `risk.md`, `basis.md`, `plan.md` exist from step one with `## Selected mode` declared (this file is step one).
+2. **Pre-flight.** Confirm every existing repo packet declares a mode. (Completed: all seven packets already have a `## Selected mode` section.)
+3. **Regression tests added first.** Paraphrase battery (F3), missing-mode (F4), `--mode cm` and `--mode golden-path` scaffolding (F5), long-label empty prompt (F7), packaging archive contents (F2 contract), `migrate` subcommand (F4). Confirmed failing before code changes.
+4. **Validator updates.** `nuclear_grade/ng_validate.py` gets: tightened `EMPTY_PROMPT_PATTERN` (F7), explicit mode requirement (F4), and hybrid prohibited-claims detector (F3) that augments the fixed-phrase list with a verb-stem regex over compliance nouns. Negation gate broadens to `inspired by`, `influenced by`, `does not claim`, `not implementing`. Existing tests at `tests/test_ng_validate.py:122-151` are guardrails.
+5. **CLI updates.** `nuclear_grade/cli.py` gets: `--mode cm` and `--mode golden-path` for `new` scaffolding all five files of each mode (F5); a `migrate` subcommand that inserts `## Selected mode` into a `risk.md` lacking one (F4 migration); and a wheel-aware resolver for `SKILLS`, `COMMANDS`, and the bundled-templates fallback (F2).
+6. **Build backend switch.** `pyproject.toml` switches to `hatchling` with `[tool.hatch.build.targets.wheel.force-include]` mapping `templates`, `skills`, `commands` into `nuclear_grade/_bundled/` (F2, F12). Version bumps to `0.2.0` (F12). Adds `[tool.ruff]` configuration (F6).
+7. **CI updates.** `.github/workflows/ci.yml` matrices on Python 3.11 and 3.12, adds a `ruff` step, and adds a `wheel-smoke` job that builds, installs, and exercises the wheel end to end (F6, F2 regression).
+8. **Test pass.** Full pytest suite under 3.11 and 3.12 (or the available interpreter); `doctor` and `validate` on every existing packet.
+9. **Content updates.** `README.md` (F1 framing, F8 tightened "validated"), `QUICKSTART.md` (F1 framing, F5 scaffold commands, F4 migration callout), `templates/quick/risk.md` (F4 pre-fill), `docs/03-worked-examples/skill-workflow-comparison/results-summary.md` (F8 banner, centered cells), `docs/04-adoption/report-swot-gap-remediation.md` (F11 proposed banner).
+10. **Hygiene.** `CHANGELOG.md` collapsed and stamped (F9), `CITATION.cff` (F10), `.github/CODEOWNERS` (F10).
+11. **Packet closure.** Fill `trace.md`, `verification.md`, `ship.md`. Run `python tools/ng.py validate .nuclear/changes/review-findings-2026-05`.
+12. **Push.** Commit and push to `claude/intelligent-knuth-QA4L5`. Open draft PR.
+
+## Critical-action self-check
+
+Not activated. No wrong-target risk: every file is edited within the repo tree and tests assert behavior at every layer.
+
+## HPI work-mode controls
+
+- **Task preview (before wheel rework):** Confirm `hatchling` `force-include` is the correct mechanism (it is, per Hatch docs). Confirm the resolver tries the repo path first so the in-repo dev workflow stays intact. Confirm CI catches a missing bundled file.
+- **Self-check (before validator change):** The new regex must not break the three existing guardrail tests at `tests/test_ng_validate.py:122-151`. Run those tests after each edit to the validator module.
+- **Turnover:** Not activated (single-author packet).
+
+## Files to create
+
+- `.nuclear/changes/review-findings-2026-05/risk.md` (this packet)
+- `.nuclear/changes/review-findings-2026-05/basis.md`
+- `.nuclear/changes/review-findings-2026-05/plan.md` (this file)
+- `.nuclear/changes/review-findings-2026-05/trace.md`
+- `.nuclear/changes/review-findings-2026-05/verification.md`
+- `.nuclear/changes/review-findings-2026-05/ship.md`
+- `CITATION.cff`
+- `.github/CODEOWNERS`
+
+## Files to modify
+
+- `nuclear_grade/cli.py`, `nuclear_grade/ng_validate.py`
+- `pyproject.toml`
+- `.github/workflows/ci.yml`
+- `tests/test_ng_validate.py`, `tests/test_ng_cli.py`, `tests/test_packaging.py`
+- `README.md`, `QUICKSTART.md`
+- `templates/quick/risk.md`
+- `docs/03-worked-examples/skill-workflow-comparison/results-summary.md`
+- `docs/04-adoption/report-swot-gap-remediation.md`
+- `CHANGELOG.md`
+
+## Required links
+
+- Packet: `.nuclear/changes/review-findings-2026-05/`
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Build sequence above is executed top to bottom.
+- Test suite green.
+- Packet passes its own validator.
+
+## Source-lineage note
+
+Original Nuclear-grade plan inspired by graded-rigor and configuration-management lifecycle concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/review-findings-2026-05/risk.md
+++ b/.nuclear/changes/review-findings-2026-05/risk.md
@@ -1,0 +1,101 @@
+# Risk
+
+## Change identity
+
+- Slug: review-findings-2026-05
+- PR / issue: (TBD on push)
+- Owner: maintainer
+- Date: 2026-05-27
+- Current lifecycle phase: Execute
+- Summary: Coordinated remediation of the twelve findings from the 2026-05 adversarial review of `nuclear-grade-context-engineering`. Closes a critical front-door framing gap (F1), a critical installed-wheel breakage (F2), and a high-leverage prohibited-claims evasion (F3); adds an enforced mode declaration (F4); raises CLI surface to cover all four template modes (F5); adds CI matrix and lint (F6); tightens validator detection (F7); softens evidence-overclaiming framing in worked-example and README (F8); cleans changelog state (F9); adds CITATION.cff and CODEOWNERS (F10); marks the SWOT remediation report as proposed (F11); and stamps 0.2.0.
+
+## Questioning-attitude summary
+
+- Decision question: Should the repo ship the twelve fixes as a single coordinated 0.2.0 release, or split them across smaller releases?
+- Assumptions that changed the mode: The Mode declaration requirement (F4) is a breaking validator rule for downstream packets; the wheel rework (F2) changes the build backend. Both warrant Standard and a minor version bump.
+- Facts still needing validation: That `hatchling` `force-include` produces a wheel where `nuclear_grade/_bundled/<dir>/...` is reachable from a clean `pip install`. That existing repo packets still validate after the validator change.
+- Stop or hold conditions: If `hatchling` switch destabilizes the wheel, defer F2 to a follow-up release, ship the other eleven fixes as 0.2.0, mark F2 as Not Included.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `nuclear_grade/cli.py` | Code | Adds `--mode cm`, `--mode golden-path`, `migrate`, wheel resolver | `../../../nuclear_grade/cli.py` |
+| `nuclear_grade/ng_validate.py` | Code | Tightens prohibited-claims regex, mode requirement, long-label detection | `../../../nuclear_grade/ng_validate.py` |
+| `pyproject.toml` | Build | Switches to `hatchling`; bumps to 0.2.0 | `../../../pyproject.toml` |
+| `.github/workflows/ci.yml` | CI | Adds matrix, ruff, wheel-smoke job | `../../../.github/workflows/ci.yml` |
+| `README.md`, `QUICKSTART.md` | Docs | Frames the demo, lists new CLI modes | `../../../README.md`, `../../../QUICKSTART.md` |
+| `templates/quick/risk.md`, `templates/standard/risk.md` | Templates | Pre-fills the Mode declaration | `../../../templates/quick/risk.md` |
+| `docs/03-worked-examples/skill-workflow-comparison/results-summary.md` | Docs | Adds methodology banner | (see file) |
+| `docs/04-adoption/report-swot-gap-remediation.md` | Docs | Marks proposed-vs-existing | (see file) |
+| `CHANGELOG.md`, `CITATION.cff`, `.github/CODEOWNERS` | Hygiene | Release-stamping and governance | `../../../CHANGELOG.md` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Affects public CLI behavior and validator rules for external users. |
+| Reversibility | medium | Each layer is revertible; wheel rework reverts as one commit. |
+| Detectability | high | CI matrix, wheel-smoke job, and pytest will fail loudly on regressions. |
+| Exposure | medium | Public repo; external users may already pin to 0.1.0. |
+| Uncertainty | medium | `hatchling` `force-include` behavior is well documented but not previously used here. |
+| Dependency trust | low | Adds `hatchling`, `ruff`, `build`. All PyPA-or-Astral mainline. |
+| AI authority | low | No new agent-write permissions. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine/repetitive action where inattention is plausible | no | n/a |
+| Known procedure where workflow adherence matters | yes | packet path with explicit execution order in `plan.md` |
+| Novel or uncertain work where assumptions may be wrong | yes | questioning attitude in this risk; wheel rework has a documented rollback |
+| Interrupted, resumed, or handed-off work | no | n/a |
+| High-consequence critical action | no | n/a |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** Twelve coordinated changes spanning code, build, CI, content, and templates; a breaking validator rule; a release stamp.
+- **Why lighter mode is not enough:** Quick cannot record claim-to-evidence mapping for twelve findings or the basis for the breaking change.
+- **Why heavier mode is not yet required:** No regulated-use deployment, no safety basis, no controlled-supplier dedication. Public repo update only.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline above for brevity. | maintainer |
+| `basis.md` | yes | Twelve findings need claim-to-evidence mapping. | maintainer |
+| `verification.md` | yes | Per-claim evidence status. | maintainer |
+| `ship.md` | yes | Release decision for 0.2.0. | maintainer |
+| `turnover.md` | no | No handoff; single-author packet. | maintainer |
+| `self-check.md` | no | No high-consequence critical action present. | maintainer |
+| `supplier-trust.md` | no | No new external supplier. | maintainer |
+| Nuclear subset record | no | Not warranted. | maintainer |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: All seven existing repo packets already declare a `## Selected mode` section. Confirmed.
+- Minimum evidence before merge/release: pytest green on 3.11 and 3.12; `doctor` OK; every existing packet validates; wheel-smoke job green; manual paraphrase battery passes; CHANGELOG stamped 0.2.0.
+- Independent review needed? no for this PR; the review under remediation is itself the independent input.
+
+## Required links
+
+- Packet: `.nuclear/changes/review-findings-2026-05/`
+- Related PR/issue: TBD on push
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Mode is justified as Standard.
+- Activated artifacts are explicit.
+- Twelve findings are individually addressed in `basis.md` claims C-001 through C-012.
+- No hidden activation trigger for a stronger mode.
+
+## Source-lineage note
+
+Original Nuclear-grade packet inspired by the public graded-rigor, configuration-management, software-assurance, and secure-development concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/review-findings-2026-05/ship.md
+++ b/.nuclear/changes/review-findings-2026-05/ship.md
@@ -1,0 +1,64 @@
+# Ship
+
+## Release decision
+
+- **Decision:** ship as version 0.2.0 once CI is green on both Python 3.11 and 3.12 legs and the `wheel-smoke` job passes.
+- **Rationale:** The validator's new Mode requirement is a deliberate breaking change versus 0.1.x. A minor-version bump signals that to anyone with pinned downstream usage. The `migrate` subcommand exists to help.
+- **Pre-merge gates:**
+  - `python -m pytest -q` green
+  - `python tools/ng.py doctor .` OK
+  - `python tools/ng.py validate` OK on every existing packet
+  - `python tools/ng.py validate .nuclear/changes/review-findings-2026-05` OK
+  - CI green on both 3.11 and 3.12 matrix legs
+  - `ruff check .` clean
+  - `wheel-smoke` job green
+
+## Evidence status summary
+
+| Area | Status | Link |
+|---|---|---|
+| Verification | pass | `verification.md` |
+| Trace | pass | `trace.md` |
+| Basis | pass | `basis.md` |
+| Test suite | pass | `tests/` (73 tests at this writing) |
+| Wheel install | pass | local build artifact + `wheel-smoke` job |
+| Packet self-validation | pass | `python tools/ng.py validate .nuclear/changes/review-findings-2026-05` |
+
+## Rollback / restore plan
+
+- The work lands as one branch (`claude/intelligent-knuth-QA4L5`) with commits aligned to the layered execution order in `plan.md`. The PR is a draft.
+- Rollback option A (clean revert): `git revert <merge-commit>` after merge.
+- Rollback option B (partial revert): revert only the validator commits if F3/F4 trip an unexpected downstream. The wheel rework and the content fixes are independent and survive.
+- Rollback option C (deferred F2): if the `wheel-smoke` job uncovers a hatchling incompatibility, revert `pyproject.toml` and `_bundled/`-resolver code; ship the other eleven fixes as 0.2.0 and call out F2 as "deferred to 0.2.1" in `CHANGELOG.md`.
+
+## Monitoring and post-release checks
+
+- Watch the `wheel-smoke` job on every PR for at least the first three PRs after merge.
+- Watch `validate` runs against the seven existing repo packets for any false-positive prohibited-claim regressions.
+- Encourage early adopters to file a GitHub issue with the offending phrase and surrounding paragraph if the paraphrase detector flags legitimate boundary prose. Treat each as a deduplication candidate for the negation gate (`BOUNDARY_PREFIXES` or `_has_paragraph_disclaimer` markers).
+- After release, watch for any external user reports that `migrate` produced a wrong-mode inference. The default behavior (Standard if any Standard-only file present, otherwise Quick) is the simplest possible heuristic and may need refinement.
+
+## Maintainer follow-ups (post-merge)
+
+- Replace `MAINTAINER:` placeholder in `CITATION.cff` with the preferred citation identity.
+- Replace `@MAINTAINER` in `.github/CODEOWNERS` with the maintainer's GitHub handle.
+- Tag the release as `v0.2.0` after the placeholder edits land on `main`.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+
+## Exit criteria
+
+- Decision is recorded.
+- Rollback plan is named.
+- Monitoring is named.
+- Maintainer follow-ups are explicit.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record inspired by lifecycle-decision and release-readiness concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/review-findings-2026-05/trace.md
+++ b/.nuclear/changes/review-findings-2026-05/trace.md
@@ -1,0 +1,34 @@
+# Trace
+
+## Trace summary
+
+| Claim ID | Finding | Evidence artifact | Status |
+|---|---|---|---|
+| C-001 | F1 README + QUICKSTART framing | `README.md` 60-second-demo paragraph; `QUICKSTART.md` Note callout | pass |
+| C-002 | F2 wheel install path | `.github/workflows/ci.yml` `wheel-smoke` job; `tests/test_packaging.py`; `nuclear_grade/cli.py` `_resolve_resource_root` and `template_root_for` | pass |
+| C-003 | F3 paraphrase detection | `nuclear_grade/ng_validate.py` `PARAPHRASE_PATTERNS`, `_check_prohibited_claims`, `_has_paragraph_disclaimer`; `tests/test_ng_validate.py` `test_paraphrased_compliance_claims_all_fail`, `test_boundary_paraphrases_all_pass` | pass |
+| C-004 | F4 mode declaration required | `nuclear_grade/ng_validate.py` `MODE_DECLARATION_PATTERN`, `_declared_mode`; `nuclear_grade/cli.py` `handle_migrate`; `tests/test_ng_validate.py` `test_packet_without_mode_declaration_fails`; `tests/test_ng_cli.py` `test_migrate_*` | pass |
+| C-005 | F5 CM + golden-path scaffolds | `nuclear_grade/cli.py` `MODE_FILES`, expanded `--mode` choices; `tests/test_ng_cli.py` `test_new_cm_packet_scaffolds_all_cm_files`, `test_new_golden_path_packet_scaffolds_all_files` | pass |
+| C-006 | F6 CI matrix + ruff | `.github/workflows/ci.yml` matrix `["3.11", "3.12"]`, `python -m ruff check .` step; `pyproject.toml` `[tool.ruff]` | pass |
+| C-007 | F7 long-label empty-prompt | `nuclear_grade/ng_validate.py` `EMPTY_PROMPT_PATTERN` (cap removed); `tests/test_ng_validate.py` `test_long_label_empty_prompt_is_detected` | pass |
+| C-008 | F8 "validated" tightened | `README.md` line referencing tested worked example + author-judged comparison; `docs/03-worked-examples/skill-workflow-comparison/results-summary.md` methodology banner | pass |
+| C-009 | F9 CHANGELOG | `CHANGELOG.md` single Unreleased + stamped `[0.2.0] - 2026-05-27` | pass |
+| C-010 | F10 CITATION + CODEOWNERS | `CITATION.cff`; `.github/CODEOWNERS` | pass |
+| C-011 | F11 SWOT proposed framing | `docs/04-adoption/report-swot-gap-remediation.md` proposed-deliverables banner | pass |
+| C-012 | F12 hatchling + force-include + version | `pyproject.toml` `build-system`, `[tool.hatch.build.targets.wheel.force-include]`, `version = "0.2.0"`; local wheel build at `/tmp/wheel-test/nuclear_grade-0.2.0-py3-none-any.whl` confirmed to contain `nuclear_grade/_bundled/{templates,skills,commands}/*` | pass |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim above has a named artifact and a recorded status.
+
+## Source-lineage note
+
+Original Nuclear-grade trace inspired by configuration-management and lifecycle-traceability concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/review-findings-2026-05/verification.md
+++ b/.nuclear/changes/review-findings-2026-05/verification.md
@@ -1,0 +1,65 @@
+# Verification
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+
+## Claim-to-evidence table
+
+| Claim | Result status | Evidence link | Notes |
+|---|---|---|---|
+| C-001 README + QUICKSTART demo framing | pass | `../../../README.md`, `../../../QUICKSTART.md` | "Try it in 60 seconds" now names the expected `FAILED`; QUICKSTART has the `> **Note on the demo**` callout. |
+| C-002 wheel install end-to-end | pass | `../../../.github/workflows/ci.yml` `wheel-smoke` job; `../../../tests/test_packaging.py` | Locally built `nuclear_grade-0.2.0-py3-none-any.whl`; installed into a clean venv; `nuclear-grade init / new --mode {quick,standard,cm,golden-path} / list / validate` all run outside the source tree. |
+| C-003 paraphrase battery | pass | `../../../tests/test_ng_validate.py` `test_paraphrased_compliance_claims_all_fail`, `test_boundary_paraphrases_all_pass` | Seven paraphrases fail; five boundary phrases pass. Existing guardrail tests at `tests/test_ng_validate.py:122-151` still pass. |
+| C-004 mode declaration required + migrate | pass | `../../../nuclear_grade/ng_validate.py` `_declared_mode`; `../../../nuclear_grade/cli.py` `handle_migrate`; `../../../tests/test_ng_cli.py` `test_migrate_*` | Three migrate tests pass; missing-mode test passes; all seven existing repo packets and the worked-example packet still validate (each declares mode). |
+| C-005 cm + golden-path scaffolds | pass | `../../../tests/test_ng_cli.py` `test_new_cm_packet_scaffolds_all_cm_files`, `test_new_golden_path_packet_scaffolds_all_files` | Both scaffold all five files. |
+| C-006 CI matrix + ruff | pass | `../../../.github/workflows/ci.yml` | Matrix is `["3.11", "3.12"]`. `ruff check .` step added before tests pass. `pyproject.toml` `[tool.ruff.lint]` selects E, F, I, B, UP. CI run on push will confirm green. |
+| C-007 long-label empty-prompt | pass | `../../../tests/test_ng_validate.py` `test_long_label_empty_prompt_is_detected` | 200-char label registers as unfilled. |
+| C-008 "validated" tightened | pass | `../../../README.md` line 19 and line 151; `../../../docs/03-worked-examples/skill-workflow-comparison/results-summary.md` banner | README now says "one tested worked example and one author-judged comparison study." Banner adds methodology disclaimer above the score table. |
+| C-009 CHANGELOG stamped | pass | `../../../CHANGELOG.md` | Single Unreleased section, then a stamped `[0.2.0] - 2026-05-27` section with Breaking / Added / Fixed / Changed. |
+| C-010 CITATION + CODEOWNERS | pass | `../../../CITATION.cff`; `../../../.github/CODEOWNERS` | Both files exist; both carry MAINTAINER placeholders to be filled by the human maintainer. |
+| C-011 SWOT proposed framing | pass | `../../../docs/04-adoption/report-swot-gap-remediation.md` | Italic banner above Phase 1 declares Phase 1 through Phase 4 lists as proposed deliverables, not refs to existing files. |
+| C-012 hatchling + force-include + 0.2.0 | pass | `../../../pyproject.toml`; locally built wheel | Wheel contains `nuclear_grade/_bundled/templates/{quick,standard,cm,golden-path}/*`, `nuclear_grade/_bundled/skills/*/SKILL.md`, and `nuclear_grade/_bundled/commands/*.md`. |
+
+## Reproduction commands
+
+```bash
+python -m pytest -q
+python tools/ng.py doctor .
+for packet in .nuclear/changes/*; do python tools/ng.py validate "$packet"; done
+find docs/03-worked-examples -path '*/.nuclear/changes/*' -type d -prune -print \
+  | while read p; do python tools/ng.py validate "$p"; done
+
+python -m build --wheel --outdir /tmp/wheel-test
+python -m venv /tmp/smoke-venv
+/tmp/smoke-venv/bin/pip install /tmp/wheel-test/nuclear_grade-0.2.0-py3-none-any.whl
+cd /tmp && mkdir smoke-work && cd smoke-work
+/tmp/smoke-venv/bin/nuclear-grade init .
+/tmp/smoke-venv/bin/nuclear-grade new my-quick --mode quick
+/tmp/smoke-venv/bin/nuclear-grade new my-cm --mode cm
+/tmp/smoke-venv/bin/nuclear-grade new my-gp --mode golden-path
+/tmp/smoke-venv/bin/nuclear-grade list
+```
+
+## Known gaps and deferrals
+
+- CI itself has not run yet at the time of packet authorship. It will run on push and is the primary public evidence for C-006 and C-002.
+- The `CITATION.cff` and `.github/CODEOWNERS` carry `MAINTAINER:` placeholders. The maintainer must replace these before tagging a release. Recorded as a `gap` not blocking 0.2.0 merge.
+- The `nuclear-grade migrate` command does not rewrite multi-mode legacy packets that mix Quick and Standard files. Recorded as `deferred`; behavior is "infer Standard if any Standard-only file is present."
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim has a recorded status of `pass`, `gap`, `deferred`, or `not applicable`.
+- Reproduction commands above are runnable.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record inspired by graded-rigor evidence and lifecycle concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,38 @@ This project uses changelog entries to record public-facing changes, not to impl
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-27
+
+### Breaking
+
+- The validator now requires every packet's `risk.md` to declare its mode under a `## Selected mode` section (e.g. `- **Mode:** Quick` or `- **Mode:** Standard`). Packets without a declaration fail validation. Use `python tools/ng.py migrate <packet>` (or `nuclear-grade migrate <packet>` from an installed wheel) to insert a `## Selected mode` block with an inferred default based on the files present.
+
 ### Added
 
-- Configuration-management public positioning and activated CM workflow records.
-- Namespaced `nuclear_grade` package entry point for installed console scripts.
-- Skill evaluation prompt bank for baseline-vs-skill trigger checks.
-- HPI overlay operating doc for AI-agent task preview, self-checking, turnover, verification selection, conservative decisions, and OPEX learning.
-- Skills and command prompts for agent turnover, critical-action self-checking, OPEX learning, and dependency/model/API trust checks.
-- Golden-path templates for turnover and self-check records, plus an activated supplier-trust template.
-- Agent near-miss issue template.
+- `nuclear-grade new --mode cm` and `--mode golden-path` scaffold all five CM files and all five golden-path files respectively, so the QUICKSTART manual-`cp` blocks are no longer required.
+- `nuclear-grade migrate <packet>` inserts a `## Selected mode` block into a packet whose `risk.md` does not yet declare one. Idempotent. Prints the inferred mode and a one-line override notice.
+- Paraphrase-aware prohibited-claims detection: a tighter, entity-adjacent regex catches phrasings like "meets NQA-1 requirements", "fully ASME qualified", "conforms to IEEE 829", "satisfies 10 CFR 50 Appendix B", "implements quality assurance per NQA-1", "audited to NRC standards", and "regulator-approved". Negation gates (`inspired by`, `influenced by`, `does not claim`, "no formal", paragraph-level disclaimer markers) suppress legitimate boundary prose. Fenced code blocks are exempt.
+- `_bundled/` snapshot of `templates/`, `skills/`, and `commands/` inside the wheel. The installed CLI no longer depends on its source-tree neighbors and now works end to end from a clean `pip install`.
+- Hatchling build backend with `[tool.hatch.build.targets.wheel.force-include]` to bundle resources at wheel-build time without duplicating sources in the repo.
+- CI matrix across Python 3.11 and 3.12.
+- `ruff` lint step in CI (selects E, F, I, B, UP; ignores E501).
+- `wheel-smoke` CI job that builds the wheel, installs it into a clean venv, and exercises `init`, `new --mode {quick,standard,cm,golden-path}`, `list`, and `validate` outside the source tree.
+- `CITATION.cff` (CFF 1.2) at the repo root.
+- `.github/CODEOWNERS` with a maintainer placeholder.
+
+### Fixed
+
+- README and QUICKSTART now frame the 60-second demo so the expected `FAILED` output reads as the validator catching unfilled prompts (intentional), not as breakage.
+- The unfilled-template-prompt detector no longer caps the matched label at 80 characters; long verbose labels are now caught.
+- `docs/03-worked-examples/skill-workflow-comparison/results-summary.md` now leads with a methodology banner naming the qualitative, author-judged nature of the 1-5 scores and centres the numeric column markers.
+- `docs/04-adoption/report-swot-gap-remediation.md` now explicitly marks the Files / Skills / Commands listed under Phases 1 through 4 as proposed deliverables, not existing refs.
 
 ### Changed
 
-- Strengthened all skill trigger descriptions against skill-creator best practices.
-- Strengthened context packs, verification, release decisions, templates, worked-example comparisons, and source lineage with HPI micro-controls.
-
-## [0.1.1] - Unreleased
-
-### Added
-
-- Issue templates for bugs and docs/methodology/source-lineage concerns.
-- Pull request template with Nuclear-grade verification and overclaiming checks.
-- Contributor Covenant Code of Conduct.
-- Private readiness cleanup: removed planning scaffolding and stripped internal content from the knowledge-graph usage note.
+- README "What you get" CLI row lists all four `new` modes and the `migrate` subcommand.
+- README "Public v0 status" replaces "validated worked example" with "tested worked example" (workspace-only file writes; pytest-checked) plus an "author-judged adoption comparison" line.
+- `templates/quick/risk.md` ships with a pre-filled `## Selected mode` block (`- **Mode:** Quick`). The standard template already shipped with one.
+- `pyproject.toml` bumps version to `0.2.0` and switches the build backend to `hatchling`.
 
 ## [0.1.0] - 2026-05-20
 
@@ -40,11 +49,24 @@ This project uses changelog entries to record public-facing changes, not to impl
 - Completed Standard-mode worked example for AI-agent workspace-only file writes.
 - Dependency-free Python validator for Quick and Standard packet structure, evidence status, source-lineage notes, local packet links, and prohibited overclaiming phrases.
 - Pytest coverage for the validator and worked-example path guard.
+- Configuration-management public positioning and activated CM workflow records.
+- Namespaced `nuclear_grade` package entry point for installed console scripts.
+- Skill evaluation prompt bank for baseline-vs-skill trigger checks.
+- HPI overlay operating doc for AI-agent task preview, self-checking, turnover, verification selection, conservative decisions, and OPEX learning.
+- Skills and command prompts for agent turnover, critical-action self-checking, OPEX learning, and dependency/model/API trust checks.
+- Golden-path templates for turnover and self-check records, plus an activated supplier-trust template.
+- Agent near-miss issue template.
+- Issue templates for bugs and docs/methodology/source-lineage concerns.
+- Pull request template with Nuclear-grade verification and overclaiming checks.
+- Contributor Covenant Code of Conduct.
+- Private readiness cleanup: removed planning scaffolding and stripped internal content from the knowledge-graph usage note.
 
 ### Changed
 
 - Reworked the README into a workflow-first landing page for AI builders.
 - Clarified Public v0 boundaries, source-lineage rules, and non-compliance claims.
+- Strengthened all skill trigger descriptions against skill-creator best practices.
+- Strengthened context packs, verification, release decisions, templates, worked-example comparisons, and source lineage with HPI micro-controls.
 
 ### Not Included
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use Nuclear-grade in academic, industry, or public-facing work, please cite this repository."
+title: "Nuclear-grade Context Engineering"
+abstract: "Questioning attitude and configuration management for AI-assisted software work. Original software workflow inspired by public graded-rigor, configuration-management, software-assurance, and secure-development concepts. Source map: docs/00-standards-foundation/source-map.md. No compliance claim is made."
+authors:
+  # MAINTAINER: replace the placeholder below with your preferred citation identity.
+  - given-names: "Nuclear-grade"
+    family-names: "Maintainers"
+type: software
+license: MIT
+repository-code: "https://github.com/FlyFission/nuclear-grade-context-engineering"
+version: "0.2.0"
+date-released: "2026-05-27"
+keywords:
+  - configuration-management
+  - software-assurance
+  - questioning-attitude
+  - ai-agents
+  - change-control
+  - evidence

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,8 @@
 
 **Goal:** question a real AI-assisted change, create a useful controlled-change record in about 15 minutes, and prove one important claim.
 
+> **Note on the demo:** the first time you run `validate` on a freshly scaffolded packet you should expect `FAILED: ... has unfilled template prompts`. Templates ship with empty prompts on purpose. Fill the prompts that matter, then re-run `validate`. The point of the validator is to refuse silent gaps.
+
 ## 1. Check the repo
 
 ```bash
@@ -72,6 +74,22 @@ Standard:
 python tools/ng.py new <slug> --mode standard
 ```
 
+Activated CM (controlled configuration):
+
+```bash
+python tools/ng.py new <slug> --mode cm
+```
+
+This scaffolds `controlled-items.md`, `change-impact.md`, `baseline.md`, `variance.md`, and `opex.md`. Delete what your change does not need.
+
+Golden path (public questioning-attitude path):
+
+```bash
+python tools/ng.py new <slug> --mode golden-path
+```
+
+This scaffolds `questioning-attitude.md`, `spec.md`, `turnover.md`, `self-check.md`, and `decision.md`.
+
 Manual fallback:
 
 ```bash
@@ -79,25 +97,15 @@ mkdir -p .nuclear/changes/<slug>/
 cp templates/quick/*.md .nuclear/changes/<slug>/
 ```
 
-For Standard, use `templates/standard/*.md` instead. Use either Quick or Standard templates, not both.
+Use either Quick or Standard templates, not both. Pick CM or golden-path additions only when the change actually needs them.
 
-If the change affects controlled configuration, copy the activated CM record you need:
-
-```bash
-cp templates/cm/controlled-items.md .nuclear/changes/<slug>/
-cp templates/cm/change-impact.md .nuclear/changes/<slug>/
-cp templates/cm/baseline.md .nuclear/changes/<slug>/
-```
-
-If the change needs the public golden path, copy the activated records:
+Upgrading an older packet (0.1.x) that does not declare a mode:
 
 ```bash
-cp templates/golden-path/questioning-attitude.md .nuclear/changes/<slug>/
-cp templates/golden-path/spec.md .nuclear/changes/<slug>/
-cp templates/golden-path/turnover.md .nuclear/changes/<slug>/
-cp templates/golden-path/self-check.md .nuclear/changes/<slug>/
-cp templates/golden-path/decision.md .nuclear/changes/<slug>/
+python tools/ng.py migrate .nuclear/changes/<slug>
 ```
+
+This inserts a `## Selected mode` block into `risk.md` with an inferred default. Edit the result if the inferred mode is wrong.
 
 ## 5. Fill the minimum useful version
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Nuclear-grade:
 question -> specify -> execute -> verify -> decide -> baseline -> operation
 ```
 
-Public v0 is a usable skill and workflow product: agent-operable skills, portable command prompts, Quick/Standard change packages, activated configuration-management records, a local CLI, a validator, a public source foundation, and one validated worked example.
+Public v0 is a usable skill and workflow product: agent-operable skills, portable command prompts, Quick / Standard / activated CM / golden-path templates, a local CLI, a validator, a public source foundation, one tested worked example, and one author-judged comparison study.
 
 ## Try it in 60 seconds
 
@@ -26,6 +26,8 @@ python tools/ng.py list
 python tools/ng.py new demo-change --mode quick
 python tools/ng.py validate .nuclear/changes/demo-change
 ```
+
+The fourth command is expected to print `FAILED: ...` with `has unfilled template prompts`. That is the demo: the validator catches an unfilled template just like it will when you skip a real prompt. Open `.nuclear/changes/demo-change/risk.md` and `proof.md`, fill the prompts that matter, then re-run `validate`.
 
 Inspect the included evidence path:
 
@@ -44,7 +46,7 @@ If your shell only has `python3`, use `python3`.
 | Skills | Agent-operable instructions with inputs, outputs, verification, escalation, and red flags | [`SKILLS.md`](SKILLS.md) |
 | Portable command prompts | Pasteable prompt cards for questioning, classification, CM impact, baselining, evidence review, release review, source checks, and legal boundaries | [`COMMANDS.md`](COMMANDS.md) |
 | Templates | Quick, Standard, activated CM, and golden-path records | [`templates/`](templates/) |
-| CLI | `init`, `new`, `validate`, `doctor`, `list`, and `status` | [`docs/05-reference/cli-reference.md`](docs/05-reference/cli-reference.md) |
+| CLI | `init`, `new --mode {quick,standard,cm,golden-path}`, `validate`, `doctor`, `list`, `status`, `migrate` | [`docs/05-reference/cli-reference.md`](docs/05-reference/cli-reference.md) |
 | Validator | Dependency-free Quick and Standard packet checks | [`tools/ng_validate.py`](tools/ng_validate.py) |
 | Worked example | Standard packet proving an AI-agent workspace boundary | [`EXAMPLES.md`](EXAMPLES.md) |
 | Source foundation | Public source map and citation boundaries | [`docs/00-standards-foundation/source-map.md`](docs/00-standards-foundation/source-map.md) |
@@ -148,7 +150,8 @@ Included now:
 - local CLI and dependency-free validator;
 - agent-operable skills and portable command prompts;
 - public source foundation and source status labels;
-- validated worked example for an AI-agent workspace boundary;
+- tested worked example for an AI-agent workspace boundary (workspace-only file writes; pytest-checked);
+- author-judged adoption comparison covering twelve use cases (see `docs/03-worked-examples/skill-workflow-comparison/`);
 - tests for validator, CLI, skill contracts, command contracts, public docs, and worked example code.
 
 Not included yet:

--- a/docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py
+++ b/docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py
@@ -1,7 +1,5 @@
-from pathlib import Path
 
 import pytest
-
 from reference.workspace_guard import WorkspaceGuard, WorkspaceViolation
 
 

--- a/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
@@ -1,9 +1,11 @@
 # Results Summary
 
+> *Author-judged qualitative 1-5 scores. See `methodology.md` for limits. No independent reviewer panel. No timing, defect-rate, or A/B measurement. The "overhead" column is judgment, not minutes.*
+
 ## Aggregate Score Table
 
 | Use case | Path | Decision clarity | Hidden risk discovery | Evidence quality | Ship/defer usefulness | Overhead |
-|---|---|---:|---:|---:|---:|---:|
+|---|---|:---:|:---:|:---:|:---:|:---:|
 | U01 Tiny README fix | Simple prompt | 4 | 2 | 3 | 3 | 1 |
 | U01 Tiny README fix | Nuclear-grade | 4 | 3 | 4 | 3 | 2 |
 | U02 Agent workspace boundary | Simple prompt | 3 | 2 | 2 | 2 | 1 |

--- a/docs/04-adoption/report-swot-gap-remediation.md
+++ b/docs/04-adoption/report-swot-gap-remediation.md
@@ -587,7 +587,9 @@ After: question -> spec/basis -> plan -> traceability -> verification -> release
 
 **Goal:** Add the report's missing quality-signature outputs without bloating Standard packets by default.
 
-**Files to create:**
+> *The "Files to create", "Skills to add", "Commands to add", "Files to modify", "CLI additions", "Tests to update", and "Examples to add" lists in Phases 1 through 4 below are proposed deliverables. They are not present in this repo today. Treat the file paths as design intent for a future PR, not as references to existing artifacts.*
+
+**Files to create (proposed):**
 
 - `docs/02-operating-system/golden-path.md`
 - `docs/02-operating-system/evidence-bundles.md`

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -17,10 +17,27 @@ if __package__ in (None, ""):
 
 from nuclear_grade.ng_validate import detect_packet_mode, validate_packet
 
+PACKAGE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PACKAGE_DIR.parent
+BUNDLED_ROOT = PACKAGE_DIR / "_bundled"
 
-ROOT = Path(__file__).resolve().parents[1]
-SKILLS = ROOT / "skills"
-COMMANDS = ROOT / "commands"
+
+def _resolve_resource_root(name: str) -> Path:
+    """Return the directory holding bundled resources ('templates', 'skills', 'commands').
+
+    Prefers the repo-relative path when running from a source checkout; falls back
+    to the wheel-bundled copy under nuclear_grade/_bundled/.
+    """
+
+    repo_path = REPO_ROOT / name
+    if repo_path.is_dir():
+        return repo_path
+    bundled = BUNDLED_ROOT / name
+    return bundled
+
+
+SKILLS = _resolve_resource_root("skills")
+COMMANDS = _resolve_resource_root("commands")
 
 QUICK_FILES = ("risk.md", "proof.md")
 STANDARD_FILES = ("risk.md", "basis.md", "plan.md", "trace.md", "verification.md", "ship.md")
@@ -33,6 +50,12 @@ GOLDEN_PATH_FILES = (
     "decision.md",
 )
 OPTIONAL_FILES = ("standard/supplier-trust.md",)
+MODE_FILES = {
+    "quick": QUICK_FILES,
+    "standard": STANDARD_FILES,
+    "cm": CM_FILES,
+    "golden-path": GOLDEN_PATH_FILES,
+}
 REQUIRED_PUBLIC_FILES = (
     "README.md",
     "DISCLAIMER.md",
@@ -74,6 +97,11 @@ REQUIRED_COMMAND_SECTIONS = (
     "## Legal/assurance boundary note",
 )
 
+MODE_DEFAULT_BLOCK = {
+    "quick": "## Selected mode\n\n- **Mode:** Quick\n",
+    "standard": "## Selected mode\n\n- **Mode:** Standard\n",
+}
+
 
 @dataclass(frozen=True)
 class PlannedWrite:
@@ -104,9 +132,13 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--yes", action="store_true", help="Overwrite managed files when needed.")
     init_parser.set_defaults(handler=handle_init)
 
-    new_parser = subcommands.add_parser("new", help="Create a Quick or Standard change packet.")
+    new_parser = subcommands.add_parser("new", help="Create a packet (quick, standard, cm, or golden-path).")
     new_parser.add_argument("slug")
-    new_parser.add_argument("--mode", required=True, choices=("quick", "standard"))
+    new_parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("quick", "standard", "cm", "golden-path"),
+    )
     new_parser.add_argument("--repo", default=".", type=Path)
     new_parser.add_argument("--force", action="store_true")
     new_parser.set_defaults(handler=handle_new)
@@ -125,6 +157,19 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser = subcommands.add_parser("status", help="List active packets and detected modes.")
     status_parser.add_argument("repo", nargs="?", default=".", type=Path)
     status_parser.set_defaults(handler=handle_status)
+
+    migrate_parser = subcommands.add_parser(
+        "migrate",
+        help="Insert a `## Selected mode` block into a legacy packet's risk.md.",
+    )
+    migrate_parser.add_argument("packet", type=Path)
+    migrate_parser.add_argument(
+        "--default",
+        choices=("quick", "standard"),
+        default=None,
+        help="Mode to record when it cannot be inferred (default: auto).",
+    )
+    migrate_parser.set_defaults(handler=handle_migrate)
 
     return parser
 
@@ -150,7 +195,7 @@ def handle_init(args: argparse.Namespace) -> int:
 def handle_new(args: argparse.Namespace) -> int:
     repo = args.repo.resolve()
     packet = repo / ".nuclear" / "changes" / args.slug
-    files = QUICK_FILES if args.mode == "quick" else STANDARD_FILES
+    files = MODE_FILES[args.mode]
     templates = template_root_for(repo, args.mode)
     writes = [PlannedWrite(packet, is_dir=True)]
     writes.extend(
@@ -185,16 +230,66 @@ def handle_doctor(args: argparse.Namespace) -> int:
     return 0
 
 
+def handle_migrate(args: argparse.Namespace) -> int:
+    packet = args.packet.resolve()
+    if not packet.is_dir():
+        print(f"packet is not a directory: {packet}", file=sys.stderr)
+        return 2
+
+    risk = packet / "risk.md"
+    if not risk.exists():
+        print(f"missing risk.md: {risk}", file=sys.stderr)
+        return 2
+
+    text = risk.read_text(encoding="utf-8")
+    if "## Selected mode" in text:
+        print(f"already declares mode: {risk}")
+        return 0
+
+    inferred = args.default or infer_mode_from_files(packet)
+    block = MODE_DEFAULT_BLOCK[inferred]
+
+    new_text = _insert_mode_block(text, block)
+    risk.write_text(new_text, encoding="utf-8")
+    print(f"migrated: {risk} (inferred Mode: {inferred.capitalize()})")
+    print("Edit risk.md to override if the inferred mode is wrong.")
+    return 0
+
+
+def infer_mode_from_files(packet: Path) -> str:
+    standard_signals = ("basis.md", "plan.md", "trace.md", "verification.md", "ship.md")
+    return "standard" if any((packet / name).exists() for name in standard_signals) else "quick"
+
+
+def _insert_mode_block(text: str, block: str) -> str:
+    """Insert the mode block after the first H1, or at top if no H1 is present."""
+
+    lines = text.splitlines(keepends=True)
+    insert_index = 0
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            insert_index = i + 1
+            break
+
+    head = "".join(lines[:insert_index])
+    tail = "".join(lines[insert_index:])
+    separator = "\n" if head and not head.endswith("\n\n") else ""
+    return f"{head}{separator}\n{block}\n{tail}"
+
+
 def template_root_for(repo: Path, mode: str) -> Path:
     repo_templates = repo / "templates"
-    required = QUICK_FILES if mode == "quick" else STANDARD_FILES
+    required = MODE_FILES[mode]
     if all((repo_templates / mode / name).exists() for name in required):
         return repo_templates
-    return ROOT / "templates"
+    bundled_templates = BUNDLED_ROOT / "templates"
+    if all((bundled_templates / mode / name).exists() for name in required):
+        return bundled_templates
+    return REPO_ROOT / "templates"
 
 
 def handle_list(args: argparse.Namespace) -> int:
-    print("Modes: quick, standard")
+    print("Modes: quick, standard, cm, golden-path")
     print("Quick files: " + ", ".join(QUICK_FILES))
     print("Standard files: " + ", ".join(STANDARD_FILES))
     print("Activated CM files: " + ", ".join(CM_FILES))

--- a/nuclear_grade/ng_validate.py
+++ b/nuclear_grade/ng_validate.py
@@ -11,9 +11,9 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-
 QUICK_MODE = "quick"
 STANDARD_MODE = "standard"
+UNSPECIFIED_MODE = "unspecified"
 REQUIRED_QUICK_FILES = ("risk.md", "proof.md")
 REQUIRED_STANDARD_FILES = ("risk.md", "basis.md", "plan.md", "trace.md", "verification.md", "ship.md")
 STANDARD_ONLY_FILES = tuple(name for name in REQUIRED_STANDARD_FILES if name != "risk.md")
@@ -21,24 +21,17 @@ REQUIRED_SECTIONS = ("Required links", "Exit criteria", "Source-lineage note")
 EVIDENCE_STATUSES = ("pass", "fail", "gap", "deferred", "not applicable", "planned")
 MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 EMPTY_PROMPT_PATTERN = re.compile(
-    r"^\s*-\s+[^|\n:][^:\n]{1,80}:\s*$|^\s*(?:Claim|Question|Answer|Decision|Rationale):\s*$",
+    r"^\s*-\s+[^|\n:][^:\n]*?:\s*$|^\s*(?:Claim|Question|Answer|Decision|Rationale):\s*$",
     re.MULTILINE,
 )
 EMPTY_TABLE_CELL_PATTERN = re.compile(r"\|[ \t]*\|")
+MODE_DECLARATION_PATTERN = re.compile(
+    r"##\s*Selected\s*mode\b[\s\S]{0,400}?(?:\*\*Mode:\*\*|Mode:)\s*(quick|standard|nuclear|incident|research board|release)",
+    re.IGNORECASE,
+)
+
+# Fixed phrases retained for noun-only items the verb-stem matcher will not catch.
 PROHIBITED_CLAIMS = (
-    "NQA-1 compliant",
-    "ASME compliant",
-    "EPRI compliant",
-    "IEEE compliant",
-    "IEC compliant",
-    "ISO compliant",
-    "ANSI/ANS compliant",
-    "NEI compliant",
-    "NRC compliant",
-    "DOE compliant",
-    "NASA compliant",
-    "NIST compliant",
-    "CISA compliant",
     "certified quality assurance program",
     "regulatory approval",
     "commercial-grade dedication package",
@@ -50,6 +43,43 @@ PROHIBITED_CLAIMS = (
     "safety-basis evidence",
     "procurement evidence",
 )
+
+# Paraphrase patterns. The entity (NQA-1, ASME, NRC, ...) and a positive-claim
+# verb stem must be adjacent (within a few tokens). Negation gates handled
+# separately by _is_boundary_context and _sentence_has_boundary.
+_ENTITY = (
+    r"NQA[- ]?1|ASME|EPRI|IEEE(?:\s+\d+)?|IEC(?:\s+\d+)?|ISO(?:\s+\d+)?|"
+    r"ANSI(?:/ANS)?|ANS\s+\d+|NEI|NRC|DOE|NASA|NIST|CISA|"
+    r"10\s*CFR(?:\s*\d+)?(?:\s+Appendix\s+[A-Z])?"
+)
+PARAPHRASE_PATTERNS = (
+    # "meets NQA-1 requirements", "conforms to IEEE 829", "satisfies 10 CFR 50",
+    # "complies with ASME"
+    re.compile(
+        r"\b(?:meets?|conform(?:s|ing)?\s+to|compl(?:y|ies)\s+with|"
+        r"satisf(?:y|ies|ied|ying)|"
+        r"implements?\s+\w*\s*(?:per|to)\s+(?:requirements?\s+of\s+)?)\s+"
+        r"(?:" + _ENTITY + r")\b",
+        re.IGNORECASE,
+    ),
+    # "<entity> compliant", "<entity> qualified", "<entity> certified",
+    # "fully ASME qualified"
+    re.compile(
+        r"\b(?:" + _ENTITY + r")\s*[-/]?\s*"
+        r"(?:compliant|qualified|certified|approved|conformant)\b",
+        re.IGNORECASE,
+    ),
+    # "audited to NRC standards"
+    re.compile(r"\baudited\s+to\s+(?:" + _ENTITY + r")\b", re.IGNORECASE),
+    # "implements quality assurance per NQA-1"
+    re.compile(
+        r"\bimplements?\s+quality\s+assurance\s+per\s+(?:" + _ENTITY + r")\b",
+        re.IGNORECASE,
+    ),
+    # "regulator-approved", "regulator approved"
+    re.compile(r"\bregulator[- ]?approved\b", re.IGNORECASE),
+)
+
 BOUNDARY_PREFIXES = (
     "no ",
     "not ",
@@ -60,6 +90,14 @@ BOUNDARY_PREFIXES = (
     "no formal ",
     "no compliance",
     "without ",
+    "inspired by",
+    "influenced by",
+    "does not claim",
+    "do not claim",
+    "not implementing",
+    "no claim of",
+    "no claim to",
+    "is not implementing",
 )
 
 
@@ -78,8 +116,19 @@ def validate_packet(packet: str | Path) -> ValidationResult:
     if not packet_path.is_dir():
         return ValidationResult(False, [f"packet is not a directory: {packet_path}"])
 
-    mode = detect_packet_mode(packet_path)
-    required_files = REQUIRED_QUICK_FILES if mode == QUICK_MODE else REQUIRED_STANDARD_FILES
+    declared = _declared_mode(packet_path)
+    if declared == UNSPECIFIED_MODE:
+        messages.append(
+            "risk.md must include a `## Selected mode` section with `- **Mode:** Quick` or `- **Mode:** Standard`"
+        )
+
+    mode = _detect_mode(packet_path)
+    required_files: tuple[str, ...]
+    if declared == UNSPECIFIED_MODE and mode == UNSPECIFIED_MODE:
+        required_files = ("risk.md",)
+    else:
+        effective = mode if mode != UNSPECIFIED_MODE else declared
+        required_files = REQUIRED_QUICK_FILES if effective == QUICK_MODE else REQUIRED_STANDARD_FILES
 
     for name in required_files:
         if not (packet_path / name).exists():
@@ -93,11 +142,13 @@ def validate_packet(packet: str | Path) -> ValidationResult:
         _check_source_lineage(md_file, text, messages)
         _check_relative_links(packet_path, md_file, text, messages)
 
-    evidence_file = packet_path / ("proof.md" if mode == QUICK_MODE else "verification.md")
-    if evidence_file.exists():
-        evidence_text = evidence_file.read_text(encoding="utf-8")
-        if not _contains_status(evidence_text):
-            messages.append(f"{evidence_file.name} must include at least one evidence status")
+    effective_mode = mode if mode != UNSPECIFIED_MODE else declared
+    if effective_mode != UNSPECIFIED_MODE:
+        evidence_file = packet_path / ("proof.md" if effective_mode == QUICK_MODE else "verification.md")
+        if evidence_file.exists():
+            evidence_text = evidence_file.read_text(encoding="utf-8")
+            if not _contains_status(evidence_text):
+                messages.append(f"{evidence_file.name} must include at least one evidence status")
 
     ship = packet_path / "ship.md"
     if ship.exists():
@@ -110,20 +161,36 @@ def validate_packet(packet: str | Path) -> ValidationResult:
 
 
 def detect_packet_mode(packet: str | Path) -> str:
-    return _detect_mode(Path(packet))
+    mode = _detect_mode(Path(packet))
+    return QUICK_MODE if mode == UNSPECIFIED_MODE else mode
+
+
+def _declared_mode(packet_path: Path) -> str:
+    """Return the explicitly declared mode from risk.md, or UNSPECIFIED.
+
+    Unlike _detect_mode, never falls back to file-presence inference.
+    """
+
+    risk = packet_path / "risk.md"
+    if not risk.exists():
+        return UNSPECIFIED_MODE
+    risk_text = risk.read_text(encoding="utf-8")
+    match = MODE_DECLARATION_PATTERN.search(risk_text)
+    if not match:
+        return UNSPECIFIED_MODE
+    declared = match.group(1).lower()
+    return QUICK_MODE if declared == "quick" else STANDARD_MODE
 
 
 def _detect_mode(packet_path: Path) -> str:
+    declared = _declared_mode(packet_path)
+    if declared != UNSPECIFIED_MODE:
+        return declared
+
     if any((packet_path / name).exists() for name in STANDARD_ONLY_FILES):
         return STANDARD_MODE
 
-    risk = packet_path / "risk.md"
-    if risk.exists():
-        risk_text = risk.read_text(encoding="utf-8").lower()
-        if re.search(r"\bmode:\s*(standard|nuclear|incident|research board|release)\b", risk_text):
-            return STANDARD_MODE
-
-    return QUICK_MODE
+    return UNSPECIFIED_MODE
 
 
 def _check_required_sections(md_file: Path, text: str, messages: list[str]) -> None:
@@ -182,7 +249,20 @@ def _is_external_or_anchor(target: str) -> bool:
 
 
 def _check_prohibited_claims(md_file: Path, text: str, messages: list[str]) -> None:
-    lowered = text.lower()
+    """Detect literal compliance claims and paraphrases.
+
+    Two passes:
+    1. Fixed-phrase scan for stable phrases (e.g. "formal V&V", "NQA-1 record").
+    2. Paraphrase regex pass: a compliance entity adjacent to a positive-claim
+       verb stem (compliant, qualified, satisfies, conforms to, ...). A
+       paragraph-aware negation gate suppresses "inspired by", "does not claim",
+       and similar boundary prose. Fenced code blocks are skipped because they
+       are commonly used to quote example phrases.
+    """
+
+    scannable = _strip_code_blocks(text)
+    lowered = scannable.lower()
+
     for phrase in PROHIBITED_CLAIMS:
         phrase_lower = phrase.lower()
         start = 0
@@ -195,10 +275,82 @@ def _check_prohibited_claims(md_file: Path, text: str, messages: list[str]) -> N
                 messages.append(f"{md_file.name} contains prohibited compliance claim: {phrase}")
             start = index + len(phrase_lower)
 
+    for pattern in PARAPHRASE_PATTERNS:
+        for match in pattern.finditer(scannable):
+            m_start = match.start()
+            context_before = lowered[max(0, m_start - 60) : m_start]
+            if _is_boundary_context(context_before):
+                continue
+            if _has_paragraph_disclaimer(scannable, m_start):
+                continue
+            snippet = match.group(0).strip()
+            messages.append(
+                f"{md_file.name} contains prohibited compliance claim (paraphrase): {snippet}"
+            )
+
+
+def _strip_code_blocks(text: str) -> str:
+    """Replace fenced code block contents with whitespace of equal length so
+    indices remain stable but the scanner does not flag quoted examples.
+    """
+
+    pattern = re.compile(r"(?ms)^```.*?$.*?^```\s*$")
+
+    def _blank(match: re.Match[str]) -> str:
+        return re.sub(r"\S", " ", match.group(0))
+
+    return pattern.sub(_blank, text)
+
+
+def _has_paragraph_disclaimer(text: str, index: int) -> bool:
+    """Walk back to the start of the current paragraph or section and check for
+    a disclaimer marker that scopes the claim as not-implied.
+    """
+
+    section_start = max(
+        text.rfind("\n\n", 0, index),
+        text.rfind("\n## ", 0, index),
+        text.rfind("\n### ", 0, index),
+    )
+    paragraph = text[max(0, section_start) : index].lower()
+    markers = (
+        "out of scope",
+        "non-goals",
+        "non-goal",
+        "anti-goal",
+        "unacceptable outcome",
+        "what we don't",
+        "what we do not",
+        "we do not claim",
+        "we don't claim",
+        "no claim",
+        "is implying",
+        "would imply",
+        "wording that implies",
+        "anything that implies",
+        "any claim that",
+        "any wording that",
+        "must not imply",
+        "do not imply",
+        "does not imply",
+        "stop or escalate",
+        "escalation triggers",
+        "avoids compliance",
+        "avoid compliance",
+        "out-of-bounds",
+        "is not a compliance",
+        "not a compliance",
+        "is not nrc",
+        "inspired by",
+        "influenced by",
+        "no formal",
+    )
+    return any(marker in paragraph for marker in markers)
+
 
 def _is_boundary_context(context: str) -> bool:
-    compact = re.sub(r"\s+", " ", context).strip()
-    return any(compact.endswith(prefix.strip()) or prefix in compact[-25:] for prefix in BOUNDARY_PREFIXES)
+    compact = re.sub(r"\s+", " ", context).strip().lower()
+    return any(compact.endswith(prefix.strip()) or prefix in compact[-40:] for prefix in BOUNDARY_PREFIXES)
 
 
 def _contains_status(text: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclear-grade"
-version = "0.1.0"
+version = "0.2.0"
 description = "Configuration management for AI-assisted software work."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -9,13 +9,39 @@ license = "MIT"
 [project.scripts]
 nuclear-grade = "nuclear_grade.cli:main"
 
-[tool.setuptools.packages.find]
-include = ["nuclear_grade*"]
-exclude = ["skills*", "commands*", "templates*", "docs*", "tests*", "tools*"]
-
 [project.optional-dependencies]
 dev = [
   "pytest>=8",
+  "ruff>=0.6",
+  "build>=1.2",
+]
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nuclear_grade"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"templates" = "nuclear_grade/_bundled/templates"
+"skills" = "nuclear_grade/_bundled/skills"
+"commands" = "nuclear_grade/_bundled/commands"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/nuclear_grade",
+  "/templates",
+  "/skills",
+  "/commands",
+  "/tests",
+  "/tools",
+  "/docs",
+  "/README.md",
+  "/LICENSE",
+  "/CHANGELOG.md",
+  "/CITATION.cff",
+  "/pyproject.toml",
 ]
 
 [tool.pytest.ini_options]
@@ -25,3 +51,17 @@ testpaths = [
 ]
 pythonpath = ["."]
 addopts = "-q"
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tools/ng.py" = ["E402", "F403", "F405"]
+"tools/ng_validate.py" = ["E402"]
+"nuclear_grade/cli.py" = ["E402", "UP036"]
+"nuclear_grade/__init__.py" = ["F401"]

--- a/templates/quick/risk.md
+++ b/templates/quick/risk.md
@@ -1,5 +1,10 @@
 # Quick Risk Template
 
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** (one line; escalate to Standard if any answer below feels uncertain)
+
 **Purpose:** Decide whether a small change can safely stay in Quick mode and name the proof required.
 
 **Activation threshold:** Use for low-consequence, reversible, easy-to-detect changes with no new user trust boundary, dependency trust decision, security/privacy effect, release posture change, or AI authority change.

--- a/tests/test_command_contracts.py
+++ b/tests/test_command_contracts.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 COMMANDS_DIR = ROOT / "commands"
 COMMANDS_INDEX = ROOT / "COMMANDS.md"

--- a/tests/test_ng_cli.py
+++ b/tests/test_ng_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from tests.test_ng_validate import minimal_quick_packet
 from tools import ng as ng_cli
 
-
 ROOT = Path(__file__).resolve().parents[1]
 NG = ROOT / "tools" / "ng.py"
 
@@ -265,3 +264,65 @@ def test_status_detects_active_packets(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert "demo: standard" in result.stdout
+
+
+def test_new_cm_packet_scaffolds_all_cm_files(tmp_path):
+    scaffold_repo(tmp_path)
+
+    result = run_ng("new", "cm-demo", "--mode", "cm", "--repo", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    packet = tmp_path / ".nuclear" / "changes" / "cm-demo"
+    assert {path.name for path in packet.glob("*.md")} == set(ng_cli.CM_FILES)
+
+
+def test_new_golden_path_packet_scaffolds_all_files(tmp_path):
+    scaffold_repo(tmp_path)
+
+    result = run_ng("new", "gp-demo", "--mode", "golden-path", "--repo", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    packet = tmp_path / ".nuclear" / "changes" / "gp-demo"
+    assert {path.name for path in packet.glob("*.md")} == set(ng_cli.GOLDEN_PATH_FILES)
+
+
+def test_migrate_inserts_standard_mode_block_when_standard_files_present(tmp_path):
+    packet = tmp_path / ".nuclear" / "changes" / "legacy"
+    packet.mkdir(parents=True)
+    (packet / "risk.md").write_text("# Risk\n\nLegacy content with no mode declaration.\n", encoding="utf-8")
+    (packet / "plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = run_ng("migrate", str(packet))
+
+    assert result.returncode == 0, result.stderr
+    text = (packet / "risk.md").read_text(encoding="utf-8")
+    assert "## Selected mode" in text
+    assert "**Mode:** Standard" in text
+
+
+def test_migrate_inserts_quick_mode_block_when_only_quick_files_present(tmp_path):
+    packet = tmp_path / ".nuclear" / "changes" / "legacy-quick"
+    packet.mkdir(parents=True)
+    (packet / "risk.md").write_text("# Risk\n\nLegacy quick packet.\n", encoding="utf-8")
+    (packet / "proof.md").write_text("# Proof\n", encoding="utf-8")
+
+    result = run_ng("migrate", str(packet))
+
+    assert result.returncode == 0, result.stderr
+    text = (packet / "risk.md").read_text(encoding="utf-8")
+    assert "**Mode:** Quick" in text
+
+
+def test_migrate_is_idempotent_when_mode_already_declared(tmp_path):
+    packet = tmp_path / ".nuclear" / "changes" / "already-declared"
+    packet.mkdir(parents=True)
+    (packet / "risk.md").write_text(
+        "# Risk\n\n## Selected mode\n\n- **Mode:** Standard\n", encoding="utf-8"
+    )
+
+    result = run_ng("migrate", str(packet))
+
+    assert result.returncode == 0, result.stderr
+    assert "already declares mode" in result.stdout
+    text = (packet / "risk.md").read_text(encoding="utf-8")
+    assert text.count("## Selected mode") == 1

--- a/tests/test_ng_validate.py
+++ b/tests/test_ng_validate.py
@@ -187,3 +187,81 @@ def test_unfilled_standard_template_fails(tmp_path):
 
     assert not result.ok
     assert any("has unfilled template prompts" in message for message in result.messages)
+
+
+def test_packet_without_mode_declaration_fails(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+    risk_text = (packet / "risk.md").read_text(encoding="utf-8")
+    stripped = risk_text.replace("## Selected mode\n\n- **Mode:** Standard\n", "")
+    (packet / "risk.md").write_text(stripped, encoding="utf-8")
+
+    result = validate_packet(packet)
+
+    assert not result.ok
+    assert any("Selected mode" in message for message in result.messages)
+
+
+def test_long_label_empty_prompt_is_detected(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+    with (packet / "basis.md").open("a", encoding="utf-8") as handle:
+        handle.write("\n- " + ("A" * 200) + ":\n")
+
+    result = validate_packet(packet)
+
+    assert not result.ok
+    assert any("has unfilled template prompts" in message for message in result.messages)
+
+
+PARAPHRASES_THAT_MUST_FAIL = (
+    "This system meets NQA-1 requirements.",
+    "The release is fully ASME qualified.",
+    "Our tests conform to IEEE 829.",
+    "The packet satisfies 10 CFR 50 Appendix B.",
+    "We implement quality assurance per NQA-1.",
+    "This deployment has been audited to NRC standards.",
+    "The product is regulator-approved.",
+)
+
+
+def test_paraphrased_compliance_claims_all_fail(tmp_path):
+    for index, phrase in enumerate(PARAPHRASES_THAT_MUST_FAIL):
+        packet = minimal_standard_packet(tmp_path / f"case-{index}")
+        basis = packet / "basis.md"
+        text = basis.read_text(encoding="utf-8")
+        marker = "## Source-lineage note"
+        idx = text.find(marker)
+        new_text = text[:idx] + f"## Independent assertion\n\n{phrase}\n\n" + text[idx:]
+        basis.write_text(new_text, encoding="utf-8")
+
+        result = validate_packet(packet)
+
+        assert not result.ok, f"Expected failure for paraphrase: {phrase}"
+        assert any(
+            "prohibited compliance claim" in message for message in result.messages
+        ), f"No prohibited-claim message for: {phrase}; got {result.messages}"
+
+
+BOUNDARY_PHRASES_THAT_MUST_PASS = (
+    "This work is inspired by NQA-1 concepts.",
+    "Influenced by ASME structure, not aligned with it.",
+    "We do not claim IEEE conformance.",
+    "This repo is not NRC compliant and does not claim to be.",
+    "No formal V&V is implied by this packet.",
+)
+
+
+def test_boundary_paraphrases_all_pass(tmp_path):
+    for index, phrase in enumerate(BOUNDARY_PHRASES_THAT_MUST_PASS):
+        packet = minimal_standard_packet(tmp_path / f"case-{index}")
+        basis = packet / "basis.md"
+        text = basis.read_text(encoding="utf-8")
+        marker = "## Source-lineage note"
+        idx = text.find(marker)
+        new_text = text[:idx] + f"## Boundary statement\n\n{phrase}\n\n" + text[idx:]
+        basis.write_text(new_text, encoding="utf-8")
+
+        result = validate_packet(packet)
+
+        assert result.ok, (
+            f"Expected pass for boundary phrase: {phrase}; got messages: {result.messages}"
+        )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,21 +1,42 @@
 import tomllib
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _config() -> dict:
+    return tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
 def test_console_entry_point_uses_namespaced_package():
-    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    config = _config()
 
     assert config["project"]["scripts"]["nuclear-grade"] == "nuclear_grade.cli:main"
 
 
-def test_package_discovery_is_explicitly_scoped():
-    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+def test_build_backend_is_hatchling():
+    config = _config()
 
-    packages = config["tool"]["setuptools"]["packages"]["find"]
-    assert packages["include"] == ["nuclear_grade*"]
-    assert "skills*" in packages["exclude"]
-    assert "commands*" in packages["exclude"]
-    assert "templates*" in packages["exclude"]
+    assert config["build-system"]["build-backend"] == "hatchling.build"
+
+
+def test_wheel_force_includes_top_level_resources():
+    config = _config()
+
+    force_include = config["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    assert force_include["templates"] == "nuclear_grade/_bundled/templates"
+    assert force_include["skills"] == "nuclear_grade/_bundled/skills"
+    assert force_include["commands"] == "nuclear_grade/_bundled/commands"
+
+
+def test_wheel_packages_only_namespaced_package():
+    config = _config()
+
+    packages = config["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    assert packages == ["nuclear_grade"]
+
+
+def test_version_is_stamped():
+    config = _config()
+
+    assert config["project"]["version"] == "0.2.0"

--- a/tests/test_public_docs.py
+++ b/tests/test_public_docs.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 PUBLIC_DOCS = (

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ROOT / "skills"
 SKILLS_INDEX = ROOT / "SKILLS.md"

--- a/tools/ng.py
+++ b/tools/ng.py
@@ -1,7 +1,7 @@
 """Repo-local wrapper for the Nuclear-grade CLI."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -9,7 +9,6 @@ if str(ROOT) not in sys.path:
 
 from nuclear_grade.cli import *  # noqa: F403
 from nuclear_grade.cli import main
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/ng_validate.py
+++ b/tools/ng_validate.py
@@ -1,7 +1,7 @@
 """Repo-local wrapper for the Nuclear-grade packet validator."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:


### PR DESCRIPTION
## Summary

Coordinated remediation of the twelve findings from the 2026-05 adversarial review of `nuclear-grade-context-engineering`. Recorded as a Standard packet at `.nuclear/changes/review-findings-2026-05/` that passes its own new validator rule. Ships as `0.2.0` because the validator's enforced `## Selected mode` declaration is a breaking change for downstream packets.

### Findings closed

| # | Severity | Fix |
|---|---|---|
| F1 | critical | README + QUICKSTART frame the 60-second demo so the expected `FAILED` reads as the validator catching unfilled prompts, not as breakage. |
| F2 | critical | `pyproject.toml` switches to `hatchling` with `[tool.hatch.build.targets.wheel.force-include]` bundling `templates/`, `skills/`, `commands/` into `nuclear_grade/_bundled/` at wheel-build time. CLI gains a `_resolve_resource_root` fallback so the installed wheel works end to end from a clean `pip install`. New `wheel-smoke` CI job exercises it. |
| F3 | high | Paraphrase-aware prohibited-claims detector: entity-adjacent verb-stem regex over compliance nouns (NQA-1, ASME, IEEE, IEC, ISO, NRC, DOE, NASA, NIST, CISA, 10 CFR, ...), paragraph-disclaimer markers, fenced-code-block exempt. Seven failing paraphrases and five passing boundary phrases gated by tests. Existing guardrail tests at `tests/test_ng_validate.py:122-151` still pass. |
| F4 | high | Validator requires every `risk.md` to declare its mode under `## Selected mode`. `nuclear-grade migrate <packet>` inserts the block for legacy packets, inferring Quick or Standard from present files. |
| F5 | high | `nuclear-grade new --mode cm` and `--mode golden-path` scaffold all five files of each mode. QUICKSTART updated; manual-`cp` blocks removed. |
| F6 | medium | CI matrix on Python 3.11 and 3.12; `ruff` lint step (E, F, I, B, UP; ignores E501); per-file ignores for the legacy `tools/` shim. |
| F7 | medium | `EMPTY_PROMPT_PATTERN` no longer caps the label at 80 characters; long verbose labels now register as unfilled. |
| F8 | medium | README "one validated worked example" tightened to "one tested worked example and one author-judged comparison study." `results-summary.md` leads with a methodology banner naming the qualitative, author-judged nature of the 1-5 scores. |
| F9 | medium | `CHANGELOG.md` collapses overlapping Unreleased sections; stamps `[0.2.0] - 2026-05-27` with Breaking / Added / Fixed / Changed. |
| F10 | low | `CITATION.cff` (CFF 1.2) and `.github/CODEOWNERS` added, both with `MAINTAINER:` placeholders. |
| F11 | low | `docs/04-adoption/report-swot-gap-remediation.md` marks Phase 1 through Phase 4 lists as proposed deliverables, not refs to existing files. |
| F12 | low | `pyproject.toml` version bump to `0.2.0`; hatchling-backed wheel; `[tool.ruff]` config. |

### Breaking change

The validator now requires every packet's `risk.md` to declare its mode under a `## Selected mode` section (e.g. `- **Mode:** Quick` or `- **Mode:** Standard`). Migration helper:

```bash
nuclear-grade migrate .nuclear/changes/<slug>
```

The CHANGELOG `### Breaking` section documents this; existing repo packets (all seven plus the worked example) already declare mode and are unaffected.

## Test plan

- [x] `python -m pytest -q` green (73 tests; pre-existing 57 plus 16 new).
- [x] `python -m ruff check .` clean.
- [x] `python tools/ng.py doctor .` OK.
- [x] `python tools/ng.py validate` OK on every existing packet and on the new `.nuclear/changes/review-findings-2026-05/` packet.
- [x] Local `python -m build --wheel` produces `nuclear_grade-0.2.0-py3-none-any.whl` whose archive contains `nuclear_grade/_bundled/{templates,skills,commands}/...`.
- [x] Wheel installed into a clean venv and exercised end to end (`init`, `new --mode {quick,standard,cm,golden-path}`, `list`, `validate`) outside the source tree.
- [ ] CI green on both 3.11 and 3.12 matrix legs (depends on this PR).
- [ ] CI `wheel-smoke` job green (depends on this PR).
- [ ] Maintainer replaces `MAINTAINER:` placeholders in `CITATION.cff` and `.github/CODEOWNERS` before tagging `v0.2.0`.

## Packet

`.nuclear/changes/review-findings-2026-05/`. Mode: Standard. Twelve claims C-001 through C-012 mapped one-to-one to findings F1 through F12, with evidence rows in `verification.md`.

https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG)_