### PR TITLE
Reproducible efficacy harness (ng eval), status health tags, and workflow visuals

### DIFF
--- a/.nuclear/changes/efficacy-eval-harness/basis.md
+++ b/.nuclear/changes/efficacy-eval-harness/basis.md
@@ -1,0 +1,53 @@
+# Basis
+
+## Change context
+
+- Slug: efficacy-eval-harness
+- Scope: A reproducible presence-check harness over worked-example artifacts, with three eval cases, a CLI subcommand, a bounded doc, and tests.
+- Outcome to protect: The repo's efficacy claims become falsifiable and drift-resistant without overclaiming.
+
+## Need and scope
+
+Before this change, every efficacy claim in the skill-workflow comparison was author-judged on a 1-5 scale with no runnable artifact. A skeptic had to trust the author. This harness adds a small mechanical layer: it reads each real trial-record artifact, isolates the `## Nuclear-Grade Trial` section, and checks that each declared decision signal is present. It does not mechanize the simple-versus-Nuclear-grade comparison, because those author-written meta-sections describe gaps using the same vocabulary as the signals and cannot be scored by substring presence without inflating the result.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Evidence planned |
+|---|---|---|
+| C-001 | `ng eval` scores the three real trial-record artifacts and reports per-case and total decision-signal coverage. | Live run; `tests/test_efficacy.py`. |
+| C-002 | The harness fails (exit non-zero) when a worked example drops a required signal. | Teeth test that strips a section and asserts the case fails. |
+| C-003 | The harness adds no runtime dependency (stdlib only: json, dataclasses, pathlib). | Clean-venv wheel install; import review. |
+| C-004 | The published doc states what the harness does and does not measure, with an explicit non-assurance boundary. | `efficacy-harness.md`. |
+| C-005 | Eval cases are plain JSON with signals authored from each scenario's stated risks, easy to review and extend. | `evals/cases/*.json`. |
+| C-006 | The command degrades gracefully (exit 0, clear message) when run outside a repo that has `evals/cases/`. | Wheel smoke run from a temp dir; `tests/test_efficacy.py`. |
+| C-007 | The comparison's qualitative scope is preserved and cross-linked, not replaced or overstated. | Links added to README and results-summary; boundary note retained. |
+
+## Assumptions, constraints, and invalidation triggers
+
+- Assumption: signal presence is a meaningful, honest proxy for "the artifact surfaces this decision element." Invalidation trigger: a signal phrase appears in unrelated prose; mitigated by scoping to the `## Nuclear-Grade Trial` section and authoring multiple specific phrasings.
+- Constraint: zero runtime dependencies, because the package ships as a dependency-free wheel and wheel-smoke installs into a clean venv.
+- Constraint: do not present signal presence as proof of correctness, safety, or assurance.
+
+## Acceptance scenarios
+
+- A skeptic clones the repo, runs `python tools/ng.py eval .`, and sees 15/15 coverage across three worked examples with a printed non-assurance caveat.
+- A maintainer edits a trial record and removes a decision element; CI fails on the efficacy test until the example or the case is corrected.
+- A user installs the wheel and runs `nuclear-grade eval` outside the repo; it reports no cases found and exits 0.
+
+## Required links
+
+- Packet: `.nuclear/changes/efficacy-eval-harness/`
+- `risk.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Claims C-001 through C-007 are mapped to plan steps and have evidence rows.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by public software verification and evidence concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/efficacy-eval-harness/plan.md
+++ b/.nuclear/changes/efficacy-eval-harness/plan.md
@@ -1,0 +1,81 @@
+# Plan
+
+## Change context
+
+- Slug: efficacy-eval-harness
+- Mode: Standard
+- Owner: maintainer
+
+## Charter and anchor check
+
+A re-evaluated gate, not a one-time note. Confirm before Plan and re-check before Verify. See `controlling-mission-drift`.
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes.
+- Re-checked before Verify? yes; scope held to a presence-check harness; the comparison-mechanization temptation stayed a non-goal.
+- Charter articles in play: Evidence over persuasion, Rising standards, Questioning attitude, Formality.
+
+If a non-goal or charter article must be crossed, record the justification here:
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | not applicable | not applicable | proceed |
+
+## Build sequence
+
+1. Add `nuclear_grade/efficacy.py`: stdlib loader and scorer over real artifacts.
+2. Author three JSON eval cases (U02, U04, U07) with signals grounded in each scenario's stated risks.
+3. Wire an `eval` subcommand into `nuclear_grade/cli.py`.
+4. Write `efficacy-harness.md` with explicit what-it-measures and what-it-does-not boundaries; link it from the comparison README and results-summary, and add `eval` to the CLI reference.
+5. Add `tests/test_efficacy.py` including a teeth test that proves the harness can fail.
+6. Run the gate (ruff, pytest, doctor, validate) and a clean-venv wheel build; fill this packet.
+
+## Non-goals
+
+- Mechanizing the simple-versus-Nuclear-grade score table.
+- Scoring a live model or claiming an A/B result.
+- Adding any runtime dependency.
+- Expanding to all 20 trials at shallow depth.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Harness scores real artifacts | `ng eval .` returns coverage | pass |
+| Harness has teeth | A stripped section fails the case | pass |
+| Zero runtime deps | Clean-venv wheel install works | pass |
+| Boundary doc | States non-assurance limits | pass |
+| Packet validates | This packet passes the validator | pass |
+
+## Rollback approach
+
+- Rollback method: revert the branch; the module, cases, subcommand, doc, and tests revert cleanly.
+- State/data reversal notes: none.
+- Feature flag / kill switch: not applicable; the command is read-only.
+- Owner: maintainer.
+- Time to restore estimate: minutes.
+
+## Proof commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py eval .
+python tools/ng.py validate .nuclear/changes/efficacy-eval-harness
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Build sequence executed; tests green; packet validates.
+
+## Source-lineage note
+
+Original Nuclear-grade plan influenced by configuration-management concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/efficacy-eval-harness/risk.md
+++ b/.nuclear/changes/efficacy-eval-harness/risk.md
@@ -1,0 +1,106 @@
+# Risk
+
+## Change identity
+
+- Slug: efficacy-eval-harness
+- PR / issue: repo-review enhancements (Track A)
+- Owner: maintainer
+- Date: 2026-05-30
+- Current lifecycle phase: Execute
+- Summary: Add a reproducible efficacy harness (`python tools/ng.py eval`) that mechanically checks each worked-example artifact still surfaces the decision signals the methodology claims it teaches. Adds `nuclear_grade/efficacy.py`, three JSON eval cases under `evals/cases/`, an `eval` CLI subcommand, a bounded `efficacy-harness.md` doc, and tests.
+
+## Mission anchor
+
+State what this change is for, so a long session can be tested against it. See `controlling-mission-drift`.
+
+- Objective: Convert one part of the existing qualitative efficacy comparison into a runnable, falsifiable check, without overclaiming that it proves engineering quality, safety, or compliance.
+- Success criteria: `ng eval .` scores the three real trial-record artifacts, exits non-zero if a worked example drops a required signal, ships with a boundary doc that states what it does and does not measure, and is covered by tests including a teeth test that proves it can fail.
+- Non-goals / forbidden directions: Out of scope is mechanizing the simple-prompt-versus-Nuclear-grade score table (unreliable via substring on author-written meta-sections), scoring a live model, adding any runtime dependency, and expanding to all 20 trials at shallow depth. Forbidden is wording that presents signal presence as proof of correctness, safety, or assurance.
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: review finding that all efficacy evidence was author-judged with nothing runnable, and `.nuclear/charter.md` (evidence over persuasion, rising standards).
+
+## Questioning-attitude summary
+
+- Decision question: What can be measured mechanically and honestly about these artifacts without dressing author judgment up as measurement?
+- Assumptions that changed the mode: A harness that emits an efficacy score is a public trust-bearing artifact; by the repo's own U04 logic, public assurance wording is a Standard trigger even when the code is small.
+- Facts still needing validation: That the harness can genuinely fail (validated by a teeth test that strips a section and asserts the case fails), and that it stays zero-runtime-dependency (validated by a clean-venv wheel install).
+- Stop or hold conditions: Stop if the only way to show a comparison "win" is to grep author-written gap prose, which would inflate the result; that path was rejected and the comparison stays qualitative.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `nuclear_grade/efficacy.py` | Code | The harness logic | `../../../nuclear_grade/efficacy.py` |
+| `evals/cases/*.json` | Data | The three eval cases and their signals | `../../../evals/cases` |
+| `nuclear_grade/cli.py` | Code | The `eval` subcommand | `../../../nuclear_grade/cli.py` |
+| `docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md` | Docs | The bounded public explanation | `../../../docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md` |
+| `tests/test_efficacy.py` | Test | Behavior and teeth coverage | `../../../tests/test_efficacy.py` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Publishes an efficacy/reproducibility claim that a hostile reader could test. |
+| Reversibility | high | Revert the branch; no migration. |
+| Detectability | high | Tests and CI catch regressions; the harness reports its own coverage. |
+| Exposure | medium | Public repo; a credibility-bearing artifact. |
+| Uncertainty | low | Pure-stdlib presence checks over real files. |
+| Dependency trust | low | No new runtime dependency. |
+| AI authority | low | No new agent write permissions. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine/repetitive action where inattention is plausible | no | Bespoke signals authored per scenario |
+| Known procedure where workflow adherence matters | yes | Packet path and the plan build sequence |
+| Novel or uncertain work where assumptions may be wrong | yes | The overclaiming risk is controlled by a bounded doc and a teeth test |
+| Interrupted, resumed, or handed-off work | no | Single session |
+| High-consequence critical action | no | Read-only scoring tool |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** It publishes a trust-bearing efficacy claim; public assurance wording is a Standard trigger by the repo's own comparison findings.
+- **Why lighter mode is not enough:** Quick cannot record the claim-to-evidence mapping or the boundary reasoning that keeps the claim honest.
+- **Why heavier mode is not yet required:** No regulated use, safety basis, irreversible data, or external supplier; the change is reversible and well tested.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline above. | maintainer |
+| `basis.md` | yes | Claim-to-evidence mapping. | maintainer |
+| `verification.md` | yes | Per-claim evidence status. | maintainer |
+| `ship.md` | yes | Release decision. | maintainer |
+| `turnover.md` | no | Single-author packet. | maintainer |
+| `self-check.md` | no | No high-consequence critical action. | maintainer |
+| `supplier-trust.md` | no | No new external supplier. | maintainer |
+| Nuclear subset record | no | Not warranted. | maintainer |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: Confirm the harness can fail, not only pass, before trusting a green run.
+- Minimum evidence before merge/release: pytest green; ruff clean; doctor OK; this packet validates; clean-venv wheel install keeps the package dependency-free; `ng eval .` reports full coverage.
+- Independent review needed? no for this PR; the boundary wording invites hostile review.
+
+## Required links
+
+- Packet: `.nuclear/changes/efficacy-eval-harness/`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md)
+
+## Exit criteria
+
+- Mode is justified as Standard.
+- The mission anchor names objective, success criteria, and non-goals.
+- Claims map to evidence in `verification.md`.
+- No hidden trigger for a stronger mode.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by public software verification and configuration-management concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/efficacy-eval-harness/ship.md
+++ b/.nuclear/changes/efficacy-eval-harness/ship.md
@@ -1,0 +1,55 @@
+# Ship
+
+## Release decision
+
+- **Decision:** ship on the review branch as part of the repo-review enhancements; merge once CI is green.
+- **Rationale:** The harness makes one efficacy claim reproducible and adds a regression guard for the worked examples, with wording bounded against overclaiming. It is read-only and non-breaking.
+- **Pre-merge gates:**
+  - `python -m pytest -q` green
+  - `ruff check .` clean
+  - `python tools/ng.py doctor .` OK
+  - `python tools/ng.py eval .` reports full coverage
+  - `python tools/ng.py validate` OK on every packet including this one
+  - CI green on the matrix and wheel-smoke jobs
+
+## Evidence status summary
+
+| Area | Status | Link |
+|---|---|---|
+| Verification | pass | `verification.md` |
+| Trace | pass | `trace.md` |
+| Harness behavior | pass | `tests/test_efficacy.py` |
+| Boundary wording | pass | `docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md` |
+| Packet self-validation | pass | `python tools/ng.py validate .nuclear/changes/efficacy-eval-harness` |
+
+## Rollback / restore plan
+
+- Revert the branch; the module, eval cases, subcommand, doc, and tests revert cleanly. No data migration.
+- If a signal is found to be too loose or too strict, edit that single JSON case; the harness permits it without code change.
+
+## Monitoring and post-release checks
+
+- Watch CI: the efficacy test will fail if a worked example later drops a decision signal, which is the intended regression signal.
+- Watch for any reading of the harness as a safety, security, or compliance claim; the boundary note and printed caveat exist to prevent that, and should be reinforced if misread.
+- Revisit adding more eval cases as new worked examples are published.
+
+## Maintainer follow-ups
+
+- Consider pairing this with the `closing-stale-packets` skill (Track C) so abandonment and efficacy both have first-class support.
+- Consider whether a future case should score a non-comparison artifact (for example a real packet) to broaden the guard.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+
+## Exit criteria
+
+- Decision recorded; rollback named; monitoring named.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record influenced by release-readiness concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/efficacy-eval-harness/trace.md
+++ b/.nuclear/changes/efficacy-eval-harness/trace.md
@@ -1,0 +1,29 @@
+# Trace
+
+## Trace summary
+
+| Claim ID | Artifact | Status |
+|---|---|---|
+| C-001 | `nuclear_grade/efficacy.py`; `evals/cases/*.json`; live `ng eval .` | pass |
+| C-002 | `tests/test_efficacy.py::test_harness_has_teeth_when_a_signal_is_dropped` | pass |
+| C-003 | `nuclear_grade/efficacy.py` imports (json, dataclasses, pathlib); clean-venv wheel install | pass |
+| C-004 | `docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md` | pass |
+| C-005 | `evals/cases/U02-...json`, `U04-...json`, `U07-...json` | pass |
+| C-006 | `tests/test_efficacy.py::test_eval_command_is_graceful_without_cases`; wheel run from temp dir | pass |
+| C-007 | `docs/03-worked-examples/skill-workflow-comparison/README.md`; `results-summary.md` links | pass |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim maps to a named artifact and a status.
+
+## Source-lineage note
+
+Original Nuclear-grade trace influenced by traceability concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/efficacy-eval-harness/verification.md
+++ b/.nuclear/changes/efficacy-eval-harness/verification.md
@@ -1,0 +1,49 @@
+# Verification
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+
+## Claim-to-evidence table
+
+| Claim | Result status | Evidence link | Notes |
+|---|---|---|---|
+| C-001 scores real artifacts | pass | `../../../nuclear_grade/efficacy.py` | `ng eval .` reports 15/15 signals across U02, U04, U07; each case isolates the `## Nuclear-Grade Trial` section. |
+| C-002 harness has teeth | pass | `../../../tests/test_efficacy.py` | The teeth test strips the scored section in a temp copy and asserts the case becomes `incomplete` with 0 present signals and a non-ok result. |
+| C-003 zero runtime deps | pass | `../../../nuclear_grade/efficacy.py` | Imports only json, dataclasses, pathlib; a clean-venv wheel install then `nuclear-grade eval` ran without extra packages. |
+| C-004 bounded doc | pass | `../../../docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md` | States what it measures, what it does not measure, and a non-assurance boundary note. |
+| C-005 reviewable JSON cases | pass | `../../../evals/cases` | Three cases; signals authored from each scenario's stated risks with multiple accepted phrasings. |
+| C-006 graceful outside repo | pass | `../../../tests/test_efficacy.py` | Run from a temp dir, the installed CLI prints "No eval cases found" and exits 0. |
+| C-007 comparison preserved | pass | `../../../docs/03-worked-examples/skill-workflow-comparison/README.md` | Harness linked from README and results-summary; the qualitative scope and boundary note are unchanged. |
+
+## Reproduction commands
+
+```bash
+ruff check .
+python -m pytest -q
+python tools/ng.py doctor .
+python tools/ng.py eval .
+python tools/ng.py validate .nuclear/changes/efficacy-eval-harness
+```
+
+## Known gaps and deferrals
+
+- The harness covers three of twelve trials by design (`deferred`): three scenario-grounded cases are more honest than twelve shallow ones; more cases can be added as JSON later.
+- The simple-versus-Nuclear-grade comparison stays qualitative (`not applicable` to mechanize): scoring author-written gap prose by substring would inflate the result and is deliberately excluded.
+- CI has not run at packet-authoring time; it is the public evidence for the matrix and wheel-smoke jobs.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `ship.md`
+
+## Exit criteria
+
+- Every claim has a recorded status.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record influenced by graded-rigor evidence concepts mapped in [`docs/00-standards-foundation/source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/status-packet-health/proof.md
+++ b/.nuclear/changes/status-packet-health/proof.md
@@ -1,0 +1,56 @@
+# Quick Proof
+
+**Purpose:** Capture the smallest credible evidence record for the `ng status` packet-health change.
+
+---
+
+## Proof summary
+
+- Change slug: status-packet-health
+- Proof owner: FlyFission
+- Date/time: 2026-05-30
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: `ng status` correctly tags filled packets `ok`, untouched scaffolds `scaffold`, and warns when packets need attention, without breaking the existing `name: mode` output.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest -q` (incl. new `test_status_flags_unfilled_scaffold_packet`, `test_status_marks_filled_packet_ok`, and the preserved `test_status_detects_active_packets`); `python tools/ng.py status .`.
+- Environment: Python 3, local, repo CI parity.
+- Inputs/fixtures: tmp_path scaffold packets and the repo's own 11 packets.
+- Expected result: 78 tests pass; every in-repo packet tagged `[ok]`; no false "need attention".
+- Self-check used? no; read-only listing change.
+
+## Result
+
+- Status: pass
+- Actual result: 78 tests pass; `status .` tags all 11 in-repo packets `[ok]` with no attention warning; the `scaffold` and `ok` paths are covered by the new tests.
+- Evidence link or artifact path: `nuclear_grade/cli.py` (`packet_health`), `tests/test_ng_cli.py`.
+- If failed/gap: not applicable.
+
+## Reviewer note
+
+- Reviewer: FlyFission
+- Review note: Health is derived from the existing `validate_packet`, so it cannot drift from validation semantics. The existing `test_status_detects_active_packets` substring assertion still holds because `name: mode` remains a prefix.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: repo-review enhancements
+- Relevant changed files: `nuclear_grade/cli.py`, `tests/test_ng_cli.py`, `docs/05-reference/cli-reference.md`
+- CI run / test output: `python -m pytest -q` (78 pass)
+- If AI-assisted: prepared by an AI agent under review; scope is one read-only CLI command plus tests and a doc line.
+
+## Exit criteria
+
+- Evidence directly matches the claim in `risk.md`.
+- Actual result is compared to the expected result named before proof.
+- Result status is explicit.
+- Any failure or gap has a next action or escalation.
+- Reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public configuration-management and operating-experience concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/status-packet-health/risk.md
+++ b/.nuclear/changes/status-packet-health/risk.md
@@ -1,0 +1,71 @@
+# Quick Risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** Small, additive CLI output change with full test coverage; no new trust boundary, dependency, or release effect, and `status` was already read-only.
+
+**Purpose:** Decide whether the `ng status` packet-health enhancement can stay in Quick mode and name the proof required.
+
+---
+
+## Change
+
+- Slug: status-packet-health
+- PR / issue: repo-review enhancements (Track C functionality)
+- Owner: FlyFission
+- Date: 2026-05-30
+- Summary: `ng status` now tags each packet `ok`, `scaffold` (untouched draft still carrying the placeholder marker), or `invalid`, and prints a closing reminder when any packet needs attention -- surfacing abandoned half-filled drafts instead of leaving them silent.
+
+## Scope
+
+- Affected files/configs/docs: `nuclear_grade/cli.py` (handle_status + packet_health), `tests/test_ng_cli.py`, `docs/05-reference/cli-reference.md`.
+- User-visible behavior changed? yes -- `status` output gains a health tag (existing `name: mode` prefix preserved).
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A packet is mislabeled in a read-only listing; reversible. |
+| Reversibility | Fully reversible; one handler plus a helper. |
+| Detectability | High; covered by three CLI tests and a live run. |
+| Exposure | Local CLI output. |
+| Uncertainty | Low; reuses the existing validator. |
+| Why Quick is enough | Read-only command, no side effects, no trust boundary. |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest -q`; `python tools/ng.py status .`.
+- Expected result: 78 tests pass; every in-repo packet tagged `[ok]`.
+- Evidence link/location: `proof.md`.
+
+## Escalation check
+
+Escalate to Standard if any are true:
+
+- users, data, security, permissions, operations, or architecture care -- no;
+- a dependency/model/API trust decision changed -- no;
+- failure could be silent, delayed, costly, or hard to reverse -- no;
+- AI had write/execute/network/approval authority beyond drafting -- no;
+- proof cannot be captured in one small `proof.md` -- false.
+
+None apply. Quick stands.
+
+## Required links
+
+- Packet: `.nuclear/changes/status-packet-health/`
+- Related PR/issue: repo-review enhancements
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Mode is justified as Quick.
+- Required proof is named before or during the change.
+- No Standard/Nuclear activation trigger is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public configuration-management and operating-experience concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/visual-readability-enhancements/proof.md
+++ b/.nuclear/changes/visual-readability-enhancements/proof.md
@@ -1,0 +1,56 @@
+# Quick Proof
+
+**Purpose:** Capture the smallest credible evidence record for this Quick change.
+
+---
+
+## Proof summary
+
+- Change slug: visual-readability-enhancements
+- Proof owner: FlyFission
+- Date/time: 2026-05-30
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: The change keeps the test suite, doctor, and all in-repo packets green, and every added Mermaid diagram renders.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest -q`; `python tools/ng.py doctor .`; `for p in .nuclear/changes/*/; do python tools/ng.py validate "$p"; done`; Mermaid render-check of all four diagrams via the diagram validator.
+- Environment: Python 3 (repo CI parity), local.
+- Inputs/fixtures: repo working tree on `claude/repo-review-enhancements-xszED`.
+- Expected result: 76 tests pass, doctor OK, every packet green, all four diagrams valid.
+- Self-check used? no; documentation change with no wrong-target risk.
+
+## Result
+
+- Status: pass
+- Actual result: 76 tests pass; `doctor` OK; in-repo packets validate (10/10 prior packets, plus this one); all four diagrams valid (flowchart) via render-check.
+- Evidence link or artifact path: `docs/diagrams.md` (diagram source); CI gate commands above.
+- If failed/gap: not applicable.
+
+## Reviewer note
+
+- Reviewer: FlyFission
+- Review note: Diagrams are canonical in `docs/diagrams.md`; README/QUICKSTART/SKILLS mirror them. Required ASCII lifecycle string preserved in README so `test_public_docs` still passes.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: repo-review enhancements
+- Relevant changed files: `docs/diagrams.md`, `docs/glossary.md`, `docs/02-operating-system/agent-threat-model.md`, `README.md`, `SKILLS.md`, `QUICKSTART.md`, `docs/README.md`, `SECURITY.md`, `templates/standard/verification.md`
+- CI run / test output: `python -m pytest -q` (pass), `python tools/ng.py doctor .` (OK)
+- If AI-assisted: changes prepared by an AI agent under review; scope is additive docs plus one template legend line.
+
+## Exit criteria
+
+- Evidence directly matches the claim in `risk.md`.
+- Actual result is compared to the expected result named before proof.
+- Result status is explicit.
+- Any failure or gap has a next action or escalation.
+- Reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public software test-documentation and verification concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/visual-readability-enhancements/risk.md
+++ b/.nuclear/changes/visual-readability-enhancements/risk.md
@@ -1,0 +1,71 @@
+# Quick Risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** Additive documentation and a template-legend line; no code paths, validator logic, or public claims changed.
+
+**Purpose:** Decide whether the visual/readability enhancements can safely stay in Quick mode and name the proof required.
+
+---
+
+## Change
+
+- Slug: visual-readability-enhancements
+- PR / issue: repo-review enhancements (PR #1 of the multi-perspective review)
+- Owner: FlyFission
+- Date: 2026-05-30
+- Summary: Add Mermaid diagrams (lifecycle, mode tree, skill graph, packet artifact graph), a glossary, an agent threat-model doc, name `using-nuclear-grade` as the skill router, align the QUICKSTART first-run note with actual validator output, and add `planned` to the verification template legend.
+
+## Scope
+
+- Affected files/configs/docs: `docs/diagrams.md` (new), `docs/glossary.md` (new), `docs/02-operating-system/agent-threat-model.md` (new), `README.md`, `SKILLS.md`, `QUICKSTART.md`, `docs/README.md`, `SECURITY.md`, `templates/standard/verification.md`.
+- User-visible behavior changed? no (documentation and one template legend line).
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A diagram or doc reads incorrectly; reversible by edit. No runtime or evidence-gate effect. |
+| Reversibility | Fully reversible; documentation and one template line. |
+| Detectability | High; diagrams render visibly, tests and doctor cover docs/templates. |
+| Exposure | Public docs, but additive and boundary-noted. |
+| Uncertainty | Low; no logic change. |
+| Why Quick is enough | No new trust boundary, dependency, permission, or release effect. |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest -q`; `python tools/ng.py doctor .`; validate all in-repo packets; Mermaid render-check via diagram validator.
+- Expected result: 76 tests pass, doctor OK, 10/10 packets green, all 4 diagrams valid.
+- Evidence link/location: `proof.md`.
+
+## Escalation check
+
+Escalate to Standard if any are true:
+
+- users, data, security, permissions, operations, or architecture care — no;
+- a dependency/model/API trust decision changed — no;
+- failure could be silent, delayed, costly, or hard to reverse — no;
+- AI had write/execute/network/approval authority beyond drafting — no;
+- proof cannot be captured in one small `proof.md` — false.
+
+None apply. Quick stands.
+
+## Required links
+
+- Packet: `.nuclear/changes/visual-readability-enhancements/`
+- Related PR/issue: repo-review enhancements
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Mode is justified as Quick.
+- Required proof is named before or during the change.
+- No Standard/Nuclear activation trigger is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public graded-rigor and software-assurance concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project uses changelog entries to record public-facing changes, not to impl
 
 ## [Unreleased]
 
