### PR TITLE
Modernize skill description contract for higher triggering accuracy (0.3.0)

### DIFF
--- a/.nuclear/changes/skill-contract-modernization/basis.md
+++ b/.nuclear/changes/skill-contract-modernization/basis.md
@@ -1,0 +1,53 @@
+# Basis
+
+## Change context
+
+- Slug: skill-contract-modernization
+- Scope: Skill-authoring contract relaxation plus rewrite of all 18 descriptions, name-format rule, optional frontmatter, progressive-disclosure docs, version sync.
+- Outcome to protect: Skills trigger reliably without breaking existing skills or downstream authors.
+
+## Need and scope
+
+The prior contract forced descriptions to start with `Use when` and capped them at 90-180 characters. Anthropic skill-authoring guidance is the opposite: descriptions should be richer (what the skill does, when to trigger it, and an explicit "Do not use for ..." near-miss) to reduce under-triggering. The repo's own rule was likely wrong. This change relaxes the rule, rewrites all descriptions, and adds supporting affordances, all non-breaking.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Evidence planned |
+|---|---|---|
+| C-001 | The contract test no longer mandates a `Use when` prefix or a 90-180 cap; it requires 80-500 characters, a negative clause, and no colon-space. | `tests/test_skill_contracts.py`; suite green. |
+| C-002 | All 18 skill descriptions are rewritten to the what-plus-when-plus-negative form, within band and colon-free. | Per-file frontmatter; the contract test iterates all skills. |
+| C-003 | `name` must be lowercase, hyphen-separated, start with a letter, with no consecutive or trailing dashes, and no length cap (existing names exceed 32 characters). | `SKILL_NAME_PATTERN` check; all 18 pass. |
+| C-004 | `license` and `compatibility` are optional supported frontmatter fields. | `ALLOWED_FRONTMATTER_KEYS`; test passes with current files. |
+| C-005 | Progressive disclosure (optional `references/`, `scripts/`, `assets/`) is documented in the authoring contract and SKILLS.md. | Diffs of those files. |
+| C-006 | Version is synced to 0.3.0 across `pyproject.toml`, `nuclear-grade.yaml`, and `CITATION.cff`, and `test_packaging.py` asserts 0.3.0. | Diffs; `tests/test_packaging.py`. |
+| C-007 | The change is non-breaking: it loosens the repo's own contract test and does not constrain externally authored skills. | Reasoning recorded; no required field added. |
+
+## Assumptions, constraints, and invalidation triggers
+
+- Assumption: relaxing the contract cannot break downstream authors because it only loosens our own test. Invalidation trigger: a real YAML loader rejects a rewritten description (mitigated by the colon-space ban).
+- Constraint: no skill renames (a 32-char name cap would force them; the rule omits a length cap).
+- Constraint: description enforcement stays in the contract test, not the CLI doctor, because the doctor's stub fixtures use short descriptions.
+
+## Acceptance scenarios
+
+- An author writes a skill whose description says what it does, when to use it, and what not to use it for, in 80-500 characters with no colon-space; the contract test passes.
+- A strict YAML loader in an agent harness parses every shipped description as a single scalar (no colon-space).
+- A reviewer reads SKILLS.md and the authoring contract and sees the new rule and the progressive-disclosure layout.
+
+## Required links
+
+- Packet: `.nuclear/changes/skill-contract-modernization/`
+- `risk.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Claims C-001 through C-007 are mapped to plan steps and have evidence rows.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by public skill-authoring practice and the concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/skill-contract-modernization/plan.md
+++ b/.nuclear/changes/skill-contract-modernization/plan.md
@@ -1,0 +1,81 @@
+# Plan
+
+## Change context
+
+- Slug: skill-contract-modernization
+- Mode: Standard
+- Owner: maintainer
+
+## Charter and anchor check
+
+A re-evaluated gate, not a one-time note. Confirm before Plan and re-check before Verify. See `controlling-mission-drift`.
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes.
+- Re-checked before Verify? yes; scope held to the contract change, deferred items stayed deferred.
+- Charter articles in play: Rising standards, Evidence over persuasion, Formality, Questioning attitude.
+
+If a non-goal or charter article must be crossed, record the justification here:
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | not applicable | not applicable | proceed |
+
+## Build sequence
+
+1. Rewrite all 18 skill descriptions to the what-plus-when-plus-negative form, colon-free, within band.
+2. Update `tests/test_skill_contracts.py` to the new rule (length band, negative clause, no colon-space, name regex, optional license/compatibility).
+3. Update the published contract: `docs/05-reference/skill-authoring-contract.md` and `SKILLS.md`, including progressive disclosure.
+4. Sync version to 0.3.0 across `pyproject.toml`, `nuclear-grade.yaml`, `CITATION.cff`; update `test_packaging.py`.
+5. Add the 0.3.0 CHANGELOG section.
+6. Fill this dogfood packet; run tests, ruff, doctor, validate.
+
+## Non-goals
+
+- The evidence-coverage validator rule.
+- Making the charter or anchor a hard required gate.
+- The cross-cutting hedge-word red-flag sweep.
+- Adding description enforcement to the CLI doctor.
+- Renaming any skill.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Descriptions rewritten | All within band and colon-free | pass |
+| Contract test updated | New rule enforced; suite green | pass |
+| Docs updated | Authoring contract and SKILLS.md reflect the rule | pass |
+| Version synced | 0.3.0 everywhere; packaging test green | pass |
+| Packet validates | This packet passes the validator | pass |
+
+## Rollback approach
+
+- Rollback method: revert the branch; descriptions and test revert cleanly.
+- State/data reversal notes: none.
+- Feature flag / kill switch: not applicable.
+- Owner: maintainer.
+- Time to restore estimate: minutes.
+
+## Proof commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py validate .nuclear/changes/skill-contract-modernization
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Build sequence executed; tests green; packet validates.
+
+## Source-lineage note
+
+Original Nuclear-grade plan influenced by configuration-management concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/skill-contract-modernization/risk.md
+++ b/.nuclear/changes/skill-contract-modernization/risk.md
@@ -1,0 +1,106 @@
+# Risk
+
+## Change identity
+
+- Slug: skill-contract-modernization
+- PR / issue: (TBD on push)
+- Owner: maintainer
+- Date: 2026-05-28
+- Current lifecycle phase: Execute
+- Summary: Modernize the skill-authoring contract for higher triggering accuracy. Drop the mandatory `Use when` prefix and the 90-180 character cap; require descriptions that state what the skill does, when to trigger, and a negative clause, within 80-500 characters and YAML-safe. Rewrite all 18 skill descriptions. Allow optional `license`/`compatibility` frontmatter, add a name-format rule, document progressive disclosure, and sync the version to 0.3.0.
+
+## Mission anchor
+
+State what this change is for, so a long session can be tested against it. See `controlling-mission-drift`.
+
+- Objective: Make skill descriptions trigger reliably, aligned with Anthropic skill-authoring guidance, without breaking existing skills or downstream authors.
+- Success criteria: All 18 descriptions rewritten to what-plus-when-plus-negative form, 80-500 chars, colon-free; the contract test enforces the new rule; name-format and optional-license fields supported; progressive disclosure documented; version synced to 0.3.0; tests, ruff, doctor, and this packet all green.
+- Non-goals / forbidden directions: Out of scope is the evidence-coverage validator rule, making the charter or anchor a hard gate, the cross-cutting hedge-word red-flag sweep, CM delta vocabulary, and adding description enforcement to the CLI doctor (which would false-fail stub fixtures). Forbidden is renaming any skill (a 32-char cap would force that).
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: the deferred-backlog discussion and `.nuclear/charter.md` (rising standards, evidence over persuasion).
+
+## Questioning-attitude summary
+
+- Decision question: Is the old 90-180 char `Use when` rule actually wrong, and how do we fix it without breaking existing skills?
+- Assumptions that changed the mode: Anthropic guidance says descriptions should be longer and richer (what + when + do-not). The change touches the contract enforced across all 18 skills, so it is a Standard change.
+- Facts still needing validation: That the relaxation breaks no downstream authors (confirmed: it loosens our own test; it does not constrain external skills) and that all rewrites stay YAML-safe (confirmed: colon-free, plain scalars).
+- Stop or hold conditions: Stop if a name-length cap or a CLI-doctor enforcement change would force skill renames or break stub fixtures; both were ruled out.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `skills/*/SKILL.md` (18) | Skills | Description frontmatter rewritten | `../../../skills` |
+| `tests/test_skill_contracts.py` | Test | The contract source of truth | `../../../tests/test_skill_contracts.py` |
+| `docs/05-reference/skill-authoring-contract.md` | Docs | The published contract | `../../../docs/05-reference/skill-authoring-contract.md` |
+| `SKILLS.md` | Docs | Contract summary | `../../../SKILLS.md` |
+| `pyproject.toml`, `nuclear-grade.yaml`, `CITATION.cff` | Config | Version sync to 0.3.0 | `../../../pyproject.toml` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Changes a public authoring contract and all skill descriptions. |
+| Reversibility | high | Revert the branch; descriptions and test revert cleanly. |
+| Detectability | high | Contract test and doctor catch regressions. |
+| Exposure | medium | Public repo; skill descriptions are agent-facing surface. |
+| Uncertainty | low | Relaxation is well understood and non-breaking. |
+| Dependency trust | low | No new dependencies. |
+| AI authority | low | No new agent write permissions. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine/repetitive action where inattention is plausible | yes | 18 near-identical edits; a script applied them uniformly and verified length and colon-safety |
+| Known procedure where workflow adherence matters | yes | packet path and the plan build sequence |
+| Novel or uncertain work where assumptions may be wrong | no | the rule change is well understood |
+| Interrupted, resumed, or handed-off work | no | n/a |
+| High-consequence critical action | no | n/a |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** Changes a public authoring contract enforced across all skills, with a version bump.
+- **Why lighter mode is not enough:** Quick cannot record the claim-to-evidence mapping for an interface change.
+- **Why heavier mode is not yet required:** Non-breaking; no regulated use, safety basis, or controlled-supplier dedication.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline above. | maintainer |
+| `basis.md` | yes | Claim-to-evidence mapping. | maintainer |
+| `verification.md` | yes | Per-claim evidence status. | maintainer |
+| `ship.md` | yes | Release decision for 0.3.0. | maintainer |
+| `turnover.md` | no | Single-author packet. | maintainer |
+| `self-check.md` | no | No high-consequence critical action. | maintainer |
+| `supplier-trust.md` | no | No new external supplier. | maintainer |
+| Nuclear subset record | no | Not warranted. | maintainer |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: Confirm the relaxation loosens, not tightens, the contract (non-breaking for downstream).
+- Minimum evidence before merge/release: pytest green; ruff clean; doctor OK; this packet validates; all 18 descriptions within band and colon-free.
+- Independent review needed? no for this PR.
+
+## Required links
+
+- Packet: `.nuclear/changes/skill-contract-modernization/`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Mode is justified as Standard.
+- The mission anchor names objective, success criteria, and non-goals.
+- Claims map to evidence in `verification.md`.
+- No hidden trigger for a stronger mode.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by public skill-authoring practice and the human-performance and configuration-management concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/skill-contract-modernization/ship.md
+++ b/.nuclear/changes/skill-contract-modernization/ship.md
@@ -1,0 +1,53 @@
+# Ship
+
+## Release decision
+
+- **Decision:** ship as 0.3.0 once CI is green.
+- **Rationale:** The change modernizes a public authoring contract and is non-breaking (it loosens the repo's own test and adds no required field). A minor bump is honest because the authoring contract is a documented interface.
+- **Pre-merge gates:**
+  - `python -m pytest -q` green
+  - `ruff check .` clean
+  - `python tools/ng.py doctor .` OK
+  - `python tools/ng.py validate` OK on every packet including this one
+  - CI green on the matrix and wheel-smoke jobs
+
+## Evidence status summary
+
+| Area | Status | Link |
+|---|---|---|
+| Verification | pass | `verification.md` |
+| Trace | pass | `trace.md` |
+| Contract test | pass | `tests/test_skill_contracts.py` |
+| Version sync | pass | `pyproject.toml`, `nuclear-grade.yaml`, `CITATION.cff` |
+| Packet self-validation | pass | `python tools/ng.py validate .nuclear/changes/skill-contract-modernization` |
+
+## Rollback / restore plan
+
+- Revert the branch; descriptions, test, docs, and version revert cleanly. No data migration.
+- If a rewritten description is found to under-trigger in practice, edit that single description; the contract permits it without further change.
+
+## Monitoring and post-release checks
+
+- Watch for any agent harness that fails to parse a description; the colon-space ban should prevent it.
+- Watch triggering behavior of the rewritten descriptions; refine individual ones if they over- or under-trigger.
+- Revisit the deferred trigger-eval automation once there is signal on real triggering accuracy.
+
+## Maintainer follow-ups
+
+- Consider the next deferred bundle: progressive-disclosure engine support (recognizing `references/` in tooling) and the evidence-coverage validator rule.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+
+## Exit criteria
+
+- Decision recorded; rollback named; monitoring named.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record influenced by release-readiness concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/skill-contract-modernization/trace.md
+++ b/.nuclear/changes/skill-contract-modernization/trace.md
@@ -1,0 +1,29 @@
+# Trace
+
+## Trace summary
+
+| Claim ID | Artifact | Status |
+|---|---|---|
+| C-001 | `tests/test_skill_contracts.py` updated assertions | pass |
+| C-002 | all 18 `skills/*/SKILL.md` descriptions | pass |
+| C-003 | `SKILL_NAME_PATTERN` in `tests/test_skill_contracts.py` | pass |
+| C-004 | `ALLOWED_FRONTMATTER_KEYS` in `tests/test_skill_contracts.py` | pass |
+| C-005 | `docs/05-reference/skill-authoring-contract.md`; `SKILLS.md` | pass |
+| C-006 | `pyproject.toml`; `nuclear-grade.yaml`; `CITATION.cff`; `tests/test_packaging.py` | pass |
+| C-007 | reasoning in `basis.md` and `verification.md` (loosens own test only) | pass |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim maps to a named artifact and a status.
+
+## Source-lineage note
+
+Original Nuclear-grade trace influenced by traceability concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/skill-contract-modernization/verification.md
+++ b/.nuclear/changes/skill-contract-modernization/verification.md
@@ -1,0 +1,48 @@
+# Verification
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+
+## Claim-to-evidence table
+
+| Claim | Result status | Evidence link | Notes |
+|---|---|---|---|
+| C-001 contract test relaxed | pass | `../../../tests/test_skill_contracts.py` | Drops the `Use when` prefix and 90-180 cap; enforces 80-500 chars, a negative-clause marker, no colon-space. |
+| C-002 all 18 descriptions rewritten | pass | `../../../skills` | A script applied the rewrites and verified each is colon-free and within 80-500 characters; the contract test iterates every skill. |
+| C-003 name-format rule | pass | `../../../tests/test_skill_contracts.py` | Lowercase, hyphen-separated, no length cap; all 18 names pass, including the 41-character `checking-license-and-assurance-boundaries`. |
+| C-004 optional license/compatibility | pass | `../../../tests/test_skill_contracts.py` | Frontmatter key set is a subset of name, description, license, compatibility. |
+| C-005 progressive disclosure documented | pass | `../../../docs/05-reference/skill-authoring-contract.md`; `../../../SKILLS.md` | Optional `references/`, `scripts/`, `assets/` layout described; wheels bundle whole skill dirs. |
+| C-006 version synced to 0.3.0 | pass | `../../../pyproject.toml`; `../../../nuclear-grade.yaml`; `../../../CITATION.cff` | `test_packaging.py` asserts 0.3.0; the stale 0.1.0 in the catalog is fixed. |
+| C-007 non-breaking | pass | reasoning | The change only loosens the repo's own contract test and adds no required field, so externally authored skills cannot newly fail. |
+
+## Reproduction commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py validate .nuclear/changes/skill-contract-modernization
+```
+
+## Known gaps and deferrals
+
+- Description enforcement remains in the contract test, not the CLI doctor. Recorded as `deferred`: adding it to doctor would false-fail the doctor stub fixtures and offers low value given the generous bounds.
+- Trigger-eval automation (selecting descriptions by held-out triggering score) is `deferred`; the should/should-not prompts in `skill-evaluation.md` remain the manual proxy.
+- CI has not run at packet-authoring time; it is the public evidence for the matrix and wheel jobs.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim has a recorded status.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record influenced by graded-rigor evidence concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses changelog entries to record public-facing changes, not to impl
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-28
+
+### Changed
+
+- Skill description contract modernized for higher triggering accuracy. Dropped the mandatory `Use when` prefix and the 90-180 character cap; descriptions now state what the skill does, when to trigger it, and an explicit negative clause ("Do not use for ..."), within an 80-500 character band, with no colon-space (so strict YAML loaders read them as one scalar). All 18 skill descriptions rewritten to this form. `name` must be lowercase and hyphen-separated (no length cap, since existing names exceed 32 characters). `license` and `compatibility` are now optional supported frontmatter fields. Documented progressive disclosure (optional `references/`, `scripts/`, `assets/` beside `SKILL.md`).
+- Synced `nuclear-grade.yaml` version with `pyproject.toml` and bumped both to 0.3.0.
+
 ### Added
 
 - Mission-driven backbone. A durable repo charter (`.nuclear/charter.md`) of named process-integrity principles (ownership, facing facts, rising standards, formality, technical depth, integrity in reporting, questioning attitude, evidence over persuasion, graded rigor, baseline discipline; nuclear-culture and Rickover/Navy lineage), plus a per-change `## Mission anchor` (objective + success criteria + non-goals) in the Standard risk template. `nuclear-grade init` now writes a starter `.nuclear/charter.md` and `.nuclear/mission.md` (both advisory).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 type: software
 license: MIT
 repository-code: "https://github.com/FlyFission/nuclear-grade-context-engineering"
