### PR TITLE
Mission-driven backbone: charter, mission anchor, and two drift skills

### DIFF
--- a/.nuclear/changes/mission-driven-backbone/basis.md
+++ b/.nuclear/changes/mission-driven-backbone/basis.md
@@ -1,0 +1,55 @@
+# Basis
+
+## Change context
+
+- Slug: mission-driven-backbone
+- Scope: Two-tier mission-driven backbone plus two drift skills and their commands.
+- Outcome to protect: The repo can detect and correct engineering drift without heavyweight mandatory process.
+
+## Need and scope
+
+AI agents drift across long sessions: they keep completing tasks while the work stops serving the objective, and rigor erodes one concession at a time. The repo controls configuration/baseline drift but nothing else. This change adds a durable charter (how we work) and a per-change mission anchor (what this change is for), plus skills and commands that force a re-anchor / escalate / stop decision and a standards-drift code review.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Evidence planned |
+|---|---|---|
+| C-001 | A durable charter of named process-integrity principles exists at `.nuclear/charter.md` and `init` writes a starter charter. | File exists; `tests/test_ng_cli.py::test_init_creates_charter_and_mission_anchor`. |
+| C-002 | A per-change mission anchor (objective + success + non-goals) is a section in the Standard risk template, and a workspace anchor is written by `init`. | Diff of `templates/standard/risk.md`; init test. |
+| C-003 | `controlling-mission-drift` is a valid skill: 11-section contract, drift symptoms as triggers, the re-anchor/escalate/stop triad, a counted (3-attempt/loop) escalation trigger, and Rickover/Navy principles woven in. | `tests/test_skill_contracts.py`; live `doctor`. |
+| C-004 | `reviewing-code-quality` is a valid skill capturing standards-drift review (delete-first, countable tripwires, abstraction-earns-keep, layering, single verdict). | `tests/test_skill_contracts.py`; live `doctor`. |
+| C-005 | `ng-drift-check.md` and `ng-code-review.md` are valid command prompts (10-section contract). | `tests/test_command_contracts.py`; live `doctor`. |
+| C-006 | The validator advisory-checks a mission anchor only when present (objective + success + non-goals) and flags unresolved clarification markers (the spec-kit style NEEDS-CLARIFICATION token), without breaking existing packets. | New `tests/test_ng_validate.py` cases; all existing packets still validate. |
+| C-007 | A drift gate (charter and anchor check, re-checked before Verify, with a justification table) is present in the Standard plan template. | Diff of `templates/standard/plan.md`. |
+| C-008 | Retrofits and registration land together: questioning-attitude, packing-agent-context, reviewing-ship-readiness, using-nuclear-grade, context-packs, WORKFLOWS, SKILLS.md, COMMANDS.md, nuclear-grade.yaml, skill-evaluation.md, results-summary.md. | Diffs; contract + public-doc tests. |
+
+## Assumptions, constraints, and invalidation triggers
+
+- Assumption: advisory only-when-present checks leave existing packets green. Invalidation trigger: any existing packet fails after the validator change.
+- Constraint: no em dashes or en dashes.
+- Constraint: both new skill descriptions obey the current 90-180 char "Use when" rule; the rule itself is not changed here.
+
+## Acceptance scenarios
+
+- A maintainer runs `nuclear-grade init` in a fresh workspace and finds `.nuclear/charter.md` and `.nuclear/mission.md`.
+- An agent twenty steps into a task runs `ng-drift-check`, restates the anchor, and gets a re-anchor / escalate / stop decision.
+- A reviewer runs `ng-code-review` on a 1500-line module and gets prioritized deletions and a single verdict.
+- A packet with a Mission anchor missing its non-goals fails validation with a clear advisory message; a packet with no anchor validates unchanged.
+
+## Required links
+
+- Packet: `.nuclear/changes/mission-driven-backbone/`
+- `risk.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Claims C-001 through C-008 are mapped to plan steps and have evidence rows.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by nuclear-industry safety and quality culture and the human-performance practices mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/mission-driven-backbone/plan.md
+++ b/.nuclear/changes/mission-driven-backbone/plan.md
@@ -1,0 +1,96 @@
+# Plan
+
+## Change context
+
+- Slug: mission-driven-backbone
+- Mode: Standard
+- Owner: maintainer
+
+## Charter and anchor check
+
+A re-evaluated gate, not a one-time note. Confirm before Plan and re-check before Verify. See `controlling-mission-drift`.
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes.
+- Re-checked before Verify? yes; scope held to the anchor, deferred items stayed deferred.
+- Charter articles in play: Rising standards, Formality, Evidence over persuasion, Graded rigor.
+
+If a non-goal or charter article must be crossed, record the justification here:
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | not applicable | not applicable | proceed |
+
+## Build sequence
+
+1. Author the two skills (`controlling-mission-drift`, `reviewing-code-quality`).
+2. Author the two command prompts.
+3. Add charter primitive (`.nuclear/charter.md`) and `init` writes for charter and mission anchor.
+4. Add the Mission anchor section to `templates/standard/risk.md` and the drift gate to `templates/standard/plan.md`.
+5. Add advisory validator checks (`_check_mission_anchor`, `_check_unresolved_clarifications`).
+6. Retrofit cross-references (questioning-attitude, packing-agent-context, reviewing-ship-readiness, using-nuclear-grade, context-packs, WORKFLOWS).
+7. Register both skills and commands (SKILLS.md, COMMANDS.md, nuclear-grade.yaml, skill-evaluation.md, results-summary.md, contract test sets).
+8. Add validator and init tests.
+9. Fill this dogfood packet; validate.
+
+## HPI task preview
+
+| Critical step | Likely error | Consequence | Control / contingency | Evidence |
+|---|---|---|---|---|
+| Validator change | False-trigger on existing packets | CI breaks | Only-when-present pattern; run all packets | verification.md |
+| Registration | Forget a coupled file | Contract test fails | doctor + contract tests before commit | verification.md |
+
+## Affected files and assets
+
+| File / asset | Change expected | Why it matters | Owner |
+|---|---|---|---|
+| `skills/*`, `commands/*` | New skills and commands | Core deliverable | maintainer |
+| `nuclear_grade/*` | Advisory checks and init writes | Teeth and primitives | maintainer |
+| `templates/standard/*` | Anchor section and gate | Per-change backbone | maintainer |
+
+## Non-goals
+
+- Changing the skill description rule or any other contract field.
+- Making the anchor or charter a hard required gate.
+- The evidence-coverage validator rule.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Skills and commands authored | Pass the contract sections | pass |
+| Validator change | Existing packets still validate | pass |
+| Registration complete | Contract and public-doc tests pass | pass |
+| Packet validates | This packet passes the validator | pass |
+
+## Rollback approach
+
+- Rollback method: revert the branch commits; each piece is additive.
+- State/data reversal notes: none; no data migrations.
+- Feature flag / kill switch: not applicable; advisory checks are non-blocking.
+- Owner: maintainer.
+- Time to restore estimate: minutes (single revert).
+
+## Proof commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py validate .nuclear/changes/mission-driven-backbone
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Build sequence executed; tests green; packet validates.
+
+## Source-lineage note
+
+Original Nuclear-grade plan influenced by lifecycle and configuration-management concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/mission-driven-backbone/risk.md
+++ b/.nuclear/changes/mission-driven-backbone/risk.md
@@ -1,0 +1,109 @@
+# Risk
+
+## Change identity
+
+- Slug: mission-driven-backbone
+- PR / issue: (TBD on push)
+- Owner: maintainer
+- Date: 2026-05-27
+- Current lifecycle phase: Execute
+- Summary: Add a mission-driven backbone to the repo: a durable charter of process-integrity principles, a per-change mission anchor, two new skills (`controlling-mission-drift`, `reviewing-code-quality`), two paired command prompts, an advisory drift gate in the Standard templates, and minimal only-when-present validator checks.
+
+## Mission anchor
+
+State what this change is for, so a long session can be tested against it. See `controlling-mission-drift`.
+
+- Objective: Give the repo a backbone that resists engineering drift, both intent drift (scope creep, goal substitution) and standards drift (normalization of deviance).
+- Success criteria: The charter and mission anchor exist and are reachable; the two skills and two commands pass the contract checks; the validator advisory-checks a mission anchor only when present; the full test suite, ruff, doctor, and this packet's validation all pass.
+- Non-goals / forbidden directions: Out of scope is rewriting the 90-180 char description rule or any other skill-contract change; out of scope is making the anchor or charter a hard required gate; out of scope is the evidence-coverage validator rule.
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: workspace `.nuclear/charter.md` and the originating design discussion.
+
+## Questioning-attitude summary
+
+- Decision question: How do we make agents mission-driven and resistant to drift without adding heavyweight, mandatory process?
+- Assumptions that changed the mode: The feature spans skills, commands, templates, validator, and docs, and adds advisory enforcement; that breadth justifies Standard.
+- Facts still needing validation: That the advisory mission-anchor check does not false-trigger on existing packets (confirmed: only-when-present) and that the two new skills pass the live doctor contract.
+- Stop or hold conditions: Stop if the advisory checks would break existing packets, or if the scope starts absorbing the deferred contract-evolution items.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `skills/controlling-mission-drift/SKILL.md` | Skill | New intent-drift skill | `../../../skills/controlling-mission-drift/SKILL.md` |
+| `skills/reviewing-code-quality/SKILL.md` | Skill | New standards-drift skill | `../../../skills/reviewing-code-quality/SKILL.md` |
+| `commands/ng-drift-check.md`, `commands/ng-code-review.md` | Commands | Portable prompts for the two skills | `../../../commands/ng-drift-check.md` |
+| `nuclear_grade/ng_validate.py` | Code | Advisory mission-anchor and clarification-marker checks | `../../../nuclear_grade/ng_validate.py` |
+| `nuclear_grade/cli.py` | Code | `init` writes charter and mission anchor | `../../../nuclear_grade/cli.py` |
+| `templates/standard/risk.md`, `templates/standard/plan.md` | Templates | Mission anchor section and drift gate | `../../../templates/standard/risk.md` |
+| `.nuclear/charter.md` | Charter | The durable backbone | `../../charter.md` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Adds public skills, commands, and an advisory validator rule. |
+| Reversibility | high | Each piece is additive and revertible. |
+| Detectability | high | Doctor, contract tests, and the validator catch regressions. |
+| Exposure | medium | Public repo; new skills are visible surface. |
+| Uncertainty | low | Only-when-present checks are well understood. |
+| Dependency trust | low | No new runtime dependencies. |
+| AI authority | low | No new agent write permissions. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine/repetitive action where inattention is plausible | no | n/a |
+| Known procedure where workflow adherence matters | yes | packet path and the plan build sequence |
+| Novel or uncertain work where assumptions may be wrong | yes | questioning attitude in this risk; advisory-only enforcement |
+| Interrupted, resumed, or handed-off work | no | n/a |
+| High-consequence critical action | no | n/a |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** A multi-surface feature (skills, commands, templates, validator, docs) with new public surface and an advisory rule.
+- **Why lighter mode is not enough:** Quick cannot record the claim-to-evidence mapping across the surfaces.
+- **Why heavier mode is not yet required:** No regulated use, no safety basis, no controlled-supplier dedication.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline above. | maintainer |
+| `basis.md` | yes | Claim-to-evidence mapping. | maintainer |
+| `verification.md` | yes | Per-claim evidence status. | maintainer |
+| `ship.md` | yes | Release decision. | maintainer |
+| `turnover.md` | no | Single-author packet. | maintainer |
+| `self-check.md` | no | No high-consequence critical action. | maintainer |
+| `supplier-trust.md` | no | No new external supplier. | maintainer |
+| Nuclear subset record | no | Not warranted. | maintainer |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: Confirm the only-when-present pattern leaves existing packets green.
+- Minimum evidence before merge/release: pytest green; ruff clean; doctor OK; this packet validates; both new skills and commands pass the live contract.
+- Independent review needed? no for this PR.
+
+## Required links
+
+- Packet: `.nuclear/changes/mission-driven-backbone/`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Charter: `../../charter.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Mode is justified as Standard.
+- The mission anchor names objective, success criteria, and non-goals.
+- Claims map to evidence in `verification.md`.
+- No hidden trigger for a stronger mode.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by nuclear-industry mission ownership and rising-standards culture and by the human-performance practices mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/mission-driven-backbone/ship.md
+++ b/.nuclear/changes/mission-driven-backbone/ship.md
@@ -1,0 +1,54 @@
+# Ship
+
+## Release decision
+
+- **Decision:** ship as a new minor feature on a new branch and PR, once CI is green.
+- **Rationale:** The backbone is additive and advisory; it adds two skills, two commands, a charter, a mission anchor, and only-when-present validator checks. Nothing is a breaking change.
+- **Pre-merge gates:**
+  - `python -m pytest -q` green
+  - `ruff check .` clean
+  - `python tools/ng.py doctor .` OK
+  - `python tools/ng.py validate` OK on every packet including this one
+  - CI green (matrix and wheel-smoke from the base branch carry over)
+
+## Evidence status summary
+
+| Area | Status | Link |
+|---|---|---|
+| Verification | pass | `verification.md` |
+| Trace | pass | `trace.md` |
+| Skills and commands | pass | live doctor + contract tests |
+| Validator advisory checks | pass | new validator tests |
+| Packet self-validation | pass | `python tools/ng.py validate .nuclear/changes/mission-driven-backbone` |
+
+## Rollback / restore plan
+
+- Each piece is additive; revert the branch commits to restore prior state. No data migration.
+- If the advisory mission-anchor check is noisy in practice, narrow `MISSION_ANCHOR_CONCEPTS` or gate it more tightly; this does not require reverting the skills.
+
+## Monitoring and post-release checks
+
+- Watch for false positives from the mission-anchor advisory check and the unresolved-clarification-marker check on real packets; widen the keyword families or the disclaimer markers if legitimate prose is flagged.
+- Watch adoption of `ng-drift-check` and `ng-code-review`; capture an OPEX note if either skill consistently misfires its trigger.
+- Revisit whether the charter should become a hard gate once the advisory version has proven out.
+
+## Maintainer follow-ups
+
+- Replace `<date>` placeholders in the init `CHARTER_TEMPLATE` output if a dated starter is preferred.
+- Consider the deferred contract-evolution PR (description rule, progressive disclosure, evidence coverage).
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+
+## Exit criteria
+
+- Decision recorded; rollback named; monitoring named.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record influenced by release-readiness concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/mission-driven-backbone/trace.md
+++ b/.nuclear/changes/mission-driven-backbone/trace.md
@@ -1,0 +1,30 @@
+# Trace
+
+## Trace summary
+
+| Claim ID | Artifact | Status |
+|---|---|---|
+| C-001 | `.nuclear/charter.md`; `handle_init` in `cli.py`; `test_init_creates_charter_and_mission_anchor` | pass |
+| C-002 | `templates/standard/risk.md` Mission anchor section; `MISSION_TEMPLATE` in `cli.py` | pass |
+| C-003 | `skills/controlling-mission-drift/SKILL.md`; `EXPECTED_SKILLS`; live doctor | pass |
+| C-004 | `skills/reviewing-code-quality/SKILL.md`; `EXPECTED_SKILLS`; live doctor | pass |
+| C-005 | `commands/ng-drift-check.md`, `commands/ng-code-review.md`; `EXPECTED_COMMANDS`; live doctor | pass |
+| C-006 | `_check_mission_anchor`, `_check_unresolved_clarifications` in `ng_validate.py`; new validator tests | pass |
+| C-007 | `templates/standard/plan.md` charter-and-anchor gate | pass |
+| C-008 | retrofit diffs and registration files; contract and public-doc tests | pass |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim maps to a named artifact and a status.
+
+## Source-lineage note
+
+Original Nuclear-grade trace influenced by traceability concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/mission-driven-backbone/verification.md
+++ b/.nuclear/changes/mission-driven-backbone/verification.md
@@ -1,0 +1,50 @@
+# Verification
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+
+## Claim-to-evidence table
+
+| Claim | Result status | Evidence link | Notes |
+|---|---|---|---|
+| C-001 charter + init write | pass | `../../charter.md`; `../../../nuclear_grade/cli.py` | `init` writes charter and mission; covered by `test_init_creates_charter_and_mission_anchor`. |
+| C-002 mission anchor section | pass | `../../../templates/standard/risk.md` | Section present after Change identity; workspace template in `MISSION_TEMPLATE`. |
+| C-003 controlling-mission-drift skill | pass | `../../../skills/controlling-mission-drift/SKILL.md` | 11 sections; description 143 chars; counted 3-attempt trigger and Rickover principles present. |
+| C-004 reviewing-code-quality skill | pass | `../../../skills/reviewing-code-quality/SKILL.md` | 11 sections; description 155 chars; delete-first, tripwires, single verdict present. |
+| C-005 two commands | pass | `../../../commands/ng-drift-check.md`; `../../../commands/ng-code-review.md` | 10 sections each; contain "portable command prompt"; no "slash command". |
+| C-006 advisory validator checks | pass | `../../../nuclear_grade/ng_validate.py` | Mission-anchor check only-when-present; clarification-marker check; new tests pass; all existing packets still validate. |
+| C-007 drift gate in plan template | pass | `../../../templates/standard/plan.md` | Charter-and-anchor check with justification table. |
+| C-008 retrofits + registration | pass | `../../../SKILLS.md`; `../../../COMMANDS.md`; `../../../nuclear-grade.yaml`; `../../../docs/05-reference/skill-evaluation.md` | Contract and public-doc tests pass; doctor OK. |
+
+## Reproduction commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py validate .nuclear/changes/mission-driven-backbone
+for p in .nuclear/changes/*; do python tools/ng.py validate "$p"; done
+```
+
+## Known gaps and deferrals
+
+- The charter and mission anchor are advisory, not blocking gates. Recorded as `deferred`: hard enforcement is a future, breaking decision.
+- The contract-evolution items (description-rule change, progressive disclosure, evidence-coverage check) are `deferred` to separate PRs.
+- CI has not run at packet-authoring time; it is the public evidence for the matrix and wheel jobs.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim has a recorded status.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record influenced by graded-rigor evidence concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/charter.md
+++ b/.nuclear/charter.md
@@ -1,0 +1,30 @@
+# Nuclear-grade Charter
+
+**Version:** 1.0.0
+**Ratified:** 2026-05-27
+**Last amended:** 2026-05-27
+
+The charter is the durable backbone: non-negotiable principles of how work is done here, independent of any single change. A mission anchor states what a given change is for; the charter states how all changes must be carried out. The charter is advisory in tooling today (the validator does not block on it) but it is the standard a reviewer and an agent are expected to hold.
+
+Principles are scaled by mode. Quick changes honor the spirit; Standard and activated records are where the charter earns its keep. Amend the charter by raising the version (major for a removed or redefined principle, minor for an added one, patch for wording) and noting the change below.
+
+## Articles
+
+1. **Ownership.** A named person owns each change and its evidence. If no one owns it, no one is accountable for whether it still serves its mission.
+2. **Face facts.** Report the actual state, not the hoped-for state. Wishful thinking is not evidence.
+3. **Rising standards.** Never normalize a deviation. A small erosion of rigor is a finding, not a rounding error.
+4. **Formality.** Follow the procedure. Deviations are documented and decided, never silent.
+5. **Technical depth.** The owner understands the details, not just the summary.
+6. **Integrity in reporting.** Bad news travels up immediately and intact. A softened report is itself a drift.
+7. **Questioning attitude.** Challenge assumptions before acting; prefer facts over confidence.
+8. **Evidence over persuasion.** Claims carry reproducible evidence or a labeled gap, not prose that convinces.
+9. **Graded rigor.** Match controls to consequence. Quick for low-consequence reversible work; Standard and activated records as consequence rises.
+10. **Baseline discipline.** The accepted configuration is recorded, and changes to it are controlled and traceable.
+
+## Amendment log
+
+- 1.0.0 (2026-05-27): Initial charter.
+
+## Source-lineage note
+
+The charter is an original software-workflow statement influenced by nuclear-industry safety and quality culture (Rickover and Navy nuclear practice, and the human-performance practices in DOE-HDBK-1028-2009) as concept lineage mapped in `docs/00-standards-foundation/source-map.md`. It does not create DOE compliance, formal assurance, safety, security, certification, or regulatory adequacy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses changelog entries to record public-facing changes, not to impl
 
 ## [Unreleased]
 
+### Added
+
+- Mission-driven backbone. A durable repo charter (`.nuclear/charter.md`) of named process-integrity principles (ownership, facing facts, rising standards, formality, technical depth, integrity in reporting, questioning attitude, evidence over persuasion, graded rigor, baseline discipline; nuclear-culture and Rickover/Navy lineage), plus a per-change `## Mission anchor` (objective + success criteria + non-goals) in the Standard risk template. `nuclear-grade init` now writes a starter `.nuclear/charter.md` and `.nuclear/mission.md` (both advisory).
+- `controlling-mission-drift` skill: detect and correct intent drift (scope creep, goal substitution) with a re-anchor / escalate / stop decision and a counted escalation trigger (stop after 3 failed attempts or a loop).
+- `reviewing-code-quality` skill: standards-drift review (prefer deletion over rearrangement, countable complexity tripwires, abstractions must earn their keep, no feature logic in shared layers, single verdict).
+- `ng-drift-check` and `ng-code-review` portable command prompts for the two skills.
+- A re-evaluated drift gate (`## Charter and anchor check` with a justification table) in the Standard plan template.
+- Advisory validator checks: a mission anchor is checked for objective, success criterion, and non-goals only when a `## Mission anchor` section is present; unresolved NEEDS-CLARIFICATION markers fail before ship. Both are non-breaking (only fire when present).
+
 ## [0.2.0] - 2026-05-27
 
 ### Breaking

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -21,6 +21,8 @@ These are portable command prompts: plain Markdown prompt cards that can be past
 | [`ng-trust-check`](commands/ng-trust-check.md) | Checking dependency, model, API, SaaS, generated artifact, or vendor trust | Intended-use trust screen |
 | [`ng-source-check`](commands/ng-source-check.md) | Checking source lineage | Source-safe wording |
 | [`ng-legal-check`](commands/ng-legal-check.md) | Checking license and assurance boundaries | Boundary-safe wording |
+| [`ng-drift-check`](commands/ng-drift-check.md) | Testing work against its mission anchor and charter | Re-anchor / escalate / stop decision |
+| [`ng-code-review`](commands/ng-code-review.md) | Reviewing a diff or module for standards drift and complexity | Findings and a single verdict |
 
 ## Contract
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -22,6 +22,8 @@ Skills are self-contained agent instructions. Each skill has a `SKILL.md` contra
 | [`checking-dependency-and-model-trust`](skills/checking-dependency-and-model-trust/SKILL.md) | Reviewing dependency, model, API, SaaS, generated artifact, or vendor trust | Intended-use trust screen |
 | [`checking-source-lineage`](skills/checking-source-lineage/SKILL.md) | Reviewing citation and source-family claims | Source-safe wording |
 | [`checking-license-and-assurance-boundaries`](skills/checking-license-and-assurance-boundaries/SKILL.md) | Reviewing license and assurance language | Boundary-safe wording |
+| [`controlling-mission-drift`](skills/controlling-mission-drift/SKILL.md) | Work drifts from the objective, scope creeps, or rigor erodes one concession at a time | Re-anchor / escalate / stop decision and updated mission anchor |
+| [`reviewing-code-quality`](skills/reviewing-code-quality/SKILL.md) | Reviewing a diff or module for standards drift and needless complexity | Prioritized findings and a single verdict |
 
 ## Contract
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -27,6 +27,8 @@ HPI for AI agents adds the micro-controls under that path: brief the work, self-
 | OPEX learning | event -> weak control -> durable update -> verification -> re-baseline trigger | Near misses, bad handoffs, escaped defects, or review surprises should change future work | `opex.md` |
 | Trust check | intended use -> external claims -> local evidence -> controls -> release impact | Dependencies, models, APIs, SaaS, generated artifacts, or vendor claims affect trust | `supplier-trust.md` or packet section |
 | Source/legal check | claim -> source map -> boundary wording -> validator | Public docs or examples cite assurance concepts | Source-lineage notes |
+| Mission drift control | anchor -> zoom out -> test action -> loop/standards check -> re-anchor/escalate/stop | A long session drifts from its objective, scope creeps, or rigor erodes | `## Mission anchor`, `.nuclear/mission.md` |
+| Code-quality review | objective -> delete-first -> tripwires -> abstraction check -> layering -> verdict | A diff or module risks standards drift or needless complexity | Review findings plus verdict |
 
 ## Quick change
 

--- a/commands/ng-code-review.md
+++ b/commands/ng-code-review.md
@@ -1,0 +1,79 @@
+# ng-code-review
+
+## Purpose
+
+Review a diff or module for standards drift (oversized files, needless abstraction, leaked feature logic, clever indirection) and issue one honest verdict. This is a portable command prompt.
+
+## Use when
+
+- A diff or module is up for review and you want a standards check, not just a correctness check.
+- A file or function has grown large, or an abstraction layer is being added.
+- A refactor is proposed and you need to judge whether it removes complexity or just moves it.
+- An agent produced code quickly and the question is whether it stays maintainable.
+
+## Do not use when
+
+- The change is a trivial, obvious edit with no structural impact.
+- The task is only about functional correctness (use ng-prove instead).
+- A hotfix must ship for incident containment before a quality pass is reasonable.
+
+## Inputs
+
+- The diff or module under review and its surrounding files.
+- The change's mission anchor or objective.
+- Project conventions and any agreed countable limits.
+- The layering map: what is shared/canonical versus feature-specific.
+
+## Prompt text
+
+```text
+Run a Nuclear-grade code-quality review on this change.
+
+Inputs:
+- diff or module:
+- objective / mission anchor:
+- agreed limits or conventions:
+- shared vs feature-specific layers:
+
+Do this:
+- Read the change against its objective; flag scope drift first.
+- Look for deletion before rearrangement; ask what can be removed entirely.
+- Apply countable tripwires as prompts, not laws (file ~1000 lines, function ~50 lines, deep nesting, duplicated branches).
+- Test each abstraction: it must remove more complexity than it adds; flag thin pass-throughs.
+- Check layering: flag feature logic leaking into shared/canonical/framework code.
+- Prefer boring direct code over clever indirection.
+
+Return:
+- a prioritized findings list (location, standard at risk, concrete fix, often a deletion)
+- one verdict: VERIFIED, NOT VERIFIED, or INCONCLUSIVE
+- a short rationale tying the verdict to the findings
+
+Do not soften every finding into "looks good." Do not imply formal assurance, compliance, certification, safety, security, or regulatory adequacy.
+```
+
+## Files created or modified
+
+- Review notes in the PR, or a section in `verification.md` when the review is packet evidence.
+
+## Expected outputs
+
+- A prioritized findings list with concrete fixes.
+- A single verdict: VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+- A rationale that matches the verdict.
+
+## Verification command
+
+```bash
+python tools/ng.py validate .nuclear/changes/<slug>
+```
+
+## Failure modes
+
+- Rearranging complexity instead of asking what deletes the need for it.
+- Treating countable tripwires as hard laws rather than investigation prompts.
+- Passing speculative abstraction because it "might be useful later."
+- Ending with no verdict, or a verdict that does not match the findings.
+
+## Legal/assurance boundary note
+
+This command supports maintainability review and evidence visibility. It does not create formal V&V, compliance, certification, safety, security, procurement adequacy, or regulatory approval.

--- a/commands/ng-drift-check.md
+++ b/commands/ng-drift-check.md
@@ -1,0 +1,81 @@
+# ng-drift-check
+
+## Purpose
+
+Test the current work against its mission anchor and the repo charter, and force a re-anchor, escalate, or stop decision. This is a portable command prompt.
+
+## Use when
+
+- A long session has drifted and the current action is hard to tie to the original objective.
+- Scope is growing, the same action is being retried, or a non-goal is about to be crossed.
+- Context was reset, compacted, or handed off and the objective must be re-established.
+- A standard is about to be relaxed "just this once."
+
+## Do not use when
+
+- A tiny Quick edit with an obvious objective and no risk of scope growth.
+- Incident containment must happen before reflection.
+- The user needs formal assurance, certification, legal advice, or regulatory approval.
+
+## Inputs
+
+- The mission anchor: `.nuclear/mission.md`, the `## Mission anchor` in `risk.md`, or the originating issue/PR.
+- The repo charter (`.nuclear/charter.md`) when present.
+- The current action and recent attempt history.
+- Affected files, the diff so far, and the declared non-goals.
+
+## Prompt text
+
+```text
+Run a Nuclear-grade mission-drift check on the current work.
+
+Inputs:
+- mission anchor (objective, success criteria, non-goals):
+- charter principles in play:
+- current action:
+- recent attempts at this objective (how many, what variants):
+- affected files / diff so far:
+
+Do this:
+- Restate the anchor from the written record, not from memory.
+- Zoom out one layer; judge at the objective/architecture altitude.
+- Test the current action against the success criteria and non-goals.
+- Check the loop: if the same objective has failed 3 times, stop attempting the next variant.
+- Check standards drift against the charter and any countable tripwires.
+
+Return one decision:
+- RE-ANCHOR: the action serves the mission; restate the anchor and continue.
+- ESCALATE: a non-goal or standard must be crossed for a defensible reason; include a justification row (what is crossed, why, why no simpler path exists).
+- STOP: the action serves a substituted goal, or the justification does not hold.
+
+Also return the updated anchor text so the decision survives the next context reset.
+Do not imply formal assurance, compliance, certification, safety, security, or regulatory adequacy.
+```
+
+## Files created or modified
+
+- `.nuclear/mission.md` or the `## Mission anchor` section in `risk.md` (updated anchor).
+- `ship.md` or an OPEX record when the drift was a near miss.
+
+## Expected outputs
+
+- A re-anchor / escalate / stop decision with one line of rationale.
+- An updated, durable mission anchor.
+- A justification row when a non-goal or standard was deliberately crossed.
+
+## Verification command
+
+```bash
+python tools/ng.py validate .nuclear/changes/<slug>
+```
+
+## Failure modes
+
+- Restating the mission without honestly testing the current action against it (drift theater).
+- Attempting the next variant after three failures instead of escalating.
+- Crossing a non-goal by editing rather than by a recorded decision.
+- Measuring progress in activity rather than in success criteria met.
+
+## Legal/assurance boundary note
+
+This command supports mission alignment and evidence visibility. It does not create formal V&V, compliance, certification, safety, security, procurement adequacy, or regulatory approval.

--- a/docs/02-operating-system/context-packs.md
+++ b/docs/02-operating-system/context-packs.md
@@ -45,6 +45,8 @@ Mode: Quick / Standard / Nuclear / Incident / Research Board / Release
 Role: builder / reviewer / verifier / releaser / incident lead / researcher
 Packet: .nuclear/changes/<slug>/
 Objective: <one paragraph>
+Mission anchor: <objective, success criteria, non-goals; survives context resets>
+Charter: <.nuclear/charter.md articles in play>
 Affected files: <paths>
 Current phase: Question / Specify / Plan / Execute / Verify / Review / Decide / Baseline / Operate / Learn
 Last completed action: <resume point>

--- a/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
@@ -33,6 +33,8 @@
 
 ## Skill Coverage
 
+*This table maps each skill to the use cases it applies to. Skills added after the original U01-U12 trials (for example `controlling-mission-drift` and `reviewing-code-quality`) are mapped retroactively to the use cases where they apply; they were not run as separate trials.*
+
 | Skill | Trial records |
 |---|---|
 | `questioning-attitude` | U02, U03, U04, U05, U06, U07, U08, U09, U10, U11, U12 |
@@ -51,6 +53,8 @@
 | `checking-dependency-and-model-trust` | U03, U05, U07, U11 |
 | `checking-source-lineage` | U04, U05, U12 |
 | `checking-license-and-assurance-boundaries` | U04, U05, U12 |
+| `controlling-mission-drift` | U05, U08, U09, U11 |
+| `reviewing-code-quality` | U02, U07, U08 |
 
 ## Workflow Coverage
 

--- a/docs/05-reference/skill-evaluation.md
+++ b/docs/05-reference/skill-evaluation.md
@@ -144,6 +144,22 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should not trigger: List changed files in the PR.
 - Should not trigger: Run the worked-example tests.
 
+### `controlling-mission-drift`
+
+- Should trigger: We are twenty steps into this task and I cannot tell if the current edit still serves the original goal.
+- Should trigger: The agent keeps adding features no one asked for; check whether we have drifted from the objective.
+- Should trigger: We have retried this fix three times without progress; should we re-anchor, escalate, or stop?
+- Should not trigger: Fix a README typo and show the diff.
+- Should not trigger: Explain what this small helper function does.
+
+### `reviewing-code-quality`
+
+- Should trigger: Review this 1500-line module for needless complexity and tell me what to delete.
+- Should trigger: Does this new wrapper earn its keep, or is it just indirection?
+- Should trigger: Check whether feature-specific logic is leaking into the shared layer in this diff.
+- Should not trigger: Confirm the unit test passes and paste the output.
+- Should not trigger: Cite a public DOE handbook as source lineage for a docs paragraph.
+
 ## Source-lineage note
 
 This evaluation prompt bank is an original Nuclear-grade artifact informed by public skill-authoring practice: concise skills, realistic trigger prompts, baseline-vs-skill comparison, and iterative trigger-description improvement. It does not create formal assurance, compliance, certification, safety, security, or regulatory adequacy.

--- a/nuclear-grade.yaml
+++ b/nuclear-grade.yaml
@@ -46,6 +46,8 @@ skills:
   - checking-dependency-and-model-trust
   - checking-source-lineage
   - checking-license-and-assurance-boundaries
+  - controlling-mission-drift
+  - reviewing-code-quality
 commands:
   - ng-question.md
   - ng-classify.md
@@ -62,6 +64,8 @@ commands:
   - ng-trust-check.md
   - ng-source-check.md
   - ng-legal-check.md
+  - ng-drift-check.md
+  - ng-code-review.md
 boundaries:
   license: MIT
   assurance: evidence visibility only

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -102,6 +102,43 @@ MODE_DEFAULT_BLOCK = {
     "standard": "## Selected mode\n\n- **Mode:** Standard\n",
 }
 
+CHARTER_TEMPLATE = (
+    "# Charter\n\n"
+    "**Version:** 1.0.0\n"
+    "**Ratified:** <date>\n"
+    "**Last amended:** <date>\n\n"
+    "Durable, non-negotiable principles of how work is done here, independent of any single change. "
+    "A mission anchor states what a change is for; the charter states how all changes must be carried out. "
+    "Advisory in tooling; the standard a reviewer and an agent are expected to hold. Scaled by mode.\n\n"
+    "## Articles\n\n"
+    "1. Ownership: a named person owns each change and its evidence.\n"
+    "2. Face facts: report actual state, not hoped-for state.\n"
+    "3. Rising standards: never normalize a deviation; a small erosion is a finding.\n"
+    "4. Formality: follow the procedure; document and decide deviations, never silent.\n"
+    "5. Technical depth: the owner understands the details, not just the summary.\n"
+    "6. Integrity in reporting: bad news travels up immediately and intact.\n"
+    "7. Questioning attitude: challenge assumptions before acting.\n"
+    "8. Evidence over persuasion: claims carry reproducible evidence or a labeled gap.\n"
+    "9. Graded rigor: match controls to consequence.\n"
+    "10. Baseline discipline: the accepted configuration is recorded and changes are controlled.\n\n"
+    "## Amendment log\n\n"
+    "- 1.0.0 (<date>): Initial charter.\n\n"
+    "This charter records principles for engineering review. It does not create compliance, formal "
+    "V&V, safety, security, certification, or regulatory adequacy.\n"
+)
+
+MISSION_TEMPLATE = (
+    "# Workspace mission anchor\n\n"
+    "The durable objective this workspace serves. Individual change packets declare their own "
+    "`## Mission anchor`; this file is the anchor those changes trace up to. Re-state it after any "
+    "context reset so the mission survives context loss.\n\n"
+    "- Objective: <the durable goal this workspace serves>\n"
+    "- Success criteria: <observable conditions that mean the objective is met>\n"
+    "- Non-goals / forbidden directions: <explicit out-of-scope and prohibited directions>\n\n"
+    "This anchor records intent for engineering review. It does not create compliance, formal V&V, "
+    "safety, security, certification, or regulatory adequacy.\n"
+)
+
 
 @dataclass(frozen=True)
 class PlannedWrite:
@@ -188,6 +225,8 @@ def handle_init(args: argparse.Namespace) -> int:
                 "create compliance, formal V&V, safety, security, or regulatory adequacy.\n"
             ),
         ),
+        PlannedWrite(repo / ".nuclear" / "charter.md", content=CHARTER_TEMPLATE),
+        PlannedWrite(repo / ".nuclear" / "mission.md", content=MISSION_TEMPLATE),
     ]
     return apply_writes(writes, dry_run=args.dry_run, overwrite=args.yes)
 

--- a/nuclear_grade/ng_validate.py
+++ b/nuclear_grade/ng_validate.py
@@ -141,6 +141,8 @@ def validate_packet(packet: str | Path) -> ValidationResult:
         _check_prohibited_claims(md_file, text, messages)
         _check_source_lineage(md_file, text, messages)
         _check_relative_links(packet_path, md_file, text, messages)
+        _check_mission_anchor(md_file, text, messages)
+        _check_unresolved_clarifications(md_file, text, messages)
 
     effective_mode = mode if mode != UNSPECIFIED_MODE else declared
     if effective_mode != UNSPECIFIED_MODE:
@@ -223,6 +225,62 @@ def _check_source_lineage(md_file: Path, text: str, messages: list[str]) -> None
         return
     if "source-map.md" not in text and "http://" not in text and "https://" not in text:
         messages.append(f"{md_file.name} source-lineage note must reference source-map.md or a public URL")
+
+
+MISSION_ANCHOR_CONCEPTS = (
+    ("objective", ("objective", "mission", "goal")),
+    ("success/done criterion", ("success", "done", "acceptance", "criteri")),
+    (
+        "non-goals / forbidden directions",
+        ("non-goal", "non goal", "out of scope", "out-of-scope", "forbidden", "do not", "not in scope"),
+    ),
+)
+
+
+def _check_mission_anchor(md_file: Path, text: str, messages: list[str]) -> None:
+    """Advisory: only runs when a `## Mission anchor` section is present.
+
+    A usable anchor names an objective, a success/done criterion, and explicit
+    non-goals (the anti-drift teeth). Matching is by keyword family so authors
+    are not forced into exact labels. Emptiness of individual prompts is already
+    caught by _check_unfilled_template_prompts.
+    """
+
+    lowered = text.lower()
+    if "## mission anchor" not in lowered:
+        return
+
+    section = _section_text(text, "## mission anchor")
+    scannable = _strip_code_blocks(section).lower()
+    for label, synonyms in MISSION_ANCHOR_CONCEPTS:
+        if not any(token in scannable for token in synonyms):
+            messages.append(f"{md_file.name} Mission anchor present but missing a {label}")
+
+
+def _check_unresolved_clarifications(md_file: Path, text: str, messages: list[str]) -> None:
+    if "[NEEDS CLARIFICATION]" in _strip_code_blocks(text):
+        messages.append(
+            f"{md_file.name} has an unresolved [NEEDS CLARIFICATION] marker; resolve it or record it as a labeled gap before ship"
+        )
+
+
+def _section_text(text: str, heading_lower: str) -> str:
+    """Return the body of a `## Heading` section (case-insensitive) up to the next H2 or end."""
+
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().lower() == heading_lower:
+            start = i
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## "):
+            end = j
+            break
+    return "".join(lines[start:end])
 
 
 def _check_relative_links(packet_path: Path, md_file: Path, text: str, messages: list[str]) -> None:

--- a/skills/controlling-mission-drift/SKILL.md
+++ b/skills/controlling-mission-drift/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: controlling-mission-drift
+description: Use when an agent keeps completing tasks but the work drifts from the stated objective, scope creeps, or rigor erodes one concession at a time.
+---
+
+# Controlling Mission Drift
+
+## Overview
+
+Mission drift is when an agent keeps shipping work that no longer serves the original objective. It has two faces: intent drift (scope creep, goal substitution, local optimization that wins the task and loses the mission) and standards drift (rigor erodes one accepted concession at a time, the normalization of deviance). This skill keeps a durable mission anchor in front of the work and forces a decision when an action stops serving it: re-anchor, escalate, or stop. The anchor is the objective, the success criteria, and the explicit non-goals. Ownership of the anchor stays with a named person, in the spirit of nuclear-culture accountability: someone is responsible for whether this change still serves its mission.
+
+## When to Use
+
+- A long session has produced many steps and the current action is hard to tie back to the original objective.
+- Scope is growing: new files, new features, or new abstractions appear that no one asked for.
+- The same action, file, or fix variant is being retried without progress (a loop).
+- Token burn is high while observable progress is low.
+- A reviewer or agent is reasoning from memory of the objective rather than a written anchor.
+- A non-goal is about to be crossed, or a standard is about to be relaxed "just this once."
+- Context was reset, compacted, or handed off and the objective must be re-established before work continues.
+
+## When Not to Use
+
+- A tiny Quick edit with an obvious objective and no risk of scope growth.
+- Incident containment that must happen before reflection.
+- The user is asking for formal assurance, certification, or regulatory approval.
+
+## Inputs
+
+- The mission anchor: `.nuclear/mission.md`, the `## Mission anchor` in `risk.md`, or the originating issue/PR.
+- The repo charter (`.nuclear/charter.md`) when present: the durable principles the work must not violate.
+- The current action and recent action history (what was attempted, how many times).
+- Affected files, the diff so far, and the declared non-goals.
+
+## Process
+
+1. Restate the mission anchor from the written record, not from memory: objective, success criteria, and non-goals.
+2. Test the current action against the anchor. Ask plainly: does this action move a success criterion, or does it serve a goal that was substituted along the way?
+3. Zoom out one layer before deciding. Look at the objective and the architecture, not the line in front of you, so the decision is made at the right altitude.
+4. Check the loop and attempt count. If the same objective has failed 3 times, or the same action or fix variant is being retried, stop attempting the next variant.
+5. Check standards drift against the charter and any countable tripwires (for example, a file or function crossing a size limit, a skipped verification, a weaker-than-agreed evidence standard). A single normalized concession is a finding, not a rounding error.
+6. Decide and record one of three outcomes:
+   - Re-anchor: the action serves the mission; restate the anchor and continue.
+   - Escalate: the action would cross a non-goal or relax a standard for a defensible reason; record a justification row (what is being crossed, why, why no simpler path exists) and get the owner's decision.
+   - Stop: the action serves a substituted goal, or the justification does not hold; halt and return to the anchor.
+7. Update the durable anchor so the decision survives the next context reset.
+
+## Outputs
+
+- A recorded re-anchor / escalate / stop decision with one line of rationale.
+- An updated mission anchor (`.nuclear/mission.md` or the `## Mission anchor` section) that survives context loss.
+- A justification row when a non-goal or standard was deliberately crossed.
+- An OPEX note when the drift was a near miss worth learning from.
+
+## Verification
+
+- The decision names which success criterion the action serves, or names the substituted goal it was serving.
+- The anchor in the written record matches the anchor the decision was tested against.
+- Crossed non-goals have a justification row, not a silent edit.
+- The attempt count and loop check were actually performed, not assumed.
+
+## Escalation
+
+- Escalate to the owner after 3 failed attempts at the same objective, on any security-sensitive or irreversible action, or on scope that cannot be verified against the anchor.
+- Report the state plainly and immediately: what the objective is, what was attempted, what is blocked, and the recommendation. Bad news travels up intact; a softened report is itself a drift.
+- Stop when the work would cross a non-goal without a defensible justification, or when no one owns the anchor.
+
+## Common Rationalizations
+
+- "While I am here, I will also fix this." Adjacent work is the most common scope drift; capture it as a separate change.
+- "This is basically what they asked for." Basically is goal substitution; check the success criteria, not the vibe.
+- "One more attempt will get it." After three failures the approach is suspect, not the next variant.
+- "We can relax this standard just this once." Once is how deviance normalizes; record it as a justified exception or do not do it.
+- "I remember the objective." Memory drifts across a long session; read the written anchor.
+- "Restating the mission counts as checking it." Re-stating without honestly testing the current action against it is drift theater.
+
+## Red Flags
+
+- The current action cannot be traced to a success criterion in the anchor.
+- Scope has grown but the anchor was never updated to justify it.
+- The same file, action, or fix variant has been retried several times.
+- A non-goal was crossed by an edit rather than by a recorded decision.
+- A standard was relaxed without a justification row.
+- Progress is measured in activity (tokens, edits) rather than in success criteria met.
+
+## Source-lineage note
+
+This skill is an original software workflow influenced by nuclear-industry mission ownership and rising-standards culture (Rickover and Navy nuclear practice as concept lineage, not an implemented program) and by the change-management, decision-making, and self-checking practices in DOE-HDBK-1028-2009 mapped in `docs/00-standards-foundation/source-map.md`. It does not create DOE compliance, formal assurance, safety, security, certification, or regulatory adequacy.

--- a/skills/packing-agent-context/SKILL.md
+++ b/skills/packing-agent-context/SKILL.md
@@ -30,7 +30,7 @@ Context packs give agents and reviewers the right focused information: role, mod
 
 ## Process
 
-1. Name the role and objective.
+1. Name the role and objective, and carry the mission anchor (objective, success criteria, non-goals) so it survives context resets. See `controlling-mission-drift`.
 2. Include only the packet files, affected files, source rows, and evidence commands needed for the next decision.
 3. State last completed action, changed conditions, critical next action, likely error, and control.
 4. State file, command, network, credential, approval, and release authority.

--- a/skills/questioning-attitude/SKILL.md
+++ b/skills/questioning-attitude/SKILL.md
@@ -39,7 +39,7 @@ Questioning attitude is the Nuclear-grade front door: challenge assumptions befo
 5. Ask what evidence would change the decision.
 6. Validate facts before relying on memory, confidence, or agent-generated claims.
 7. Name pause conditions, hold conditions, and escalation triggers.
-8. Route the next artifact: Quick proof, Standard spec, context pack, turnover, self-check, CM record, or release decision.
+8. Route the next artifact: Quick proof, Standard spec, context pack, turnover, self-check, CM record, mission anchor or drift check, or release decision.
 
 ## Outputs
 

--- a/skills/reviewing-code-quality/SKILL.md
+++ b/skills/reviewing-code-quality/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: reviewing-code-quality
+description: Use when reviewing a diff or module for standards drift: oversized files, needless abstraction, leaked feature logic, or complexity that should be deleted.
+---
+
+# Reviewing Code Quality
+
+## Overview
+
+Standards drift in code is the slow accretion of complexity: files grow past the point of comprehension, abstractions get added that do not earn their keep, feature-specific logic leaks into shared layers, and clever indirection replaces boring direct code. Each step is locally defensible; the sum is an unmaintainable system. This review holds a rising-standards line. Its strongest move is deletion: prefer removing structure over rearranging it. It ends in a single honest verdict, not a softened summary, because a review that always says "looks good" is not a control.
+
+## When to Use
+
+- A diff or module is up for review and you want a standards check, not just a correctness check.
+- A file or function has grown large, or an abstraction layer is being added.
+- Feature logic may be leaking into shared, canonical, or framework layers.
+- A refactor is proposed and you need to judge whether it removes complexity or just moves it.
+- An agent produced code quickly and the question is whether it will be maintainable.
+
+## When Not to Use
+
+- The change is a trivial, obvious edit with no structural impact.
+- The task is purely about whether the code is functionally correct (use proving-claims and verification instead).
+- A hotfix must ship for incident containment before a quality pass is reasonable.
+
+## Inputs
+
+- The diff or module under review and its surrounding files.
+- The change's mission anchor or objective, so scope can be judged.
+- Project conventions and any countable limits the team has agreed.
+- The dependency and layering map: what is shared/canonical versus feature-specific.
+
+## Process
+
+1. Read the change against its objective. Code that does not serve the stated objective is scope drift; flag it before judging style.
+2. Look first for deletion. Ask what could be removed entirely rather than reorganized. Prefer cutting structure over moving it.
+3. Apply countable tripwires as prompts, not laws: a file crossing roughly 1000 lines, a function past roughly 50 lines, deep nesting, or duplicated branches are signals to investigate, each with rationale.
+4. Test every abstraction for its keep. A wrapper, helper, or layer must remove more complexity than it adds; flag thin pass-throughs and indirection that only renames.
+5. Check layering. Feature-specific logic must not leak into shared, canonical, or framework code; flag special cases that pollute a general path.
+6. Prefer boring over clever. Flag magic, implicit coupling, and indirection where direct code would read plainly.
+7. Issue one verdict with no hedging.
+
+## Outputs
+
+- A prioritized findings list: each finding names the location, the standard at risk, and the concrete fix (often a deletion).
+- A single verdict: VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+- A short rationale tying the verdict to the findings.
+
+## Verification
+
+- Each finding points to a specific location and a specific standard, not a general impression.
+- Deletion was considered before rearrangement for each complexity finding.
+- The verdict matches the findings; an INCONCLUSIVE verdict names what evidence is missing and routes to escalation.
+
+## Escalation
+
+- Return NOT VERIFIED when a finding would degrade maintainability and the author disagrees; let the owner decide with the finding on record.
+- Return INCONCLUSIVE when the diff cannot be judged without context the review does not have; name the missing context.
+- Escalate when standards drift recurs across changes; a repeated concession is a pattern, and the fix is a control, not another one-off review.
+
+## Common Rationalizations
+
+- "It works, so the structure is fine." Working is correctness; this review is about whether the next change stays cheap.
+- "The abstraction might be useful later." Speculative abstraction is complexity now for a benefit that may never arrive.
+- "It is only a little over the limit." Limits exist because the little overages are how files become unreadable.
+- "Refactoring it would touch a lot." Moving complexity is not removing it; ask what deletes the need.
+- "The author is experienced." The review checks the code, not the author.
+
+## Red Flags
+
+- A file or function well past the agreed size with no decomposition.
+- A wrapper or helper that only forwards calls or renames a thing.
+- Feature-specific branches inside shared or canonical code.
+- Clever indirection where boring direct code would read plainly.
+- A review summary that softens every finding into "looks good" with no verdict.
+
+## Source-lineage note
+
+This skill is an original software workflow influenced by nuclear-industry rising-standards and questioning-attitude culture (Rickover and Navy nuclear practice as concept lineage, not an implemented program) and by the self-checking and verification practices in DOE-HDBK-1028-2009 mapped in `docs/00-standards-foundation/source-map.md`. It does not create DOE compliance, formal assurance, safety, security, certification, or regulatory adequacy.

--- a/skills/reviewing-ship-readiness/SKILL.md
+++ b/skills/reviewing-ship-readiness/SKILL.md
@@ -29,7 +29,7 @@ Ship readiness is a decision record, not a mood. It ties baseline, evidence stat
 ## Process
 
 1. Confirm baseline and affected artifacts.
-2. Review each evidence status and unresolved gap.
+2. Review each evidence status and unresolved gap, and check for accumulated drift: does the shipped change still serve the mission anchor, with non-goals uncrossed? See `controlling-mission-drift`.
 3. Confirm rollback or restore path.
 4. Confirm monitoring and post-release checks.
 5. State why the decision is conservative enough for remaining uncertainty.

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -7,7 +7,7 @@ description: Use when adopting Nuclear-grade for an AI-assisted change, repo wor
 
 ## Overview
 
-Use Nuclear-grade to turn AI-assisted software work into a focused evidence path: question assumptions, classify consequence inside the risk screen, create the smallest useful packet, specify intent, prove important claims, and make the release decision explicit.
+Use Nuclear-grade to turn AI-assisted software work into a focused evidence path: question assumptions, classify consequence inside the risk screen, create the smallest useful packet, specify intent, prove important claims, and make the release decision explicit. The repo charter (`.nuclear/charter.md`) states the durable principles all changes hold to; a per-change mission anchor states what a given change is for and guards against drift.
 
 ## When to Use
 

--- a/templates/standard/plan.md
+++ b/templates/standard/plan.md
@@ -19,6 +19,20 @@
 - Date:
 - Current lifecycle phase: Plan / Execute / Verify / Review / Decide
 
+## Charter and anchor check
+
+A re-evaluated gate, not a one-time note. Confirm before Plan and re-check before Verify. See `controlling-mission-drift`.
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes/no:
+- Re-checked before Verify? yes/no/not yet:
+- Charter articles in play:
+
+If a non-goal or charter article must be crossed, record the justification here:
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| | | | |
+
 ## Build sequence
 
 Number the minimum steps needed to complete the change.

--- a/templates/standard/risk.md
+++ b/templates/standard/risk.md
@@ -19,6 +19,16 @@
 - Current lifecycle phase: Question / Specify / Plan / Execute / Verify / Review / Decide / Baseline / Operate / Learn
 - Summary:
 
+## Mission anchor
+
+State what this change is for, so a long session can be tested against it. See `controlling-mission-drift`.
+
+- Objective:
+- Success criteria:
+- Non-goals / forbidden directions:
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: workspace `.nuclear/mission.md`, charter article, or originating PR/issue.
+
 ## Questioning-attitude summary
 
 - Decision question:

--- a/tests/test_command_contracts.py
+++ b/tests/test_command_contracts.py
@@ -21,6 +21,8 @@ EXPECTED_COMMANDS = {
     "ng-trust-check.md",
     "ng-source-check.md",
     "ng-legal-check.md",
+    "ng-drift-check.md",
+    "ng-code-review.md",
 }
 
 REQUIRED_SECTIONS = (

--- a/tests/test_ng_cli.py
+++ b/tests/test_ng_cli.py
@@ -99,6 +99,18 @@ def test_init_creates_nuclear_workspace(tmp_path):
     assert (tmp_path / ".nuclear" / "changes").is_dir()
 
 
+def test_init_creates_charter_and_mission_anchor(tmp_path):
+    result = run_ng("init", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    charter = tmp_path / ".nuclear" / "charter.md"
+    mission = tmp_path / ".nuclear" / "mission.md"
+    assert charter.exists()
+    assert mission.exists()
+    assert "Ownership" in charter.read_text(encoding="utf-8")
+    assert "Non-goals" in mission.read_text(encoding="utf-8")
+
+
 def test_new_quick_packet_copies_templates(tmp_path):
     scaffold_repo(tmp_path)
     result = run_ng("new", "demo", "--mode", "quick", "--repo", str(tmp_path))

--- a/tests/test_ng_validate.py
+++ b/tests/test_ng_validate.py
@@ -265,3 +265,63 @@ def test_boundary_paraphrases_all_pass(tmp_path):
         assert result.ok, (
             f"Expected pass for boundary phrase: {phrase}; got messages: {result.messages}"
         )
+
+
+FILLED_MISSION_ANCHOR = (
+    "## Mission anchor\n\n"
+    "- Objective: ship the drift control feature.\n"
+    "- Success criteria: validator and tests pass; packet validates.\n"
+    "- Non-goals: no contract rewrite; out of scope is changing the description rule.\n\n"
+)
+
+
+def _insert_before_tail(text: str, block: str) -> str:
+    marker = "## Required links"
+    idx = text.find(marker)
+    return text[:idx] + block + text[idx:]
+
+
+def test_filled_mission_anchor_passes(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+    risk = packet / "risk.md"
+    risk.write_text(_insert_before_tail(risk.read_text(encoding="utf-8"), FILLED_MISSION_ANCHOR), encoding="utf-8")
+
+    result = validate_packet(packet)
+
+    assert result.ok, result.messages
+
+
+def test_mission_anchor_missing_non_goals_fails(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+    anchor = (
+        "## Mission anchor\n\n"
+        "- Objective: ship the feature.\n"
+        "- Success criteria: tests pass.\n\n"
+    )
+    risk = packet / "risk.md"
+    risk.write_text(_insert_before_tail(risk.read_text(encoding="utf-8"), anchor), encoding="utf-8")
+
+    result = validate_packet(packet)
+
+    assert not result.ok
+    assert any("Mission anchor present but missing a non-goals" in m for m in result.messages)
+
+
+def test_mission_anchor_absent_is_not_checked(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+
+    result = validate_packet(packet)
+
+    assert result.ok, result.messages
+    assert not any("Mission anchor" in m for m in result.messages)
+
+
+def test_unresolved_clarification_marker_fails(tmp_path):
+    packet = minimal_standard_packet(tmp_path)
+    with (packet / "basis.md").open("a", encoding="utf-8") as handle:
+        handle.write("\nOpen question: [NEEDS CLARIFICATION] which API version applies.\n")
+
+    result = validate_packet(packet)
+
+    assert not result.ok
+    assert any("[NEEDS CLARIFICATION]" in m for m in result.messages)

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -23,6 +23,8 @@ EXPECTED_SKILLS = {
     "checking-dependency-and-model-trust",
     "checking-source-lineage",
     "checking-license-and-assurance-boundaries",
+    "controlling-mission-drift",
+    "reviewing-code-quality",
 }
 
 REQUIRED_SECTIONS = (


### PR DESCRIPTION
## Summary

Adds a mission-driven backbone so the repo can detect and correct **engineering drift**, modeled on nuclear-industry practice (Rickover / Navy nuclear culture) and benchmarked against eleven external skill/spec collections (notably spec-kit's "constitution" gate, Anthropic's skill-authoring guidance, ECC's mission-persistence skills, and the thermo-nuclear code-quality review).

Two tiers:
- **Charter** (`.nuclear/charter.md`): durable, repo-level, non-negotiable process-integrity principles (ownership, facing facts, rising standards, formality, technical depth, integrity in reporting, questioning attitude, evidence over persuasion, graded rigor, baseline discipline). `nuclear-grade init` now writes a starter charter and a workspace mission anchor; both advisory.
- **Mission anchor** (per change): objective + success criteria + explicit non-goals, added as a section in the Standard risk template.

Two new skills + paired commands:
- `controlling-mission-drift` (+ `ng-drift-check`): intent drift (scope creep, goal substitution); re-anchor / escalate / stop decision; counted escalation trigger (stop after 3 failed attempts or a loop).
- `reviewing-code-quality` (+ `ng-code-review`): standards drift (delete over rearrange, countable complexity tripwires, abstractions must earn their keep, no feature logic in shared layers, single verdict).

Templates + validator:
- Standard plan template gains a re-evaluated **charter-and-anchor gate** with a justification table (confirm before Plan, re-check before Verify).
- Advisory validator checks, both **only-when-present (non-breaking)**: a mission anchor must name objective, success criterion, and non-goals; unresolved NEEDS-CLARIFICATION markers fail before ship.

Retrofits + registration: light cross-references in `questioning-attitude`, `packing-agent-context`, `reviewing-ship-readiness`, `using-nuclear-grade`, `context-packs`, and `WORKFLOWS`; both skills and commands registered across `SKILLS.md`, `COMMANDS.md`, `nuclear-grade.yaml`, `skill-evaluation.md`, and the comparison-study coverage table (with an honesty note that newer skills are mapped retroactively, not re-run as trials).

### Deliberate non-goals (separate follow-on PRs)

Applying the discipline the feature is about, these are explicitly out of scope: changing the 90–180 char skill description rule, progressive-disclosure validator support (`references/`/`scripts/`/`assets/`, `license` frontmatter), an evidence-coverage validator rule, and making the charter/anchor a hard required gate.

## Base branch

Stacked on `claude/intelligent-knuth-QA4L5` (PR #3), because the dogfood packet declares `Mode: Standard` and exercises the only-when-present validator pattern, both of which live on that branch. Retarget to `main` after #3 merges.

## Test plan

- [x] `python -m pytest -q` green (84 tests; 11 new).
- [x] `ruff check .` clean.
- [x] `python tools/ng.py doctor .` OK.
- [x] `python tools/ng.py validate` OK on every packet, including the new `.nuclear/changes/mission-driven-backbone/`.
- [x] `nuclear-grade init` writes `.nuclear/charter.md` and `.nuclear/mission.md`.
- [x] Built wheel bundles both new skills and both new commands under `nuclear_grade/_bundled/`.
- [ ] CI green on the matrix and wheel-smoke jobs (inherited from the base branch).

## Dogfood packet

`.nuclear/changes/mission-driven-backbone/` (Standard). Declares a filled `## Mission anchor` that exercises the new advisory check, and validates clean.

https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG)_