+### Added
+
+- Reproducible efficacy harness. `nuclear-grade eval` (and `python tools/ng.py eval`) mechanically checks that each worked-example artifact still surfaces the decision signals the methodology claims it teaches, exiting non-zero if a worked example drops a required signal. Eval cases live as plain JSON in `evals/cases/`; the harness is stdlib-only (no new runtime dependency). It measures presence of named decision elements, not engineering correctness, safety, or compliance; see `docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md`. The simple-prompt-versus-Nuclear-grade comparison stays qualitative and is deliberately not mechanized.
+- `nuclear-grade status` now tags each packet `ok`, `scaffold` (an untouched draft still carrying the placeholder marker), or `invalid`, and prints a reminder when any packet needs attention, so abandoned half-filled drafts are visible rather than silent.
+- Workflow diagrams (`docs/diagrams.md`), a plain-language glossary (`docs/glossary.md`), and an agent threat model (`docs/02-operating-system/agent-threat-model.md`).
+
 ## [0.3.0] - 2026-05-28
 
 ### Changed

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,7 @@
 
 Nuclear-grade should make decisions faster, not paperwork heavier. Move quickly while exploring and building reversible candidates; slow down when you are accepting a claim, baseline, public statement, release decision, or authority change.
 
-> **Note on the demo:** the first time you run `validate` on a freshly scaffolded packet you should expect `FAILED: ... has unfilled template prompts`. Templates ship with empty prompts on purpose. Fill the prompts that matter, then re-run `validate`. The point of the validator is to refuse silent gaps.
+> **Note on the demo:** the first time you run `validate` on a freshly scaffolded packet you should expect it to **fail**. Each template ships with a `NUCLEAR-GRADE-PLACEHOLDER` marker line and empty prompts on purpose, so the validator reports `still contains the placeholder marker` and `has unfilled template prompts`. Fill the prompts that matter, delete the marker line, then re-run `validate`. The point of the validator is to refuse silent gaps.
 
 ## 1. Check the repo
 