-version: "0.2.0"
-date-released: "2026-05-27"
+version: "0.3.0"
+date-released: "2026-05-28"
 keywords:
   - configuration-management
   - software-assurance

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -29,11 +29,12 @@ Skills are self-contained agent instructions. Each skill has a `SKILL.md` contra
 
 Every skill must include:
 
-- YAML frontmatter with `name` and `description`.
-- A description that starts with `Use when`.
+- YAML frontmatter with `name` and `description` (required); `license` and `compatibility` are optional.
+- A `name` that is lowercase and hyphen-separated.
+- A `description` that says what the skill does, when to trigger it, and a "Do not use for ..." negative clause (80 to 500 characters, no colon-space).
 - Overview, use and non-use conditions, inputs, process, outputs, verification, escalation, common rationalizations, red flags, and source-lineage note.
 
-See `docs/05-reference/skill-authoring-contract.md`.
+Skills may add optional `references/`, `scripts/`, and `assets/` subfolders for progressive disclosure. See `docs/05-reference/skill-authoring-contract.md`.
 
 ## Boundary note
 

--- a/docs/05-reference/skill-authoring-contract.md
+++ b/docs/05-reference/skill-authoring-contract.md
@@ -12,8 +12,9 @@ skills/<skill-name>/SKILL.md
 
 The file must include:
 