@@ -61,6 +61,16 @@ Trust check: What dependency, model, API, SaaS, or vendor claim affects the deci
 | A failure, defect, incident, or near miss | Incident pattern |
 | Mostly an architecture or research decision | Research Board pattern |
 | A release-readiness decision | Release pattern |
+
+```mermaid
+flowchart TD
+    Start([Change request]) --> Q1{Local, reversible,<br/>obvious proof,<br/>no new trust boundary?}
+    Q1 -->|yes| Quick[Quick packet<br/>risk.md + proof.md]
+    Q1 -->|no| Q2{User / data / dep /<br/>permission / AI authority /<br/>release consequence?}
+    Q2 -->|yes| Standard[Standard packet<br/>6 files]
+    Q2 -->|severe, silent,<br/>irreversible, external trust| Strong[Human-reviewed<br/>stronger mode]
+    Q2 -->|already went wrong| Incident[Incident pattern]
+```
 
 When unsure, start with Standard and keep the packet thin.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Short launch version:
 Question -> Specify -> Execute -> Verify -> Decide
 ```
 
+```mermaid
+flowchart LR
+    Q[Question] --> D[Discover] --> S[Specify] --> P[Plan]
+    P --> E[Execute] --> V[Verify] --> R[Review]
+    R --> Dec{Decide}
+    Dec -->|ship / defer| B[Baseline] --> O[Operate] --> L[Learn]
+    Dec -->|block| P
+    L -.feeds future basis.-> Q
+```
+
+More diagrams (mode decision tree, skill graph, packet artifact graph) are in [`docs/diagrams.md`](docs/diagrams.md).
+
 Quick and Standard packets are the Git-native way to record that lifecycle. `Classify` stays inside the risk/mode screen so the public path stays teachable. Activated CM records add controlled items, change impact, baseline, variance, and OPEX detail only when consequence justifies it.
 
 HPI overlays sit underneath that path. Use them when they change the work: task preview before consequential execution, self-check before critical actions, turnover before another agent or human continues, independent verification before high-trust decisions, and OPEX after near misses or review surprises.
@@ -148,6 +160,8 @@ docs/02-operating-system/       lifecycle, HPI overlays, modes, packets, thresho
 docs/03-worked-examples/        flagship worked example
 docs/04-adoption/               rollout, agent authority, reviewer playbook
 docs/05-reference/              skill, command, and CLI contracts
+docs/diagrams.md                visual maps of lifecycle, modes, skills, packets
+docs/glossary.md                plain-language decoding of terms and idioms
 ```
 
 ## Public v0 status

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,10 @@ For non-sensitive issues, open a normal GitHub issue with:
 - why the issue could mislead users or weaken evidence;
 - suggested fix, if known.
 
+## Agent operating posture
+
+For the trust assumptions of an AI agent operating this workflow — packet content is untrusted input, and the validator is not a security boundary — see [`docs/02-operating-system/agent-threat-model.md`](docs/02-operating-system/agent-threat-model.md).
+
 ## Disclosure posture
 
 We prefer precise, scoped language over broad claims. If a report identifies overclaiming, the likely fix is to narrow language, add evidence, or mark the item as a gap/deferred claim.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -29,6 +29,45 @@ Skills are self-contained agent instructions. Each skill has a `SKILL.md` contra
 | [`decomposing-work-breakdown`](skills/decomposing-work-breakdown/SKILL.md) | Decomposing an epic, feature, or subsystem into a product-oriented, 100%-rule, non-overlapping work breakdown | WBS table and dictionary |
 | [`structuring-agentic-folders`](skills/structuring-agentic-folders/SKILL.md) | Laying out a repo or agent workspace, placing a file, or fixing a junk-drawer directory | Folder map and naming/depth audit |
 
+## How the skills compose
+
+`using-nuclear-grade` is the entry point and router. From there the spine runs question -> classify -> create -> prove -> ship -> baseline -> learn, and the HPI overlays activate only when consequence warrants them. Reach for an overlay when its trigger fires, not by default.
+
+```mermaid
+flowchart TD
+    UNG([using-nuclear-grade<br/>router / entry point])
+    UNG --> QA[questioning-attitude]
+    QA --> CCR[classifying-change-risk]
+    CCR -->|controlled config touched| ICI[identifying-controlled-items]
+    CCR --> CCP[creating-change-packets]
+    ICI --> SCI[screening-change-impact]
+    CCP --> PC[proving-claims]
+    PC --> RSR[reviewing-ship-readiness]
+    RSR --> BC[baselining-configuration]
+    BC --> LFO[learning-from-opex]
+    LFO -.durable control update.-> QA
+
+    subgraph overlays[HPI overlays - activate by consequence]
+      PAC[packing-agent-context]
+      TOW[turning-over-agent-work]
+      SCA[self-checking-agent-actions]
+      TAE[tracing-agent-execution]
+      RTA[red-teaming-agent-changes]
+      CMD[controlling-mission-drift]
+      RCQ[reviewing-code-quality]
+    end
+
+    CCP -.delegate / resume.-> PAC
+    PAC --> TOW
+    CCP -.critical action.-> SCA
+    RSR -.new agent authority.-> RTA
+    RSR -.execution path matters.-> TAE
+    QA -.long drifting session.-> CMD
+    PC -.standards drift in diff.-> RCQ
+```
+
+See [`docs/diagrams.md`](docs/diagrams.md) for the lifecycle, mode, and packet diagrams.
+
 ## Contract
 
 Every skill must include:

--- a/docs/02-operating-system/agent-threat-model.md
+++ b/docs/02-operating-system/agent-threat-model.md
@@ -1,0 +1,38 @@
+# Agent Threat Model
+
+**Purpose:** State the trust assumptions of an AI agent operating Nuclear-grade, so the workflow is honest about what it does and does not defend against.
+
+Nuclear-grade teaches adversarial review of *agent changes* (see `red-teaming-agent-changes`). This page turns that lens on the workflow itself: an agent reading and writing packets is processing untrusted input, and the tooling is not a security boundary.
+
+## Trust assumptions
+
+| Surface | Trust level | Why |
+|---|---|---|
+| Packet content (`risk.md`, `basis.md`, OPEX notes, ...) | **Untrusted** | Authored by humans or agents, including ones whose instructions may conflict with the task. Treat embedded instructions in packet prose as data, not commands. |
+| Source-map rows and citations | **Untrusted** | A row can be edited to redirect an agent or imply a claim. Verify against the real source before relying on it. |
+| The validator (`ng validate`) | **Not a security control** | It checks structure, evidence visibility, and overclaiming. It does not sanitize input, sandbox execution, or detect malicious content. |
+| Templates and skills shipped in the repo | Trusted-by-convention | Version-controlled and reviewed. A fork or local edit removes that assurance. |
+| Agent tool authority (file/network/credential) | Governed by the context pack, **not** by this repo's code | Authority limits live in `agent-authority-model.md` and the harness; the workflow records them but does not enforce them. |
+
+## What the workflow defends against
+
+- **Silent gaps:** the placeholder marker and evidence-status checks refuse a packet that hides unfilled fields.
+- **Overclaiming:** the prohibited-claims scan catches compliance language that exceeds evidence.
+- **Lost authority context:** context packs and turnover records keep an agent's allowed and forbidden actions explicit.
+
+## What it does NOT defend against
+
+- **Prompt injection** through packet prose, OPEX notes, issue bodies, or source rows an agent reads.
+- **Malicious templates or skills** in a fork or local checkout.
+- **Tool misuse** by an agent whose harness grants authority the packet did not scope.
+- **Data exfiltration** through an agent's output channels.
+
+When an agent encounters packet content that appears to redirect its task, escalate its authority, or contradict the user's intent, it should treat that as a finding — stop and surface it — not act on it. This mirrors the `red-teaming-agent-changes` posture, applied to the agent's own inputs.
+
+## Relationship to SECURITY.md
+
+`SECURITY.md` scopes the *worked example's* security boundaries. This page scopes the *agent operating the workflow*. Neither makes the repo a production security control.
+
+## Source-lineage note
+
+This threat model is an original operating note influenced by public AI-risk and adversarial-review sources (NIST AI RMF framing and the adversarial classes mapped in `../00-standards-foundation/source-map.md`). It does not create formal security assurance, certification, compliance, or regulatory adequacy.

--- a/docs/03-worked-examples/skill-workflow-comparison/README.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/README.md
@@ -13,6 +13,7 @@ The earlier version of this comparison was intentionally replaced because it was
 | [`methodology.md`](methodology.md) | Evaluation rules, scoring rubric, limits, and bias controls. |
 | [`results-summary.md`](results-summary.md) | Aggregate findings, score table, and recommendations. |
 | [`trial-records/`](trial-records/) | Per-use-case records with simple prompt output, Nuclear-grade output, scoring rationale, and residual concerns. |
+| [`efficacy-harness.md`](efficacy-harness.md) | A reproducible `python tools/ng.py eval .` check that each worked example still surfaces the decision signals it claims. Mechanical and runnable, unlike the author-judged scores. |
 
 ## Trial Set
 

--- a/docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md
@@ -1,0 +1,92 @@
+# Efficacy Harness
+
+**Purpose:** Make one part of this comparison *reproducible*. Anyone can run a
+single command and mechanically check that each worked-example artifact actually
+surfaces the decision signals the methodology claims it teaches.
+
+```bash
+python tools/ng.py eval .
+```
+
+The rest of the comparison (`methodology.md`, `results-summary.md`,
+`trial-records/`) is author-judged and qualitative. This harness adds a small,
+honest, runnable layer on top of it.
+
+## What it measures
+
+For each eval case, the harness reads the real trial-record artifact, isolates
+the `## Nuclear-Grade Trial` section, and checks whether each declared decision
+signal is present (any of several accepted phrasings counts). It reports
+per-case coverage and an overall total, and exits non-zero if any case is
+missing a required signal.
+
+A *signal* is a decision element drawn from that scenario's stated risks, for
+example:
+
+- U02 (agent workspace boundary): bounds agent write authority; states
+  adversarial proof claims; makes a public non-claim.
+- U07 (payment webhook idempotency): escalates mode for money-moving impact;
+  bounds payment credentials; conditions release on rollback and a risk owner.
+- U04 (public assurance wording): separates source inspiration from satisfied
+  requirements; separates license permission from assurance; conditions release
+  on a prohibited-claim scan.
+
+The cases live in [`evals/cases/`](../../../evals/cases) as plain JSON so they
+are easy to read, review, and extend.
+
+## What it does NOT measure
+
+- It does **not** prove the underlying engineering is correct, safe, secure,
+  compliant, certified, or production-ready.
+- A present signal means the artifact *names* the decision element. It is not
+  evidence that the element is adequately handled in the real world.
+- It is **not** an A/B benchmark or a user study, and it does not score a live
+  model. The simple-prompt-versus-Nuclear-grade comparison stays qualitative in
+  `results-summary.md`; it is deliberately not mechanized here, because those
+  author-written meta-sections describe gaps using the same vocabulary as the
+  signals and cannot be scored by substring presence without inflating the
+  result.
+
+## Why it is useful anyway
+
+- **Regression guard.** If a worked example is later edited and a decision
+  element is dropped, the harness fails. The examples cannot silently drift away
+  from what the methodology claims they demonstrate.
+- **Reproducibility.** A skeptic does not have to trust the author's 1-5 scores
+  to confirm the artifacts contain the named decision structure. They run the
+  command.
+- **Extensibility.** Adding a worked example means adding one JSON case with
+  signals grounded in that scenario's risks.
+
+## Adding a case
+
+Create `evals/cases/<id>-<slug>.json`:
+
+```json
+{
+  "id": "U13",
+  "title": "Short scenario name",
+  "artifact": "docs/03-worked-examples/.../trial-records/<file>.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    { "name": "Human-readable decision element", "any": ["phrase one", "phrase two"] }
+  ]
+}
+```
+
+Author the signals from the scenario's stated risks, not by copying the prose
+back out of the artifact. Each signal should be a decision a reviewer would want
+surfaced, with several accepted phrasings so the check is robust to small wording
+changes.
+
+## Boundary Note
+
+This harness checks the presence of named decision signals in artifacts. It does
+not establish safety, security, compliance, certification, formal verification,
+formal validation, production suitability, or regulatory adequacy.
+
+## Source-Lineage Note
+
+This harness is an original Nuclear-grade adoption artifact using the repo
+operating model and public-source lineage summarized in
+`docs/00-standards-foundation/source-map.md`.