-- YAML frontmatter with `name` and `description`.
-- `description` starts with `Use when`.
+- YAML frontmatter with `name` and `description` (required). `license` and `compatibility` are optional supported fields.
+- A `name` that is lowercase, hyphen-separated, starts with a letter, and has no consecutive or trailing dashes.
+- A `description` that states what the skill does, when to trigger it, and an explicit negative clause (a "Do not use for ..." near-miss). Aim for one or two rich sentences, 80 to 500 characters. Avoid a colon followed by a space so strict YAML loaders read it as a single scalar.
 - `## Overview`
 - `## When to Use`
 - `## When Not to Use`
@@ -26,10 +27,25 @@ The file must include:
 - `## Red Flags`
 - `## Source-lineage note`
 
+## Progressive disclosure
+
+Keep `SKILL.md` under 500 lines. When detail grows, offload it to optional sibling files the agent can load on demand:
+
+```text
+skills/<skill-name>/
+  SKILL.md
+  references/   long reference material, one topic per file
+  scripts/      runnable helpers the skill can call
+  assets/       templates or fixtures the skill emits
+```
+
+The metadata (frontmatter) is always loaded, the `SKILL.md` body loads on trigger, and `references/`, `scripts/`, and `assets/` load only when the skill needs them. Packaged wheels bundle the whole skill directory, so these subfolders travel with the skill.
+
 ## Writing rules
 
 - One skill, one job.