--- a/docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md
@@ -69,15 +69,18 @@ Create `evals/cases/<id>-<slug>.json`:
   "artifact": "docs/03-worked-examples/.../trial-records/<file>.md",
   "section": "## Nuclear-Grade Trial",
   "signals": [
-    { "name": "Human-readable decision element", "any": ["phrase one", "phrase two"] }
+    { "name": "Alternatives: any phrasing counts", "any": ["phrase one", "phrase two"] },
+    { "name": "Conjunctive gates: all must appear", "all": ["rollback path", "monitoring query", "residual risk owner"] }
   ]
 }
 ```
 
-Author the signals from the scenario's stated risks, not by copying the prose
-back out of the artifact. Each signal should be a decision a reviewer would want
-surfaced, with several accepted phrasings so the check is robust to small wording
-changes.
+Use `any` for genuine alternatives (several ways to name the same element) and
+`all` for distinct gates that must each be present (so a multi-part release
+decision cannot score as satisfied when only one gate is named). Author the
+signals from the scenario's stated risks, not by copying the prose back out of
+the artifact. Each signal should be a decision a reviewer would want surfaced,
+with phrasings robust to small wording changes.
 
 ## Boundary Note
 

--- a/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
+++ b/docs/03-worked-examples/skill-workflow-comparison/results-summary.md
@@ -1,6 +1,6 @@
 # Results Summary
 
-> *Author-judged qualitative 1-5 scores. See `methodology.md` for limits. No independent reviewer panel. No timing, defect-rate, or A/B measurement. The "overhead" column is judgment, not minutes.*
+> *Author-judged qualitative 1-5 scores. See `methodology.md` for limits. No independent reviewer panel. No timing, defect-rate, or A/B measurement. The "overhead" column is judgment, not minutes. For the reproducible, mechanical layer that checks each artifact still surfaces its claimed decision signals, see [`efficacy-harness.md`](efficacy-harness.md) (`python tools/ng.py eval .`).*
 
 ## Aggregate Score Table
 

--- a/docs/05-reference/cli-reference.md
+++ b/docs/05-reference/cli-reference.md
@@ -11,6 +11,7 @@ python tools/ng.py validate <packet>
 python tools/ng.py doctor [repo]
 python tools/ng.py list
 python tools/ng.py status [repo]
+python tools/ng.py eval [repo]
 ```
 
 ## Behavior
@@ -21,6 +22,7 @@ python tools/ng.py status [repo]
 - `doctor` checks a Nuclear-grade distribution repo for public files, contracts, and templates. In an initialized target repo, it checks `.nuclear/README.md` and `.nuclear/changes/`.
 - `list` shows available modes, skills, commands, packet files, CM files, golden-path files, and optional templates, including turnover, self-check, and supplier-trust records.
 - `status` lists active packets, their detected modes, and a health tag: `ok` (validates), `scaffold` (an untouched draft still carrying the placeholder marker), or `invalid` (fails validation for another reason). It prints a closing reminder when any packet needs attention, so abandoned half-filled drafts are visible rather than silent.
+- `eval` scores the worked-example artifacts in `evals/cases/` for the decision signals they claim to teach, exiting non-zero if any worked example dropped a required signal. It measures presence of named decision elements, not engineering correctness, safety, or compliance. See `docs/03-worked-examples/skill-workflow-comparison/efficacy-harness.md`.
 
 ## Boundary note
 

--- a/docs/05-reference/cli-reference.md
+++ b/docs/05-reference/cli-reference.md
@@ -20,7 +20,7 @@ python tools/ng.py status [repo]
 - `validate` delegates to `tools/ng_validate.py`.
 - `doctor` checks a Nuclear-grade distribution repo for public files, contracts, and templates. In an initialized target repo, it checks `.nuclear/README.md` and `.nuclear/changes/`.
 - `list` shows available modes, skills, commands, packet files, CM files, golden-path files, and optional templates, including turnover, self-check, and supplier-trust records.
-- `status` lists active packets and detected modes.
+- `status` lists active packets, their detected modes, and a health tag: `ok` (validates), `scaffold` (an untouched draft still carrying the placeholder marker), or `invalid` (fails validation for another reason). It prints a closing reminder when any packet needs attention, so abandoned half-filled drafts are visible rather than silent.
 
 ## Boundary note
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ Nuclear-grade docs have two maps: use the workflow first, then inspect the sourc
 | Manage controlled configuration | [`02-operating-system/configuration-management.md`](02-operating-system/configuration-management.md) |
 | Add HPI controls for agent work | [`02-operating-system/hpi-overlays.md`](02-operating-system/hpi-overlays.md) |
 | Understand CLI behavior | [`05-reference/cli-reference.md`](05-reference/cli-reference.md) |
+| See the workflow as diagrams | [`diagrams.md`](diagrams.md) |
+| Decode a term or idiom | [`glossary.md`](glossary.md) |
 
 ## Reference foundation
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,0 +1,102 @@
+# Nuclear-grade Diagrams
+
+Visual maps of the workflow. These are the canonical source for the diagrams embedded across the public docs; update them here and mirror changes where they are referenced.
+
+Diagrams are Mermaid so they render natively on GitHub, stay diffable in version control, and need no build step. Treat each diagram as a controlled item: when the lifecycle, modes, or skill set change, update the matching diagram in the same change.
+
+---
+
+## 1. Core lifecycle
+
+The full lifecycle. The short launch version is `Question -> Specify -> Execute -> Verify -> Decide`.
+
+```mermaid
+flowchart LR
+    Q[Question] --> D[Discover] --> S[Specify] --> P[Plan]
+    P --> E[Execute] --> V[Verify] --> R[Review]
+    R --> Dec{Decide}
+    Dec -->|ship / defer| B[Baseline] --> O[Operate] --> L[Learn]
+    Dec -->|block| P
+    L -.feeds future basis.-> Q
+```
+
+---
+
+## 2. Mode decision tree
+
+Which packet mode a change earns. Rigor scales with consequence, not effort tolerance.
+
+```mermaid
+flowchart TD
+    Start([Change request]) --> Q1{Local, reversible,<br/>obvious proof,<br/>no new trust boundary?}
+    Q1 -->|yes| Quick[Quick packet<br/>risk.md + proof.md]
+    Q1 -->|no| Q2{User / data / dep /<br/>permission / AI authority /<br/>release consequence?}
+    Q2 -->|yes| Standard[Standard packet<br/>6 files]
+    Q2 -->|severe, silent,<br/>irreversible, external trust| Strong[Human-reviewed<br/>stronger mode]
+    Q2 -->|already went wrong| Incident[Incident pattern]
+```
+
+---
+
+## 3. Skill-relationship graph
+
+How the skills compose. `using-nuclear-grade` is the single entry point and router; the spine is the per-change pipeline; the HPI overlays activate only when consequence warrants them.
+
+```mermaid
+flowchart TD
+    UNG([using-nuclear-grade<br/>router / entry point])
+    UNG --> QA[questioning-attitude]
+    QA --> CCR[classifying-change-risk]
+    CCR -->|controlled config touched| ICI[identifying-controlled-items]
+    CCR --> CCP[creating-change-packets]
+    ICI --> SCI[screening-change-impact]
+    CCP --> PC[proving-claims]
+    PC --> RSR[reviewing-ship-readiness]
+    RSR --> BC[baselining-configuration]
+    BC --> LFO[learning-from-opex]
+    LFO -.durable control update.-> QA
+
+    subgraph overlays[HPI overlays - activate by consequence]
+      PAC[packing-agent-context]
+      TOW[turning-over-agent-work]
+      SCA[self-checking-agent-actions]
+      TAE[tracing-agent-execution]
+      RTA[red-teaming-agent-changes]
+      CMD[controlling-mission-drift]
+      RCQ[reviewing-code-quality]
+    end
+
+    CCP -.delegate / resume.-> PAC
+    PAC --> TOW
+    CCP -.critical action.-> SCA
+    RSR -.new agent authority.-> RTA
+    RSR -.execution path matters.-> TAE
+    QA -.long drifting session.-> CMD
+    PC -.standards drift in diff.-> RCQ
+```
+
+---
+
+## 4. Packet artifact-dependency graph
+
+How a Standard packet's records depend on each other. Later records point back to the basis they depend on; operating lessons feed forward into the next change. The text form lives in [`00-standards-foundation/artifact-dependency-graph.md`](00-standards-foundation/artifact-dependency-graph.md).
+
+```mermaid
+flowchart TD
+    intent[Change intent] --> consequence[Consequence classification]
+    consequence --> basis[Design basis<br/>basis.md]
+    basis --> items[Controlled items]
+    items --> plan[Implementation plan<br/>plan.md]
+    plan --> trace[Traceability<br/>trace.md]
+    trace --> verify[Verification<br/>verification.md]
+    verify --> baseline[Baseline record]
+    baseline --> ship[Release readiness<br/>ship.md]
+    ship --> opex[Operating signals / OPEX<br/>opex.md]
+    opex -.feeds forward.-> basis
+```
+
+---
+
+## Source-lineage note
+
+These diagrams are an original visual restatement of the Nuclear-grade workflow, influenced by public lifecycle, configuration-management, and software-assurance sources mapped in [`00-standards-foundation/source-map.md`](00-standards-foundation/source-map.md). They do not create formal V&V, compliance, certification, safety, security, or regulatory adequacy.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,43 @@
+# Glossary
+
+Plain-language decoding of Nuclear-grade terms and idioms. The skills and docs use a dense, idiomatic register; this page is the translation layer so the workflow is legible to readers who are newer to the vocabulary or to English.
+
+## Core terms
+
+| Term | Plain meaning |
+|---|---|
+| Packet | A small folder of Markdown files (`.nuclear/changes/<slug>/`) that records one change: what it is, why it matters, what proves it, and the release decision. |
+| Mode | How much rigor a change earns: Quick (tiny), Standard (consequential), or a stronger human-reviewed pattern. |
+| Quick mode | Low-consequence, reversible work with obvious proof and no new trust boundary. Two files: `risk.md`, `proof.md`. |
+| Standard mode | Work with user, data, dependency, permission, AI-authority, or release consequence. Six files. |
+| Controlled item | Anything whose approved state matters to trust: code, prompts, models, dependencies, docs, releases, tools. |
+| Baseline | The accepted state of controlled items at a decision point, plus what would make it stale. |
+| Mission anchor | The objective, success criteria, and explicit non-goals a change traces back to. Guards against drift. |
+| Charter | The durable, non-negotiable principles of how all work here is done, independent of any one change. |
+| Evidence status | A label on a claim: `pass`, `fail`, `gap`, `deferred`, `not applicable`, or `planned`. |
+| HPI overlay | A small control behavior (brief, self-check, turnover, verify, decide, learn) layered on a change only when it changes the work. |
+| OPEX | Operating experience: turning a near miss, bad handoff, or review surprise into a durable control update. |
+| Turnover | Handing unfinished work to another agent or person with state, remaining scope, authority limits, and open evidence. |
+| Context pack | A focused briefing for an agent: role, authority, evidence obligations, forbidden actions, stop conditions. |
+| Source lineage | A note saying which public sources influenced a concept, without claiming compliance with them. |
+
+## Idioms used in the skills
+
+| Idiom | What it actually means |
+|---|---|
+| "Rigor must earn its keep" | Only add a control if it changes a decision, reduces cost, or increases trust. Otherwise cut it. |
+| "Earns its keep" (an abstraction) | A wrapper or layer must remove more complexity than it adds, or delete it. |
+| "Drift theater" | Restating the mission without honestly re-checking whether the current action still serves it. Going through the motions. |
+| "Postmortem theater" | Writing an incident review that changes no durable control. Motion without learning. |
+| "A small erosion is a finding, not a rounding error" | Do not wave off a minor drop in standards; record it as a real issue. |
+| "Bad news travels up intact" | Report problems immediately and without softening them. |
+| "Prefer boring over clever" | Direct, obvious code beats clever indirection that is hard to read later. |
+| "Prefer deletion over rearrangement" | The strongest fix for complexity is removing structure, not moving it around. |
+| "Green CI is not a release argument" | Passing tests do not, by themselves, justify shipping. |
+| "Confidence is not a source" | An agent sounding sure is not evidence; verify the fact. |
+| "Front door" (questioning attitude) | The first skill to apply before building: challenge assumptions. |
+| "Normalization of deviance" | Letting standards slip one accepted exception at a time until the exception is the norm. |
+
+## Source-lineage note
+
+This glossary is an original plain-language aid for the Nuclear-grade workflow. It does not create formal V&V, compliance, certification, safety, security, or regulatory adequacy.

--- a/evals/cases/U02-agent-workspace-boundary.json
+++ b/evals/cases/U02-agent-workspace-boundary.json
@@ -1,0 +1,28 @@
+{
+  "id": "U02",
+  "title": "Agent workspace boundary",
+  "artifact": "docs/03-worked-examples/skill-workflow-comparison/trial-records/agent-workspace-boundary.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    {
+      "name": "Bounds agent file-write authority (allowed and forbidden)",
+      "any": ["may edit guard and tests only", "may not broaden", "write authority"]
+    },
+    {
+      "name": "Names the controlled items at stake",
+      "any": ["controlled items:"]
+    },
+    {
+      "name": "Classifies mode with a stated rationale",
+      "any": ["mode: standard because", "changes a trust boundary"]
+    },
+    {
+      "name": "States adversarial proof claims, not just a happy path",
+      "any": ["symlink escape denied", "traversal denied", "absolute external path denied"]
+    },
+    {
+      "name": "Makes a bounded release decision with a public non-claim",
+      "any": ["not as production sandbox", "residual risk"]
+    }
+  ]
+}

--- a/evals/cases/U02-agent-workspace-boundary.json
+++ b/evals/cases/U02-agent-workspace-boundary.json
@@ -6,7 +6,7 @@
   "signals": [
     {
       "name": "Bounds agent file-write authority (allowed and forbidden)",
-      "any": ["may edit guard and tests only", "may not broaden", "write authority"]
+      "all": ["may edit guard and tests only", "may not broaden"]
     },
     {
       "name": "Names the controlled items at stake",

--- a/evals/cases/U02-agent-workspace-boundary.json
+++ b/evals/cases/U02-agent-workspace-boundary.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "Makes a bounded release decision with a public non-claim",
-      "any": ["not as production sandbox", "residual risk"]
+      "all": ["not as production sandbox", "residual risk"]
     }
   ]
 }

--- a/evals/cases/U04-public-assurance-wording.json
+++ b/evals/cases/U04-public-assurance-wording.json
@@ -1,0 +1,28 @@
+{
+  "id": "U04",
+  "title": "Public assurance wording",
+  "artifact": "docs/03-worked-examples/skill-workflow-comparison/trial-records/public-assurance-wording.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    {
+      "name": "Separates source inspiration from satisfied requirements",
+      "any": ["public inspiration and concept lineage", "not satisfied requirements"]
+    },
+    {
+      "name": "Separates license permission from assurance",
+      "any": ["mit permission remains separate", "separate from fitness"]
+    },
+    {
+      "name": "Runs a self-check with a stop condition before the public claim",
+      "any": ["self-check:", "stop condition are named"]
+    },
+    {
+      "name": "Screens cross-document impact of the wording change",
+      "any": ["impact screen:", "readme, disclaimer, source-map"]
+    },
+    {
+      "name": "Conditions release on a prohibited-claim scan",
+      "any": ["prohibited-claim scan", "boundary-safe wording"]
+    }
+  ]
+}

--- a/evals/cases/U04-public-assurance-wording.json
+++ b/evals/cases/U04-public-assurance-wording.json
@@ -6,7 +6,7 @@
   "signals": [
     {
       "name": "Separates source inspiration from satisfied requirements",
-      "any": ["public inspiration and concept lineage", "not satisfied requirements"]
+      "all": ["public inspiration and concept lineage", "not satisfied requirements"]
     },
     {
       "name": "Separates license permission from assurance",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Runs a self-check with a stop condition before the public claim",
-      "any": ["self-check:", "stop condition are named"]
+      "all": ["self-check:", "stop condition are named"]
     },
     {
       "name": "Screens cross-document impact of the wording change",

--- a/evals/cases/U07-payment-webhook-idempotency.json
+++ b/evals/cases/U07-payment-webhook-idempotency.json
@@ -1,0 +1,28 @@
+{
+  "id": "U07",
+  "title": "Payment webhook idempotency",
+  "artifact": "docs/03-worked-examples/skill-workflow-comparison/trial-records/payment-webhook-idempotency.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    {
+      "name": "Escalates mode for money-moving consequence",
+      "any": ["mode: standard", "money-moving behavior is affected"]
+    },
+    {
+      "name": "Identifies money-side controlled items",
+      "any": ["idempotency store", "ledger/credit side effects"]
+    },
+    {
+      "name": "Bounds agent payment authority and credentials",
+      "any": ["may not use live credentials", "call production apis", "alter billing data"]
+    },
+    {
+      "name": "States adversarial proof claims (duplicate, partial failure, replay)",
+      "any": ["does not double-credit", "partial failure can retry", "invalid signature is denied"]
+    },
+    {
+      "name": "Conditions release on rollback, monitoring, and a risk owner",
+      "any": ["rollback path", "monitoring query", "residual risk owner"]
+    }
+  ]
+}

--- a/evals/cases/U07-payment-webhook-idempotency.json
+++ b/evals/cases/U07-payment-webhook-idempotency.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "Conditions release on rollback, monitoring, and a risk owner",
-      "any": ["rollback path", "monitoring query", "residual risk owner"]
+      "all": ["rollback path", "monitoring query", "residual risk owner"]
     }
   ]
 }

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -16,7 +16,7 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from nuclear_grade.efficacy import run_all as run_efficacy
-from nuclear_grade.ng_validate import detect_packet_mode, validate_packet
+from nuclear_grade.ng_validate import PLACEHOLDER_MARKER, detect_packet_mode, validate_packet
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = PACKAGE_DIR.parent
@@ -386,20 +386,28 @@ def packet_health(packet: Path) -> str:
     """Classify a packet for `status`: ok, scaffold (untouched draft), or invalid.
 
     A scaffold still carries the placeholder marker, so it is an unfilled draft
-    rather than a wrong one. Anything else that fails validation is invalid.
+    rather than a wrong one. Anything else that fails validation is invalid. The
+    scaffold test reads the actual marker from the packet files (not the
+    validator's message text) so it tracks behavior rather than wording.
     """
 
-    result = validate_packet(packet)
-    if result.ok:
+    if validate_packet(packet).ok:
         return "ok"
-    if any("placeholder marker" in message for message in result.messages):
-        return "scaffold"
+    for md_file in packet.glob("*.md"):
+        if PLACEHOLDER_MARKER in md_file.read_text(encoding="utf-8"):
+            return "scaffold"
     return "invalid"
 
 
 def handle_eval(args: argparse.Namespace) -> int:
     repo = args.repo.resolve()
-    results = run_efficacy(repo)
+    try:
+        results = run_efficacy(repo)
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        # ValueError covers json.JSONDecodeError; KeyError/TypeError cover a
+        # malformed case (missing "name", non-list "signals", and so on).
+        print(f"eval: could not load eval cases under {repo / 'evals' / 'cases'}: {error}")
+        return 1
     if not results:
         print(f"No eval cases found under {repo / 'evals' / 'cases'}.")
         return 0

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from nuclear_grade.efficacy import run_all as run_efficacy
 from nuclear_grade.ng_validate import detect_packet_mode, validate_packet
 
 PACKAGE_DIR = Path(__file__).resolve().parent
@@ -211,6 +212,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     migrate_parser.set_defaults(handler=handle_migrate)
 
+    eval_parser = subcommands.add_parser(
+        "eval",
+        help="Score worked-example artifacts for the decision signals they claim to teach.",
+    )
+    eval_parser.add_argument("repo", nargs="?", default=".", type=Path)
+    eval_parser.set_defaults(handler=handle_eval)
+
     return parser
 
 
@@ -387,6 +395,41 @@ def packet_health(packet: Path) -> str:
     if any("placeholder marker" in message for message in result.messages):
         return "scaffold"
     return "invalid"
+
+
+def handle_eval(args: argparse.Namespace) -> int:
+    repo = args.repo.resolve()
+    results = run_efficacy(repo)
+    if not results:
+        print(f"No eval cases found under {repo / 'evals' / 'cases'}.")
+        return 0
+
+    failures = 0
+    for result in results:
+        if not result.ok:
+            failures += 1
+        print(
+            f"{result.case.id} {result.case.title}: "
+            f"{result.present_count}/{result.total} signals [{result.status}]"
+        )
+        for signal in result.signals:
+            if not signal.present:
+                print(f"    - missing: {signal.name}")
+
+    total = sum(result.total for result in results)
+    present = sum(result.present_count for result in results)
+    print(
+        f"\nDecision-signal coverage: {present}/{total} across "
+        f"{len(results)} worked example(s)."
+    )
+    print(
+        "Coverage means the artifact names the decision element; it is not proof "
+        "the element is adequately handled, safe, secure, or compliant."
+    )
+    if failures:
+        print(f"{failures} case(s) missing required signals.")
+        return 1
+    return 0
 
 
 def apply_writes(writes: list[PlannedWrite], dry_run: bool, overwrite: bool) -> int:

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -358,9 +358,35 @@ def handle_status(args: argparse.Namespace) -> int:
         print("No active packets found.")
         return 0
 
+    needs_attention = 0
     for packet in packets:
-        print(f"{packet.name}: {detect_packet_mode(packet)}")
+        health = packet_health(packet)
+        if health != "ok":
+            needs_attention += 1
+        print(f"{packet.name}: {detect_packet_mode(packet)}  [{health}]")
+
+    if needs_attention:
+        print(
+            f"\n{needs_attention} packet(s) need attention. "
+            "A scaffold packet is an unfilled draft; an invalid packet fails validation. "
+            "Fill it, or close it with a rationale, or delete it -- do not leave it half-done."
+        )
     return 0