-- Make trigger descriptions concrete enough to catch realistic use cases.
+- Write the description for triggering: lead with what it does, name concrete trigger conditions, and add a negative clause so the skill does not over-trigger.
+- Explain the why; prefer rationale over ALL-CAPS MUST or NEVER.
 - Put process in the body, not in frontmatter.
 - Name exact artifacts or decisions the skill produces.
 - Include stop conditions and escalation triggers.

--- a/nuclear-grade.yaml
+++ b/nuclear-grade.yaml
@@ -1,5 +1,5 @@
 name: nuclear-grade
-version: 0.1.0
+version: 0.3.0
 description: Configuration-management workflow surface for AI-assisted software changes.
 validator_modes:
   - quick

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuclear-grade"
-version = "0.2.0"
+version = "0.3.0"
 description = "Configuration management for AI-assisted software work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/baselining-configuration/SKILL.md
+++ b/skills/baselining-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: baselining-configuration
-description: Use when recording accepted controlled state after review, merge, release, prompt/model/tool changes, dependency updates, or public-doc changes.
+description: Records the accepted controlled state of items and the evidence behind it, and names what would make the baseline stale. Use when a Standard packet ships, when prompts, models, tools, dependencies, docs, or release artifacts are accepted, or when OPEX requires re-baselining. Do not use for a Quick local edit with no release or trust-bearing state, or while work is still under review.
 ---
 
 # Baselining Configuration

--- a/skills/checking-dependency-and-model-trust/SKILL.md
+++ b/skills/checking-dependency-and-model-trust/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checking-dependency-and-model-trust
-description: Use when dependencies, models, APIs, SaaS tools, generated artifacts, or vendor claims affect evidence, permissions, data, release posture, or public trust.
+description: Screens dependencies, models, APIs, SaaS tools, generated artifacts, and vendor claims for intended use, local evidence, gaps, and release impact. Use when any of these affect evidence, permissions, data, release posture, or public trust. Do not use for a purely internal refactor with no external dependency, or for a functional-correctness question.
 ---
 
 # Checking Dependency And Model Trust

--- a/skills/checking-license-and-assurance-boundaries/SKILL.md
+++ b/skills/checking-license-and-assurance-boundaries/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checking-license-and-assurance-boundaries
-description: Use when reviewing public text for license, warranty, compliance, assurance, safety, security, certification, or adequacy overclaims.
+description: Reviews public text for license, warranty, compliance, assurance, safety, security, certification, and adequacy overclaims and rewrites them to safe boundaries. Use when shipping or editing public docs, READMEs, or adoption copy. Do not use for internal code comments, or for deciding actual legal adequacy, which needs qualified counsel.
 ---
 
 # Checking License and Assurance Boundaries