+
+
+def packet_health(packet: Path) -> str:
+    """Classify a packet for `status`: ok, scaffold (untouched draft), or invalid.
+
+    A scaffold still carries the placeholder marker, so it is an unfilled draft
+    rather than a wrong one. Anything else that fails validation is invalid.
+    """
+
+    result = validate_packet(packet)
+    if result.ok:
+        return "ok"
+    if any("placeholder marker" in message for message in result.messages):
+        return "scaffold"
+    return "invalid"
 
 
 def apply_writes(writes: list[PlannedWrite], dry_run: bool, overwrite: bool) -> int:

--- a/nuclear_grade/efficacy.py
+++ b/nuclear_grade/efficacy.py
@@ -31,14 +31,25 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Signal:
-    """A decision element, present when any of its phrasings appears in a section."""
+    """A decision element, scored by phrase presence in a section.
+
+    ``any_of`` passes when at least one phrasing appears: use it for genuine
+    alternatives (several ways to name the same element). ``all_of`` passes only
+    when every phrasing appears: use it for distinct conjunctive gates that must
+    all be present, for example a release decision that requires a rollback path
+    *and* a monitoring query *and* a named risk owner. When both are given, both
+    must hold.
+    """
 
     name: str
-    any_of: tuple[str, ...]
+    any_of: tuple[str, ...] = ()
+    all_of: tuple[str, ...] = ()
 
     def present_in(self, text: str) -> bool:
         lowered = text.lower()
-        return any(needle.lower() in lowered for needle in self.any_of)
+        any_ok = (not self.any_of) or any(needle.lower() in lowered for needle in self.any_of)
+        all_ok = all(needle.lower() in lowered for needle in self.all_of)
+        return any_ok and all_ok
 
 
 @dataclass(frozen=True)
@@ -91,7 +102,11 @@ def load_cases(cases_dir: Path) -> list[EvalCase]:
     for path in sorted(cases_dir.glob("*.json")):
         data = json.loads(path.read_text(encoding="utf-8"))
         signals = tuple(
-            Signal(name=signal["name"], any_of=tuple(signal["any"]))
+            Signal(
+                name=signal["name"],
+                any_of=tuple(signal.get("any", ())),
+                all_of=tuple(signal.get("all", ())),
+            )
             for signal in data["signals"]
         )
         cases.append(

--- a/nuclear_grade/efficacy.py
+++ b/nuclear_grade/efficacy.py
@@ -1,0 +1,146 @@
+"""Reproducible efficacy harness for Nuclear-grade worked examples.
+
+What this measures
+------------------
+Whether each worked-example artifact actually surfaces the decision signals the
+methodology claims it demonstrates. It is a transparent presence check over the
+real artifacts already in the repository, runnable by anyone, that guards the
+worked examples against silent drift.
+
+What this does NOT measure
+--------------------------
+Whether the underlying engineering is correct, safe, secure, compliant, or
+production-ready. Signals are authored from each scenario's stated risks. A
+present signal means the artifact *names* the decision element; it is not proof
+that the element is adequately handled in the real world. This harness is a
+reproducibility and regression aid, not an assurance, benchmark, or A/B proof.
+
+The qualitative simple-prompt-versus-Nuclear-grade comparison lives in
+``docs/03-worked-examples/skill-workflow-comparison/results-summary.md`` and is
+deliberately not mechanized here, because those author-written meta-sections
+describe gaps using the same vocabulary as the signals and cannot be scored by
+substring presence without inflating the result.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Signal:
+    """A decision element, present when any of its phrasings appears in a section."""
+
+    name: str
+    any_of: tuple[str, ...]
+
+    def present_in(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(needle.lower() in lowered for needle in self.any_of)
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    id: str
+    title: str
+    artifact: str  # repo-relative path to the artifact being scored
+    section: str  # exact heading whose body is scored, e.g. "## Nuclear-Grade Trial"
+    signals: tuple[Signal, ...]
+
+
+@dataclass(frozen=True)
+class SignalResult:
+    name: str
+    present: bool
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    case: EvalCase
+    artifact_found: bool
+    section_found: bool
+    signals: tuple[SignalResult, ...]
+
+    @property
+    def present_count(self) -> int:
+        return sum(1 for signal in self.signals if signal.present)
+
+    @property
+    def total(self) -> int:
+        return len(self.signals)
+
+    @property
+    def status(self) -> str:
+        if not self.artifact_found:
+            return "artifact-missing"
+        if not self.section_found:
+            return "section-missing"
+        if self.present_count == self.total:
+            return "ok"
+        return "incomplete"
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+
+def load_cases(cases_dir: Path) -> list[EvalCase]:
+    cases: list[EvalCase] = []
+    for path in sorted(cases_dir.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        signals = tuple(
+            Signal(name=signal["name"], any_of=tuple(signal["any"]))
+            for signal in data["signals"]
+        )
+        cases.append(
+            EvalCase(
+                id=data["id"],
+                title=data["title"],
+                artifact=data["artifact"],
+                section=data["section"],
+                signals=signals,
+            )
+        )
+    return cases
+
+
+def extract_section(text: str, heading: str) -> str | None:
+    """Return the body under an exact ``## Heading`` up to the next ``## `` heading."""
+
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start = index + 1
+            break
+    if start is None:
+        return None
+    body: list[str] = []
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def run_case(case: EvalCase, repo: Path) -> CaseResult:
+    artifact_path = repo / case.artifact
+    empty = tuple(SignalResult(signal.name, False) for signal in case.signals)
+    if not artifact_path.exists():
+        return CaseResult(case, artifact_found=False, section_found=False, signals=empty)
+    section = extract_section(artifact_path.read_text(encoding="utf-8"), case.section)
+    if section is None:
+        return CaseResult(case, artifact_found=True, section_found=False, signals=empty)
+    results = tuple(
+        SignalResult(signal.name, signal.present_in(section)) for signal in case.signals
+    )
+    return CaseResult(case, artifact_found=True, section_found=True, signals=results)
+
+
+def run_all(repo: Path, cases_dir: Path | None = None) -> list[CaseResult]:
+    cases_dir = cases_dir or (repo / "evals" / "cases")
+    if not cases_dir.exists():
+        return []
+    return [run_case(case, repo) for case in load_cases(cases_dir)]

--- a/templates/standard/verification.md
+++ b/templates/standard/verification.md
@@ -22,7 +22,7 @@
 
 ## Evidence status legend
 
-Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
 
 ## Claim-to-evidence table
 
@@ -86,7 +86,7 @@ Use if activated.
 
 ## Exit criteria
 
-- Each important claim has `pass`, `fail`, `gap`, `deferred`, or `not applicable` status.
+- Each important claim has `pass`, `fail`, `gap`, `deferred`, `not applicable`, or `planned` status.
 - Each important claim separates support type from verification type.
 - Evidence is linked rather than pasted in full.
 - Gaps are explicit and reflected in `ship.md`.

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from nuclear_grade import efficacy
 from tests.test_ng_cli import run_ng
 
@@ -86,21 +88,45 @@ def test_all_of_requires_every_phrase_unlike_any_of():
     assert conjunctive.present_in(text + " with a residual risk owner")
 
 
-def test_u07_release_gates_are_conjunctive():
-    case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == "U07")
-    gate_signal = next(s for s in case.signals if "rollback" in s.name.lower())
+# Signals whose phrases name complementary halves the methodology requires
+# together: dropping either half loses a distinct decision element, so these
+# must be conjunctive (`all`). A signal is identified by (case id, substring of
+# its name). When a new case adds a complementary signal, list it here so the
+# regression guard catches drift instead of leaving it to an external reviewer.
+# Signals whose phrases are redundant indicators of one element -- including the
+# by-design adversarial-claim signals where one denial proves "not just a happy
+# path" -- correctly stay `any` and are not listed.
+COMPLEMENTARY_SIGNALS = (
+    ("U07", "rollback"),  # rollback path AND monitoring query AND risk owner
+    ("U02", "authority"),  # allowed (may edit ... only) AND forbidden (may not broaden)
+    ("U02", "bounded release decision"),  # internal residual risk AND public non-claim
+    ("U04", "source inspiration"),  # what sources are for AND what they do not satisfy
+    ("U04", "self-check"),  # the self-check ran AND it named a stop condition
+)
 
-    assert gate_signal.all_of, "U07 release-gate signal should require all gates, not any"
+
+@pytest.mark.parametrize("case_id, name_substring", COMPLEMENTARY_SIGNALS)
+def test_complementary_signals_are_conjunctive(case_id, name_substring):
+    """Each complementary signal must require all its halves, so dropping one
+    half cannot still score as covered (the teeth-weakness Codex flagged)."""
+
+    case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == case_id)
+    signal = next(s for s in case.signals if name_substring in s.name.lower())
+
+    assert signal.all_of, (
+        f"{case_id} signal {signal.name!r} names complementary halves and must use "
+        f"`all`, not `any`, or dropping one half still reports full coverage"
+    )
+    assert not signal.any_of, (
+        f"{case_id} signal {signal.name!r} mixes `any` with `all`; a loose `any` "
+        f"alternative would let the signal pass without every required half"
+    )
 
 
-def test_u02_authority_boundary_requires_both_sides():
-    """A signal naming distinct elements ("allowed and forbidden") must be conjunctive,
-    so dropping the forbidden side cannot still score as covered."""
-
+def test_u02_authority_signal_has_no_leaky_generic_fallback():
     case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == "U02")
     authority = next(s for s in case.signals if "authority" in s.name.lower())
 
-    assert authority.all_of, "U02 authority signal should require allowed AND forbidden"
     assert "write authority" not in authority.all_of + authority.any_of, (
         "generic 'write authority' fallback leaks: it also appears in the controlled-items line"
     )

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -29,7 +29,9 @@ def test_cases_are_loadable_and_well_formed():
         assert case.section.startswith("## ")
         assert len(case.signals) >= 3
         for signal in case.signals:
-            assert signal.any_of, f"{case.id} signal {signal.name!r} has no phrasings"
+            assert signal.any_of or signal.all_of, (
+                f"{case.id} signal {signal.name!r} has no phrasings"
+            )
 
 
 def test_extract_section_returns_body_until_next_heading():