--- a/skills/checking-source-lineage/SKILL.md
+++ b/skills/checking-source-lineage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checking-source-lineage
-description: Use when public docs, templates, skills, packets, or adoption copy cite source families, agencies, standards, or borrowed concepts.
+description: Checks that citations of source families, agencies, standards, or borrowed concepts are source-safe and non-overclaiming. Use when public docs, templates, skills, packets, or adoption copy reference outside sources. Do not use for private notes, or for verifying the functional correctness of code.
 ---
 
 # Checking Source Lineage

--- a/skills/classifying-change-risk/SKILL.md
+++ b/skills/classifying-change-risk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: classifying-change-risk
-description: Use when selecting Quick, Standard, or stronger human-reviewed mode for code, docs, dependency, AI-authority, release, or public-claim changes.
+description: Selects Quick, Standard, or a stronger human-reviewed mode from consequence, reversibility, and uncertainty. Use when starting a change to code, docs, dependencies, AI authority, releases, or public claims and the right rigor level is unclear. Do not use for a trivial reversible edit with obvious proof, which is Quick by default.
 ---
 
 # Classifying Change Risk

--- a/skills/controlling-mission-drift/SKILL.md
+++ b/skills/controlling-mission-drift/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: controlling-mission-drift
-description: Use when an agent keeps completing tasks but the work drifts from the stated objective, scope creeps, or rigor erodes one concession at a time.
+description: Tests current work against a durable mission anchor and forces a re-anchor, escalate, or stop decision. Use when an agent keeps completing tasks but the work drifts from the objective, scope creeps, the same action is retried in a loop, or rigor erodes one concession at a time. Do not use for a tiny edit with an obvious objective, or during incident containment.
 ---
 
 # Controlling Mission Drift

--- a/skills/creating-change-packets/SKILL.md
+++ b/skills/creating-change-packets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-change-packets
-description: Use when creating or updating Quick or Standard packets, adding required files, refreshing evidence obligations, or preparing an evidence-backed PR.
+description: Creates or updates Quick or Standard packets, adds the required files, and refreshes evidence obligations for an evidence-backed PR. Use when starting or revising a change record. Do not use for a one-off throwaway script, or for work that belongs in an existing packet rather than a new one.
 ---
 
 # Creating Change Packets

--- a/skills/identifying-controlled-items/SKILL.md
+++ b/skills/identifying-controlled-items/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identifying-controlled-items
-description: Use when deciding which code, prompts, models, tools, dependencies, docs, tests, evals, releases, or claims need controlled-state tracking.
+description: Decides which code, prompts, models, tools, dependencies, docs, tests, evals, releases, or claims need controlled-state tracking. Use when scoping what a change puts at risk or what must stay reviewable. Do not use for ephemeral scratch work with no downstream dependents.
 ---
 
 # Identifying Controlled Items

--- a/skills/learning-from-opex/SKILL.md
+++ b/skills/learning-from-opex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learning-from-opex
-description: Use when incidents, near misses, bad handoffs, review surprises, escaped defects, user feedback, or operating signals should update durable controls.
+description: Turns incidents, near misses, bad handoffs, review surprises, escaped defects, and operating signals into durable control updates. Use after something went wrong or nearly did and a future safeguard should change. Do not use during active incident containment, which comes first, or to assign blame.
 ---
 
 # Learning From OPEX

--- a/skills/packing-agent-context/SKILL.md
+++ b/skills/packing-agent-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: packing-agent-context
-description: Use when preparing focused context for an AI agent, human reviewer, verifier, or releaser with explicit authority, evidence, and stop conditions.
+description: Prepares focused context for an AI agent, reviewer, verifier, or releaser with explicit role, mission anchor, authority, evidence obligations, forbidden actions, and stop conditions. Use when delegating or resuming consequential work. Do not use for a trivial self-contained task that needs no handoff.
 ---
 
 # Packing Agent Context

--- a/skills/proving-claims/SKILL.md
+++ b/skills/proving-claims/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: proving-claims
-description: Use when mapping claims to evidence, statuses, gaps, tests, evals, reviews, traces, release posture, or narrowed non-claims.
+description: Maps claims to evidence, statuses, gaps, tests, evals, reviews, and traces, and narrows anything unsupported into an explicit non-claim. Use when a packet asserts something a reviewer must trust. Do not use to invent evidence that does not exist, or to treat green CI as proof of unrelated claims.
 ---
 
 # Proving Claims