@@ -43,7 +45,7 @@ def test_extract_section_returns_body_until_next_heading():
 def test_harness_has_teeth_when_a_signal_is_dropped(tmp_path):
     """A tampered artifact that drops a signal must fail the case (exit 1)."""
 
-    case = efficacy.load_cases(CASES_DIR)[0]
+    case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == "U02")
     artifact = ROOT / case.artifact
     section = efficacy.extract_section(artifact.read_text(encoding="utf-8"), case.section)
     assert section is not None
@@ -67,8 +69,44 @@ def test_harness_has_teeth_when_a_signal_is_dropped(tmp_path):
     assert result.present_count == 0
 
 
+def test_all_of_requires_every_phrase_unlike_any_of():
+    text = "names a rollback path and a monitoring query"
+    conjunctive = efficacy.Signal(
+        name="release gates",
+        all_of=("rollback path", "monitoring query", "residual risk owner"),
+    )
+    alternative = efficacy.Signal(
+        name="release gates",
+        any_of=("rollback path", "monitoring query", "residual risk owner"),
+    )
+
+    # all_of fails because "residual risk owner" is missing; any_of still passes.
+    assert not conjunctive.present_in(text)
+    assert alternative.present_in(text)
+    assert conjunctive.present_in(text + " with a residual risk owner")
+
+
+def test_u07_release_gates_are_conjunctive():
+    case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == "U07")
+    gate_signal = next(s for s in case.signals if "rollback" in s.name.lower())
+
+    assert gate_signal.all_of, "U07 release-gate signal should require all gates, not any"
+
+
 def test_run_all_is_empty_outside_a_repo_with_cases(tmp_path):
     assert efficacy.run_all(tmp_path) == []
+
+
+def test_eval_command_reports_malformed_case_clearly(tmp_path):
+    cases_dir = tmp_path / "evals" / "cases"
+    cases_dir.mkdir(parents=True)
+    (cases_dir / "broken.json").write_text("{ not valid json", encoding="utf-8")
+
+    result = run_ng("eval", str(tmp_path))
+
+    assert result.returncode == 1
+    assert "could not load eval cases" in result.stdout
+    assert "Traceback" not in (result.stdout + result.stderr)
 
 
 def test_eval_command_reports_full_coverage():

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -93,6 +93,19 @@ def test_u07_release_gates_are_conjunctive():
     assert gate_signal.all_of, "U07 release-gate signal should require all gates, not any"
 
 
+def test_u02_authority_boundary_requires_both_sides():
+    """A signal naming distinct elements ("allowed and forbidden") must be conjunctive,
+    so dropping the forbidden side cannot still score as covered."""
+
+    case = next(c for c in efficacy.load_cases(CASES_DIR) if c.id == "U02")
+    authority = next(s for s in case.signals if "authority" in s.name.lower())
+
+    assert authority.all_of, "U02 authority signal should require allowed AND forbidden"
+    assert "write authority" not in authority.all_of + authority.any_of, (
+        "generic 'write authority' fallback leaks: it also appears in the controlled-items line"
+    )
+
+
 def test_run_all_is_empty_outside_a_repo_with_cases(tmp_path):
     assert efficacy.run_all(tmp_path) == []
 

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from nuclear_grade import efficacy
+from tests.test_ng_cli import run_ng
+
+ROOT = Path(__file__).resolve().parents[1]
+CASES_DIR = ROOT / "evals" / "cases"
+
+
+def test_real_worked_examples_surface_every_claimed_signal():
+    """Each shipped worked example must contain all the decision signals it claims."""
+
+    results = efficacy.run_all(ROOT)
+
+    assert results, "expected eval cases under evals/cases/"
+    for result in results:
+        assert result.artifact_found, f"{result.case.id} artifact missing: {result.case.artifact}"
+        assert result.section_found, f"{result.case.id} missing section {result.case.section!r}"
+        missing = [signal.name for signal in result.signals if not signal.present]
+        assert not missing, f"{result.case.id} dropped decision signals: {missing}"
+
+
+def test_cases_are_loadable_and_well_formed():
+    cases = efficacy.load_cases(CASES_DIR)
+
+    assert len(cases) >= 3
+    for case in cases:
+        assert case.id and case.title and case.artifact
+        assert case.section.startswith("## ")
+        assert len(case.signals) >= 3
+        for signal in case.signals:
+            assert signal.any_of, f"{case.id} signal {signal.name!r} has no phrasings"
+
+
+def test_extract_section_returns_body_until_next_heading():
+    text = "# Title\n\n## A\n\nalpha\n\n## B\n\nbeta\n"
+
+    assert "alpha" in efficacy.extract_section(text, "## A")
+    assert "beta" not in efficacy.extract_section(text, "## A")
+    assert efficacy.extract_section(text, "## Missing") is None
+
+
+def test_harness_has_teeth_when_a_signal_is_dropped(tmp_path):
+    """A tampered artifact that drops a signal must fail the case (exit 1)."""
+
+    case = efficacy.load_cases(CASES_DIR)[0]
+    artifact = ROOT / case.artifact
+    section = efficacy.extract_section(artifact.read_text(encoding="utf-8"), case.section)
+    assert section is not None
+
+    # Reproduce the repo layout under tmp_path, but strip the scored section body
+    # so every signal goes missing.
+    target = tmp_path / case.artifact
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tampered = artifact.read_text(encoding="utf-8").replace(section, "\n(content removed)\n")
+    target.write_text(tampered, encoding="utf-8")
+    (tmp_path / "evals" / "cases").mkdir(parents=True)
+    for json_path in CASES_DIR.glob("*.json"):
+        (tmp_path / "evals" / "cases" / json_path.name).write_text(
+            json_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    result = next(r for r in efficacy.run_all(tmp_path) if r.case.id == case.id)
+
+    assert not result.ok
+    assert result.status == "incomplete"
+    assert result.present_count == 0
+
+
+def test_run_all_is_empty_outside_a_repo_with_cases(tmp_path):
+    assert efficacy.run_all(tmp_path) == []
+
+
+def test_eval_command_reports_full_coverage():
+    result = run_ng("eval", str(ROOT))
+
+    assert result.returncode == 0, result.stderr
+    assert "Decision-signal coverage: 15/15" in result.stdout
+    assert "[ok]" in result.stdout
+
+
+def test_eval_command_is_graceful_without_cases(tmp_path):
+    result = run_ng("eval", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    assert "No eval cases found" in result.stdout

--- a/tests/test_ng_cli.py
+++ b/tests/test_ng_cli.py
@@ -292,6 +292,28 @@ def test_status_detects_active_packets(tmp_path):
     assert "demo: standard" in result.stdout
 
 
+def test_status_flags_unfilled_scaffold_packet(tmp_path):
+    shutil.copytree(ROOT / "templates", tmp_path / "templates")
+    (tmp_path / "nuclear-grade.yaml").write_text("name: test-catalog\n", encoding="utf-8")
+    assert run_ng("new", "draft", "--mode", "quick", "--repo", str(tmp_path)).returncode == 0
+
+    result = run_ng("status", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    assert "draft: quick  [scaffold]" in result.stdout
+    assert "need attention" in result.stdout
+
+
+def test_status_marks_filled_packet_ok(tmp_path):
+    minimal_quick_packet(tmp_path)
+
+    result = run_ng("status", str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    assert "quick-demo: quick  [ok]" in result.stdout
+    assert "need attention" not in result.stdout
+
+
 def test_new_cm_packet_scaffolds_all_cm_files(tmp_path):
     scaffold_repo(tmp_path)
 


### PR DESCRIPTION
## What this is

Three batches from a multi-perspective repo review, on the designated review branch. All low-risk and fully tested; each is recorded as its own dogfooded packet. Rebased onto main after #9 (doctrine spine) merged; conflicts in `QUICKSTART.md` and `templates/standard/verification.md` resolved (kept both #9's `Support type` exit criterion and this PR's `planned` status).

### Commit — Reproducible efficacy harness (`ng eval`) — headline
Addresses the review's biggest credibility gap: every efficacy claim was author-judged 1–5 with nothing runnable.

`python tools/ng.py eval .` reads each real trial-record artifact, isolates the `## Nuclear-Grade Trial` section, and verifies it still surfaces the decision signals the methodology claims it teaches. It **exits non-zero if a worked example drops a required signal** — a regression guard so the examples can't silently drift.

- `nuclear_grade/efficacy.py` — stdlib-only loader + scorer (**no new runtime dependency**; clean-venv wheel install verified). Supports `any` (interchangeable phrasings of one element) and `all` (complementary halves that must both appear).
- `evals/cases/*.json` — 3 scenario-grounded cases (U02, U04, U07)
- `eval` subcommand; `efficacy-harness.md` boundary doc
- `tests/test_efficacy.py` — behavior, a teeth test, and a parametrized guard pinning every complementary signal as conjunctive

**Review hardening (Codex/Copilot, all threads resolved):** the scorer originally used `any` everywhere, which let a multi-part signal pass on one phrase while the others were dropped. Re-audited all 15 signals; the five that name complementary halves (U07 release gates, U02 authority + release non-claim, U04 source-lineage + self-check) are now `all`, guarded by a parametrized test. Also: `packet_health` reads the marker constant not validator message text; `handle_eval` reports malformed cases cleanly instead of a traceback.

**Honesty boundary (deliberate non-goal):** the simple-prompt-vs-Nuclear-grade score table is **not** mechanized — author-written gap prose shares the signals' vocabulary, so substring scoring would inflate it. The harness measures presence of named decision elements, not correctness/safety/compliance.

### Commit — `ng status` packet health tags
`status` tags each packet `ok` / `scaffold` (untouched draft) / `invalid`, with an attention reminder, so abandoned half-filled drafts are visible.

### Commit — Visual + readability (additive docs, no logic change)
4 render-checked Mermaid diagrams (`docs/diagrams.md`), `docs/glossary.md`, `docs/02-operating-system/agent-threat-model.md`, the skill-graph router fix naming `using-nuclear-grade` as the front door, and two small wins.

## Verification
- `python -m pytest -q` — **93 pass**
- `ruff check .` — clean
- `python tools/ng.py doctor .` — OK
- `python tools/ng.py eval .` — 15/15 decision signals across 3 worked examples
- Clean-venv wheel build + install verified

## Dropped after scrutiny
The "progressive disclosure" token refactor was dropped: always-loaded cost is the skill descriptions (~1.6k tokens, already lean), not the bodies; the proposed move was a negative trade.

## Still planned (separate PR)
The `closing-stale-packets` skill that pairs with the `status` change.

https://claude.ai/code/session_013dbxsS9GsD5oijEJQ5mYzW