--- a/skills/questioning-attitude/SKILL.md
+++ b/skills/questioning-attitude/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: questioning-attitude
-description: Use when a request, plan, diff, dependency, agent action, public claim, or release decision needs skeptical fact-finding before work continues.
+description: Challenges assumptions with skeptical fact-finding before an agent builds, merges, or releases, surfacing what would change the decision. Use when a request, plan, diff, dependency, agent action, public claim, or release decision is vague, consequential, or easy to rationalize. Do not use for a tiny Quick edit with obvious proof, or when the user wants formal assurance.
 ---
 
 # Questioning Attitude

--- a/skills/reviewing-code-quality/SKILL.md
+++ b/skills/reviewing-code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-code-quality
-description: Use when reviewing a diff or module for standards drift: oversized files, needless abstraction, leaked feature logic, or complexity that should be deleted.
+description: Reviews a diff or module for standards drift, preferring deletion over rearrangement and ending in one honest verdict. Use when a change risks oversized files, needless abstraction, feature logic leaking into shared layers, or clever indirection. Do not use for a trivial obvious edit, or for a purely functional-correctness check.
 ---
 
 # Reviewing Code Quality

--- a/skills/reviewing-ship-readiness/SKILL.md
+++ b/skills/reviewing-ship-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-ship-readiness
-description: Use when deciding ship, block, defer, or ship-with-risk for packets, PRs, releases, dependency changes, or agent-authority changes.
+description: Records a ship, block, defer, or ship-with-risk decision that ties baseline, evidence status, residual risk, rollback, monitoring, and handoff together. Use when a packet, PR, release, dependency change, or agent-authority change approaches merge. Do not use early in development before evidence exists.
 ---
 
 # Reviewing Ship Readiness

--- a/skills/screening-change-impact/SKILL.md
+++ b/skills/screening-change-impact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: screening-change-impact
-description: Use when a controlled change may stale docs, tests, skills, commands, templates, validators, prompts, releases, baselines, or evidence.
+description: Screens what a controlled change may stale across docs, tests, skills, commands, templates, validators, prompts, releases, baselines, and evidence, and names revalidation triggers. Use when a change touches controlled configuration. Do not use for an isolated edit with no downstream dependents.
 ---
 
 # Screening Change Impact

--- a/skills/self-checking-agent-actions/SKILL.md
+++ b/skills/self-checking-agent-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-checking-agent-actions
-description: Use when an agent is about to take a critical edit, command, tool, credential, public-claim, migration, dependency, model, API, or release action.
+description: Checks a critical agent action against its exact target, expected result, and stop condition before and after execution. Use when an agent is about to make a critical edit, run a command or migration, use a credential or tool, change a dependency or model, make a public claim, or affect a release. Do not use for low-stakes reversible edits.
 ---
 
 # Self-Checking Agent Actions

--- a/skills/turning-over-agent-work/SKILL.md
+++ b/skills/turning-over-agent-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: turning-over-agent-work
-description: Use when handing off AI-agent, reviewer, verifier, releaser, or resumed-thread work with unfinished scope, changed conditions, authority limits, or open evidence.
+description: Hands off unfinished work with a closed-loop briefing of state, changed conditions, remaining scope, authority limits, and open evidence. Use when AI-agent, reviewer, verifier, releaser, or resumed-thread work transfers to a new owner. Do not use when the same owner continues uninterrupted with full context.
 ---
 
 # Turning Over Agent Work

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-nuclear-grade
-description: Use when adopting Nuclear-grade for an AI-assisted change, repo workflow, packet path, evidence plan, mode choice, or release decision.
+description: Turns an AI-assisted change into a focused evidence path by choosing a mode, packet, and evidence plan, and points to the charter and mission anchor. Use when adopting Nuclear-grade for a change, repo workflow, or release decision. Do not use for a throwaway experiment with no review value.
 ---
 
 # Using Nuclear-grade

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -39,4 +39,4 @@ def test_wheel_packages_only_namespaced_package():
 def test_version_is_stamped():
     config = _config()
 
-    assert config["project"]["version"] == "0.2.0"
+    assert config["project"]["version"] == "0.3.0"

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -5,6 +6,13 @@ SKILLS_DIR = ROOT / "skills"
 SKILLS_INDEX = ROOT / "SKILLS.md"
 CATALOG = ROOT / "nuclear-grade.yaml"
 SKILL_EVALUATION = ROOT / "docs" / "05-reference" / "skill-evaluation.md"
+
+# Frontmatter contract: name + description are required; license and compatibility
+# are optional supported fields (Anthropic skill-creator convention).
+ALLOWED_FRONTMATTER_KEYS = {"name", "description", "license", "compatibility"}
+# Name format: lowercase, hyphen-separated, starts with a letter, no consecutive
+# or trailing dashes. No length cap (existing names exceed 32 chars).
+SKILL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 
 EXPECTED_SKILLS = {
     "questioning-attitude",
@@ -64,13 +72,21 @@ def test_every_skill_has_valid_agent_operable_contract():
         text = skill_file.read_text(encoding="utf-8")
         frontmatter = read_frontmatter(text)
 
-        assert set(frontmatter) == {"name", "description"}
+        assert {"name", "description"} <= set(frontmatter) <= ALLOWED_FRONTMATTER_KEYS
         assert frontmatter["name"] == skill_name
-        assert frontmatter["description"].startswith("Use when")
-        assert len(frontmatter["description"]) >= 90
-        assert len(frontmatter["description"]) <= 180
-        assert " then " not in frontmatter["description"].lower()
-        assert " step " not in frontmatter["description"].lower()
+        assert SKILL_NAME_PATTERN.match(skill_name), f"{skill_name} is not a valid skill name"
+
+        description = frontmatter["description"]
+        lowered = description.lower()
+        # Rich, high-triggering descriptions: what it does, when to trigger, and an
+        # explicit negative clause. No fixed-prefix mandate; generous length band.
+        assert 80 <= len(description) <= 500, f"{skill_name} description length {len(description)}"
+        # An explicit negative clause sharpens triggering and curbs over-triggering.
+        assert any(
+            marker in lowered for marker in ("do not use", "not for", "skip when", "avoid when")
+        ), f"{skill_name} description must include a negative clause (e.g. 'Do not use for ...')"
+        # Single-line YAML scalar safety: no colon-space, which strict loaders misparse.
+        assert ": " not in description, f"{skill_name} description must not contain a colon-space"
         assert len(text.splitlines()) <= 500
 
         for section in REQUIRED_SECTIONS:


### PR DESCRIPTION
## Summary

Modernizes the skill description contract for higher triggering accuracy, the first of the deferred follow-ups. The old rule forced descriptions to start with `Use when` and capped them at 90–180 characters; Anthropic's skill-authoring guidance is the opposite — richer descriptions that state **what the skill does, when to trigger it, and an explicit "Do not use for …" near-miss** trigger far more reliably. The old rule was wrong, so this fixes it.

### Contract changes (in `tests/test_skill_contracts.py`, the source of truth)
- Drop the mandatory `Use when` prefix and the 90–180 char cap.
- Require **80–500 characters, an explicit negative clause, and no colon-space** (so strict YAML loaders in agent harnesses read the description as a single scalar — the previously shipped `reviewing-code-quality` description contained a colon-space and could misparse).
- `name` must be lowercase, hyphen-separated, start with a letter, no consecutive/trailing dashes. **No length cap** — `checking-license-and-assurance-boundaries` is 41 chars and a cap would force breaking renames.
- `license` and `compatibility` are now optional supported frontmatter fields.

### Content
- **Rewrote all 18 skill descriptions** to the what + when + negative form; verified colon-free, within band, and parseable under a strict YAML loader.
- Documented the new rule and **progressive disclosure** (optional `references/`, `scripts/`, `assets/` beside `SKILL.md`) in `docs/05-reference/skill-authoring-contract.md` and `SKILLS.md`.

### Versioning
- Synced the stale `nuclear-grade.yaml` version (`0.1.0`) with `pyproject.toml` and bumped both + `CITATION.cff` to **0.3.0**; `test_packaging` asserts it.

### Non-breaking
The change only **loosens** the repo's own contract test and adds no required field, so externally authored skills cannot newly fail.

### Deliberately out of scope (next follow-ons)
Adding description enforcement to the CLI `doctor` (would false-fail stub fixtures), the evidence-coverage validator rule, trigger-eval automation, and the cross-cutting hedge-word red-flag sweep.

## Test plan

- [x] `python -m pytest -q` green.
- [x] `ruff check .` clean.
- [x] `python tools/ng.py doctor .` OK.
- [x] `python tools/ng.py validate` OK on all 10 packets, including the new `.nuclear/changes/skill-contract-modernization/`.
- [x] All 18 skill frontmatters parse cleanly under a strict YAML loader.
- [ ] CI green on the matrix and wheel-smoke jobs.

## Dogfood packet

`.nuclear/changes/skill-contract-modernization/` (Standard), with a filled mission anchor; validates clean.

https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMSAQoAX9t8Kisxw9gGUMG)_