### PR TITLE
Add doctrine spine controls

### DIFF
--- a/.nuclear/changes/doctrine-spine-influence/baseline.md
+++ b/.nuclear/changes/doctrine-spine-influence/baseline.md
@@ -1,0 +1,57 @@
+# Baseline Record
+
+**Purpose:** Record the accepted controlled configuration state after review.
+
+**Activation threshold:** Use because trust-bearing public docs, skills, command prompts, templates, evaluation prompts, and source-boundary posture change.
+
+**Minimum useful version:** Baseline identity, included controlled items, evidence links, accepted gaps, and re-baseline triggers.
+
+**Overhead trap:** This baseline records accepted state and what would make it stale; it is not a changelog.
+
+---
+
+## Baseline identity
+
+- Baseline name: doctrine-spine-influence
+- Commit / PR / release / artifact: forthcoming commit and PR
+- Owner: FlyFission
+- Date: 2026-05-30
+- Related packet: `.nuclear/changes/doctrine-spine-influence/`
+
+## Included controlled items
+
+| Item | Accepted state | Evidence link | Residual gap | Revalidation trigger |
+|---|---|---|---|---|
+| Charter and public docs | Accepted after tests, doctor, boundary scan, and PR review | `verification.md` | Semantic quality remains review-based | Future public doctrine edit |
+| Skills and commands | Accepted after contract tests and manual trigger review | `verification.md` | No automated semantic trigger quality beyond existing tests | Future skill/command edit |
+| Standard templates | Accepted after packet validation and manual review | `verification.md` | Validator does not enforce every new semantic prompt | Future template edit or OPEX |
+| OPEX/control update | Accepted when durable updates are present | `opex.md` | none | Repeated shallow influence mapping |
+
+## Exclusions
+
+| Item or claim excluded | Why excluded | Follow-up / trigger |
+|---|---|---|
+| CLI behavior and validator rules | Plan excludes behavior changes unless tests require them | Future repeated OPEX or explicit request |
+| Quotes, attributions, new source lineage | User requested influence only, not public quotes | Explicit user request and source/legal check |
+| Dependency/model/API trust | No external trust-bearing item changes | Future dependency/model/API change |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- `controlled-items.md`
+- `change-impact.md`
+
+## Exit criteria
+
+- Baseline identity is reproducible.
+- Included and excluded items are explicit.
+- Accepted gaps have owners or triggers.
+- Future revalidation/re-baseline triggers are named.
+
+## Source-lineage note
+
+Original Nuclear-grade baseline record inspired by public configuration-management, lifecycle, release-readiness, and operating-learning sources mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/basis.md
+++ b/.nuclear/changes/doctrine-spine-influence/basis.md
@@ -1,0 +1,102 @@
+# Standard Basis Record
+
+**Purpose:** State what must remain true while translating owner-supplied influences into Nuclear-grade controls.
+
+**Activation threshold:** Use because public docs, skills, commands, templates, and adoption surfaces need an explicit design basis.
+
+**Minimum useful version:** Mission, protected outcomes, unacceptable outcomes, assumptions, constraints, influence mapping, and evidence needs.
+
+**Overhead trap:** Do not convert influence into a doctrine essay. Capture only the controls needed for users, agents, and reviewers.
+
+---
+
+## Change context
+
+- Slug: doctrine-spine-influence
+- Related risk record: `risk.md`
+- Owner: FlyFission
+- Date: 2026-05-30
+- Decision this basis supports: Accept or block the doctrine-spine update for public workflow artifacts.
+
+## Mission / need
+
+Nuclear-grade needs a tighter control spine: question the decision first, make instructions hard to misuse, keep small work aligned to mission, ground claims in evidence, let agents build candidates quickly, and slow acceptance before claims, baselines, and releases.
+
+## Protected outcomes
+
+| Protected outcome | Why it matters | Evidence needed |
+|---|---|---|
+| End users can still start quickly | Doctrine that slows every action would undermine adoption | Quickstart review and public-doc tests |
+| Downstream agents receive operational instructions | Agent behavior is driven by skill descriptions, command cards, and templates | Skill/command contract tests and manual trigger review |
+| Claims remain grounded | Public methodology must not confuse influence, source claim, local proof, or authority | Boundary scan and updated proving/source language |
+| Acceptance gates remain deliberate | Fast candidate work must not become accepted configuration without evidence | Ship and baseline records |
+
+## Unacceptable outcomes
+
+| Unacceptable outcome | Consequence | Prevent / detect / mitigate |
+|---|---|---|
+| Quotes or named attributions appear in public artifacts | Creates source and attribution burden outside the chosen scope | Quote-exclusion scan |
+| Inspirational wording replaces controls | Users and agents get prose without behavior change | Change-impact review across docs, skills, commands, templates |
+| Every edit becomes slow | End users abandon the workflow as ceremony | Activation-threshold and Quickstart language preserve Quick mode |
+| Subjective confidence is treated as proof | Release decisions become persuasion again | Claim-to-evidence and fact/source separation updates |
+| Public language implies assurance | Legal/trust boundary weakens | Doctor and prohibited-claim scans |
+
+## Assumptions, constraints, and invalidation triggers
+
+| Assumption / constraint | Fact / assumption / unknown | Basis or source | Invalidation trigger | Owner |
+|---|---|---|---|---|
+| Existing docs are the chosen surface | fact | User selected existing-docs approach | User requests a new doctrine page | FlyFission |
+| No quotes or named attributions | fact | User direction and approved plan | User explicitly requests quoted material | FlyFission |
+| Existing test contracts should remain enough | assumption | Current plan excludes validator changes | Tests cannot detect an unsafe required behavior | FlyFission |
+| This is a public workflow-control update | fact | Risk screen | Scope expands to code, dependency, model, API, or release automation | FlyFission |
+
+## Interfaces and trust boundaries
+
+- Internal interfaces affected: skill contracts, command card contracts, Standard template fields, public docs, adoption docs, evaluation prompts.
+- External services/APIs affected: none.
+- Data classes affected: none.
+- Human approval boundaries: PR review and requested Copilot review before merge.
+- AI/model/tool authority boundaries: agent-facing instructions change; no new tool permissions are granted.
+
+## Dependency / model / supplier intended use
+
+Not activated. No dependency, model, API, SaaS, generated artifact, vendor claim, credential, or network authority changes.
+
+## Doctrine influence mapping
+
+| Control | Software translation | Artifact surface | Evidence planned |
+|---|---|---|---|
+| Decision-question discipline | Start by naming the decision and evidence that would change it | risk, lifecycle, questioning skill, classify command | Review and contract tests |
+| Operational unambiguity | Instructions should be hard to misuse under pressure | skills, commands, templates | Skill/command contract tests |
+| Mission-aligned small work | Local actions must serve objective and non-goals | charter, drift skill, risk/plan templates | Manual review |
+| Grounded truth | Separate fact, assumption, unknown, source claim, local proof, and authority | basis, proving skill, verification templates | Boundary scan and tests |
+| Two-speed control | Build candidates quickly; audit acceptance slowly | lifecycle, thresholds, Quickstart, ship template | Public-doc review |
+| Cut-point self-checking | Measure exact target before critical or trust-bearing action | self-check skill/command, HPI overlays | Manual review |
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Basis | Design feature or control | Evidence planned |
+|---|---|---|---|---|
+| C-001 | Public docs express the control stack without quotes or new attributions | Owner direction | Existing-doc updates plus boundary scan | `verification.md` |
+| C-002 | Downstream-agent surfaces are harder to misuse | Agent-facing need | Skill, command, template, and evaluation updates | Contract tests and manual review |
+| C-003 | The workflow preserves fast exploration and slow acceptance | Adoption constraint | Quickstart, thresholds, lifecycle, ship/baseline edits | Public-doc review |
+| C-004 | The review surprise becomes a durable control update | OPEX principle | `opex.md` and affected surfaces | Packet validation |
+
+## Required links
+
+- Risk record: `risk.md`
+- Verification record: `verification.md`
+- Ship record: `ship.md`
+- Product requirement / issue / ADR / design doc: user-approved plan in conversation
+- Source lineage, if cited: existing notes map to `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Builder and reviewer can answer "what must remain true?"
+- Protected and unacceptable outcomes are explicit.
+- Important assumptions have invalidation triggers.
+- Evidence needs flow into `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade basis record inspired by public design-basis, safety-in-design, design-description, hazard/failure-analysis, AI-risk, and supply-chain-risk concepts mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/basis.md
+++ b/.nuclear/changes/doctrine-spine-influence/basis.md
@@ -50,6 +50,18 @@ Nuclear-grade needs a tighter control spine: question the decision first, make i
 | Existing test contracts should remain enough | assumption | Current plan excludes validator changes | Tests cannot detect an unsafe required behavior | FlyFission |
 | This is a public workflow-control update | fact | Risk screen | Scope expands to code, dependency, model, API, or release automation | FlyFission |
 
+## Grounding status
+
+Separate confidence from evidence before derived claims are accepted.
+
+| Statement | Fact / assumption / unknown / source claim / local proof / decision authority | Evidence or source | Decision impact |
+|---|---|---|---|
+| Existing docs are the chosen surface | fact | User selected existing-docs approach | Controls are added to existing artifacts, not a new page |
+| No quotes or named attributions should be added | fact | User direction and approved plan | Boundary scan and packet wording must preserve this |
+| Contract tests cover agent-facing structural regressions | local proof | `tests/test_skill_contracts.py` and `tests/test_command_contracts.py` | Passing tests support PR acceptance |
+| Semantic quality of doctrine wording is partly review-based | assumption | `ship.md` residual risk | PR/Copilot review and future OPEX remain acceptance controls |
+| PR review can block acceptance | decision authority | `ship.md` | Actionable review feedback must be addressed or explicitly dispositioned |
+
 ## Interfaces and trust boundaries
 
 - Internal interfaces affected: skill contracts, command card contracts, Standard template fields, public docs, adoption docs, evaluation prompts.

--- a/.nuclear/changes/doctrine-spine-influence/change-impact.md
+++ b/.nuclear/changes/doctrine-spine-influence/change-impact.md
@@ -1,0 +1,55 @@
+# Change Impact Record
+
+**Purpose:** Screen downstream artifacts that may become stale when the doctrine-spine controls change.
+
+**Activation threshold:** Use because this change affects multiple artifact families and could stale public docs, skills, commands, templates, evaluation prompts, and release posture.
+
+**Minimum useful version:** Impacted artifact family, required update, evidence, owner, and disposition.
+
+**Overhead trap:** Only record impacts that could change review, adoption, agent behavior, or release decisions.
+
+---
+
+## Change context
+
+- Slug: doctrine-spine-influence
+- Related packet: `.nuclear/changes/doctrine-spine-influence/`
+- Owner: FlyFission
+- Date: 2026-05-30
+
+## Impact screen
+
+| Artifact family | Impact | Required action | Evidence / link | Disposition | Owner |
+|---|---|---|---|---|---|
+| Docs/public claims | Public doctrine and adoption wording changes | update | `verification.md` | planned | FlyFission |
+| Tests/evals/validator | Contract/public tests must still pass; no validator changes planned | update evaluation prompts; no-op validator | `verification.md` | planned | FlyFission |
+| Skills/commands/templates | Agent-operable surfaces must reflect control stack | update | `verification.md` | planned | FlyFission |
+| Dependencies/models/tools | No trust-bearing external item changes | no-op | `basis.md` | not applicable | FlyFission |
+| Release/operate/support | Baseline and PR review posture changes | update | `ship.md`, `baseline.md` | planned | FlyFission |
+
+## Revalidation triggers
+
+| Trigger | What must be rerun or reviewed | Owner |
+|---|---|---|
+| Skill or command wording changes | Skill/command contract tests and evaluation prompt review | FlyFission |
+| Public docs or templates change | Public-doc tests, doctor, boundary scan | FlyFission |
+| New source lineage, quote, or attribution is proposed | Source/legal check and source-map decision | FlyFission |
+| Validator or CLI behavior change is proposed | Full validator/CLI tests and packet update | FlyFission |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `controlled-items.md`
+- `verification.md`
+- `ship.md`
+
+## Exit criteria
+
+- Impacted artifact families are updated, deferred with owner, or explicitly not applicable.
+- Revalidation triggers are visible.
+- No stale public claim or validator behavior is silently accepted.
+
+## Source-lineage note
+
+Original Nuclear-grade CM record inspired by public configuration-management, secure-development, lifecycle, and release-readiness sources mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/controlled-items.md
+++ b/.nuclear/changes/doctrine-spine-influence/controlled-items.md
@@ -1,0 +1,48 @@
+# Controlled Items Record
+
+**Purpose:** Name the configuration items affected by this doctrine-spine change and why their state matters.
+
+**Activation threshold:** Use because this change affects public docs, skills, command prompts, templates, evaluation prompts, and baseline records.
+
+**Minimum useful version:** Controlled item, current state, intended state, owner, evidence link, and revalidation trigger.
+
+**Overhead trap:** Do not inventory the whole repo. List only trust-bearing artifact families affected by this change.
+
+---
+
+## Change context
+
+- Slug: doctrine-spine-influence
+- Related packet: `.nuclear/changes/doctrine-spine-influence/`
+- Owner: FlyFission
+- Date: 2026-05-30
+
+## Controlled item table
+
+| Item | Type | Current state | Intended state | Why controlled | Owner | Evidence / link | Revalidation trigger |
+|---|---|---|---|---|---|---|---|
+| `.nuclear/charter.md` | charter | Existing 1.0.0 articles | 1.1.0 with doctrine-spine articles | Durable principles guide all changes | FlyFission | `verification.md` | Charter amendment |
+| README / WORKFLOWS / QUICKSTART | public docs | Teach lifecycle and quick adoption | Teach control stack without quotes or ceremony | End-user first-contact surface | FlyFission | `verification.md` | Public wording update |
+| Operating-system docs | public docs | Lifecycle, HPI, thresholds, evidence spine | Preserve fast build and slow acceptance controls | Core workflow doctrine | FlyFission | `verification.md` | Workflow phase change |
+| Adoption docs | public docs | Reviewer and authority guidance | Add end-user and downstream-agent review challenges | Team rollout and agent authority expectations | FlyFission | `verification.md` | Adoption guidance update |
+| Selected skills | agent instructions | Existing trigger/process wording | Harder-to-misuse decision, evidence, drift, and acceptance controls | Downstream agent behavior | FlyFission | `verification.md` | Skill contract update |
+| Selected commands | portable prompts | Existing pasteable prompt cards | Prompt outputs reflect control stack | Portable agent behavior | FlyFission | `verification.md` | Command prompt update |
+| Standard templates | packet interface | Existing Standard packet prompts | Capture decision question, fact/source status, and audit gates | User evidence records | FlyFission | `verification.md` | Template update |
+| Skill evaluation prompts | test/reference | Existing trigger prompt bank | Add prompts for wrong-question, ambiguity, premature acceptance, drift | Future skill quality review | FlyFission | `verification.md` | Skill behavior review |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `change-impact.md`
+- `baseline.md`
+
+## Exit criteria
+
+- Each item has a reason for control.
+- Each item has an evidence link or explicit gap.
+- Revalidation triggers are named for trust-bearing items.
+
+## Source-lineage note
+
+Original Nuclear-grade CM record inspired by public configuration-management and software assurance sources mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/opex.md
+++ b/.nuclear/changes/doctrine-spine-influence/opex.md
@@ -1,0 +1,43 @@
+# OPEX Record
+
+**Purpose:** Convert the review surprise from this thread into durable workflow updates.
+
+**Activation threshold:** Use because the user identified a shallow influence-to-control mapping that should affect future docs, skills, commands, templates, and evaluation prompts.
+
+**Minimum useful version:** Event, impact, evidence, weak or missing control, corrective action, verification, and baseline/update disposition.
+
+**Overhead trap:** The lesson must update durable controls, not remain a chat apology.
+
+---
+
+## Event
+
+- Date: 2026-05-30
+- Source: User adversarial review
+- Affected baseline: public workflow-control doctrine before this branch
+- Summary: Initial planning treated the owner-supplied influences too much like content placement and missed the direct tie between question-framing influence and Nuclear-grade questioning attitude.
+
+## Learning and action
+
+| Finding | Weak or missing control | Impact | Action | Verification | Owner | Due / trigger |
+|---|---|---|---|---|---|---|
+| Influence-to-control mapping was too shallow | No explicit doctrine-spine mapping from influence to user/agent controls | Could create inspirational prose without behavior change | update docs / template / skill / command / baseline | packet validation, tests, boundary scans, PR review | FlyFission | this change |
+| Questioning attitude was underweighted | Decision-question discipline was not explicit enough across surfaces | Agents could ask generic questions instead of framing the decision | update skill / command / risk template / Quickstart | contract tests and manual review | FlyFission | this change |
+| End-user and downstream-agent perspectives needed earlier review | Plan focused on maintainer doctrine first | Could increase ceremony or miss trigger surfaces | update adoption docs and skill-evaluation prompts | public-doc tests and manual review | FlyFission | this change |
+
+## Required links
+
+- Baseline record: `baseline.md`
+- Related packet / issue / incident: `.nuclear/changes/doctrine-spine-influence/`
+- Verification evidence: `verification.md`
+
+## Exit criteria
+
+- Each finding has an action or explicit closure.
+- Closure without durable update explains why no basis, test, validator, template, skill, command, monitor, doc, or baseline change is warranted.
+- Any re-baseline trigger is recorded.
+- Future reviewers can see what changed because of the lesson.
+
+## Source-lineage note
+
+Original Nuclear-grade OPEX record inspired by public operating-experience, corrective-action, lifecycle, and configuration-management sources mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/plan.md
+++ b/.nuclear/changes/doctrine-spine-influence/plan.md
@@ -1,0 +1,135 @@
+# Standard Plan Record
+
+**Purpose:** Bound the doctrine-spine update so implementation, review, verification, and rollback remain linked.
+
+**Activation threshold:** Use because this change touches multiple controlled artifact families and public agent-facing behavior.
+
+**Minimum useful version:** Build sequence, affected files/assets, non-goals, review checkpoints, rollback approach, and proof commands.
+
+**Overhead trap:** Do not turn the plan into a source essay. Keep it tied to controls and evidence.
+
+---
+
+## Change context
+
+- Slug: doctrine-spine-influence
+- Related risk record: `risk.md`
+- Related basis record: `basis.md`
+- Owner: FlyFission
+- Date: 2026-05-30
+- Current lifecycle phase: Execute
+
+## Charter and anchor check
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes
+- Re-checked before Verify? planned
+- Charter articles in play: questioning attitude, evidence over persuasion, graded rigor, baseline discipline, plus new doctrine-spine articles.
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | not applicable | not applicable | not applicable |
+
+## Two-speed work plan
+
+| Phase | Allowed speed | Gate |
+|---|---|---|
+| Explore / candidate | Fast edits to controlled docs and prompts | Keep scope tied to control stack and non-goals |
+| Audit / accept | Slow review of claims, tests, scans, packet, and baseline | Do not ship until evidence links match claims |
+
+## Build sequence
+
+1. Fill the Standard packet and activated CM/OPEX/baseline records.
+2. Update charter and operating docs.
+3. Update end-user adoption surfaces.
+4. Update downstream-agent skills and command cards.
+5. Update Standard templates and skill-evaluation prompts.
+6. Run validation, contract tests, public-doc tests, doctor, and boundary scans.
+7. Update verification, ship, and baseline records with results.
+8. Commit, push, open PR, request/inspect Copilot review, and address actionable feedback.
+
+## HPI task preview
+
+| Critical step | Likely error | Consequence | Control / contingency | Evidence |
+|---|---|---|---|---|
+| Public wording update | Accidental quote, attribution, or assurance claim | Source/legal boundary drift | Quote-exclusion and prohibited-claim scan | `verification.md` |
+| Skill/command description change | Contract violation | Downstream agent trigger breakage | Run skill/command contract tests | `verification.md` |
+| Template update | New prompt bloat slows users | Adoption friction | Manual Quickstart/template review | `ship.md` |
+| PR publication | Unverified public claim | Review trust loss | Validate before commit/push | `verification.md` |
+
+## Agent briefing
+
+- Role: builder/verifier for public workflow-control update
+- Authority source: user-approved implementation plan
+- Active procedure/template: Standard packet plus CM/OPEX records
+- Last completed action if resumed: packet scaffolded
+- Handoff or turnover needed? no
+- Pause when unsure condition: any need for quotes, new source lineage, validator behavior, dependency/model trust, or broader release posture.
+
+## Affected files and assets
+
+| File / asset | Change expected | Why it matters | Owner |
+|---|---|---|---|
+| `.nuclear/charter.md` and packet files | Doctrine and evidence record | Controlled workflow state | FlyFission |
+| README, WORKFLOWS, QUICKSTART, operating docs | User-facing doctrine | Adoption and expectations | FlyFission |
+| Selected skills and commands | Agent-facing controls | Downstream execution behavior | FlyFission |
+| Standard templates and evaluation prompts | Packet interface and trigger tests | Future user/agent behavior | FlyFission |
+
+## Non-goals
+
+- Add public quotes or named attributions.
+- Add a new public doctrine page.
+- Change CLI behavior or validator rules.
+- Add dependencies, models, API integrations, or release automation.
+
+## Dependency / model / tool decisions
+
+Not activated. No dependency/model/tool change.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Specification reviewed | Protected/unacceptable outcomes and assumptions are explicit. | pass |
+| Tests/evals defined | Evidence maps to claims. | pass |
+| Build complete | Affected files match plan. | planned |
+| Verification complete | Evidence is linked in `verification.md`. | planned |
+| Release decision ready | Residual risks and rollback are recorded. | planned |
+| PR review complete | Copilot/actionable review feedback is addressed or recorded. | planned |
+
+## Rollback approach
+
+- Rollback method: revert the PR/commit.
+- State/data reversal notes: no data or external state changes.
+- Feature flag / kill switch: not applicable.
+- Owner: FlyFission.
+- Time to restore estimate: one revert.
+
+## Proof commands
+
+```bash
+python3 tools/ng.py validate .nuclear/changes/doctrine-spine-influence
+python3 -m pytest tests/test_public_docs.py tests/test_skill_contracts.py tests/test_command_contracts.py tests/test_ng_validate.py -q
+python3 tools/ng.py doctor .
+rg -n "quote|quotation|formal|certified|approval|compliant|regulatory adequacy|safe|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence
+# Also run a local attribution-name scan for the owner-supplied names without adding those names to tracked artifacts.
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Issue / PR / ADR / design doc: forthcoming PR
+
+## Exit criteria
+
+- Work is bounded enough to prevent scope creep.
+- Review checkpoints are explicit.
+- Rollback/restore thinking exists before release.
+- Proof commands or checks are ready for `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade plan record inspired by public lifecycle, configuration-management, software assurance, secure-development, release-readiness, and operating-learning sources mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/plan.md
+++ b/.nuclear/changes/doctrine-spine-influence/plan.md
@@ -31,10 +31,12 @@
 
 ## Two-speed work plan
 
-| Phase | Allowed speed | Gate |
+| Work phase | Allowed actions | Acceptance gate |
 |---|---|---|
-| Explore / candidate | Fast edits to controlled docs and prompts | Keep scope tied to control stack and non-goals |
-| Audit / accept | Slow review of claims, tests, scans, packet, and baseline | Do not ship until evidence links match claims |
+| explore | Read current docs, skills, commands, templates, and tests | No file acceptance; use findings to shape the packet |
+| candidate | Edit controlled docs, skills, commands, templates, and packet records | Keep scope tied to control stack and non-goals |
+| audit | Run validation, tests, doctor, boundary scans, and PR review | Address actionable findings before acceptance |
+| accept | Commit, push, and request PR/Copilot review | Do not merge until CI and actionable review feedback are clean |
 
 ## Build sequence
 

--- a/.nuclear/changes/doctrine-spine-influence/risk.md
+++ b/.nuclear/changes/doctrine-spine-influence/risk.md
@@ -1,0 +1,112 @@
+# Standard Risk Record
+
+**Purpose:** Classify the doctrine-spine influence update and name the controls needed before public workflow artifacts are accepted.
+
+**Activation threshold:** Standard mode is required because the change affects public docs, skills, command prompts, templates, and baseline expectations for downstream agents.
+
+**Minimum useful version:** Decision question, mission anchor, affected controlled items, threshold screen, activated artifacts, and evidence obligations.
+
+**Overhead trap:** Do not turn the influence into inspirational copy. Only add controls that improve decisions, evidence, or agent operation.
+
+---
+
+## Change identity
+
+- Slug: doctrine-spine-influence
+- PR / issue: branch `add-quotes-and-influence`
+- Owner: FlyFission
+- Date: 2026-05-30
+- Current lifecycle phase: Execute
+- Summary: Convert owner-supplied operating influences into existing Nuclear-grade control surfaces without adding quotes, attribution, or a new doctrine page.
+
+## Mission anchor
+
+- Objective: Make Nuclear-grade harder to misuse by end users and downstream agents while preserving fast candidate work and slow acceptance gates.
+- Success criteria: Existing docs, skills, command prompts, and Standard templates express the control stack; Quickstart remains usable; public wording does not add quotes or new assurance claims; validation and contract tests pass.
+- Non-goals / forbidden directions: No verbatim quotes, named quote attributions, new manifesto page, compliance claim, safety claim, security claim, certification claim, formal assurance claim, legal advice, CLI behavior change, or validator rule change.
+- Drift check: re-anchor when an edit does not improve a decision, evidence path, agent trigger, or acceptance gate; escalate before broadening to unrelated docs.
+- Traces to: `.nuclear/charter.md`, `WORKFLOWS.md`, and the user-approved implementation plan.
+
+## Questioning-attitude summary
+
+- Decision question: How should these influences change Nuclear-grade's controls so users and downstream agents make better decisions without adding ceremony?
+- Assumptions that changed the mode: Public workflow wording, skill triggers, command prompts, and templates are controlled items; a shallow doctrine update would be misleading; the prior review surprise warrants OPEX.
+- Facts still needing validation: Contract tests continue to pass after description and prompt changes; public boundary scans find no quote insertion or unsafe claims.
+- Stop or hold conditions: Stop if a change requires quote attribution, new public source lineage, validator behavior, dependency/model trust review, or a new public doctrine page.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| Charter and operating docs | Public doctrine | Define how all changes should be carried out | `controlled-items.md` |
+| Skills and command prompts | Agent-operable instructions | Downstream agents discover behavior through triggers and prompt cards | `controlled-items.md` |
+| Standard templates | Packet interface | Users encode the control stack through these fields | `controlled-items.md` |
+| Adoption and evaluation docs | User/agent adoption | Shape end-user rollout and future skill assessment | `controlled-items.md` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Public methodology and agent behavior surfaces change. |
+| Reversibility | medium | Text changes can be reverted, but public workflow drift affects users. |
+| Detectability | medium | Misuse may appear later as bad packets or shallow agent behavior. |
+| Exposure | medium | Public docs, skills, and command prompts are end-user surfaces. |
+| Uncertainty | medium | The influence must be translated into controls without overfitting. |
+| Dependency trust | low | No dependency, model, API, SaaS, or vendor trust change. |
+| AI authority | medium | Agent-facing instructions and command prompts change. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine/repetitive action where inattention is plausible | yes | self-check for public claims and exact target files |
+| Known procedure where workflow adherence matters | yes | Standard packet plus CM records |
+| Novel or uncertain work where assumptions may be wrong | yes | questioning attitude and adversarial review |
+| Interrupted, resumed, or handed-off work | yes | packet state and PR evidence |
+| High-consequence critical action | no | no release or external-state action before PR review |
+
+## Selected mode
+
+- Mode: Standard
+- Why this mode: The change affects durable public workflow controls and agent-operable artifacts.
+- Why lighter mode is not enough: Quick proof cannot show downstream skill, command, template, adoption, OPEX, and boundary impacts.
+- Why heavier mode is not yet required: No code behavior, release automation, dependency/model trust, credentials, data, or production state changes.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Compact summary in this risk record is enough. | FlyFission |
+| `basis.md` | yes | Needs protected outcomes and grounded influence mapping. | FlyFission |
+| `verification.md` | yes | Public/contract tests and boundary scans must be recorded. | FlyFission |
+| `ship.md` | yes | Acceptance and baseline posture must be explicit. | FlyFission |
+| `turnover.md` | no | Same owner/agent continues in-thread. | FlyFission |
+| `self-check.md` | no | Critical claim checks are embedded in verification and ship records. | FlyFission |
+| `supplier-trust.md` | no | No external dependency, model, API, or vendor trust decision. | FlyFission |
+| CM records | yes | Controlled items, change impact, OPEX, and baseline are activated. | FlyFission |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: confirm affected files and non-goals; record OPEX and controlled items.
+- Minimum evidence before merge/release: packet validation, public-doc tests, skill/command contract tests, validator tests, doctor output, quote-exclusion and boundary scan.
+- Independent review needed? yes; PR review/Copilot review is requested because the change affects public agent behavior.
+
+## Required links
+
+- Packet: `.nuclear/changes/doctrine-spine-influence/`
+- `basis.md`
+- `controlled-items.md`
+- `change-impact.md`
+- `verification.md`
+- `ship.md`
+- Source-map/crosswalk references if source lineage is invoked: existing source-lineage notes only; no new direct source lineage added.
+
+## Exit criteria
+
+- Mode is justified.
+- Activated artifacts are explicit.
+- Important risks, assumptions, and evidence obligations are not hidden in chat or commit messages.
+
+## Source-lineage note
+
+Original Nuclear-grade packet record inspired by public graded quality, configuration management, lifecycle, software assurance, secure development, AI risk, and supply-chain sources mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/risk.md
+++ b/.nuclear/changes/doctrine-spine-influence/risk.md
@@ -80,6 +80,8 @@
 |---|---|---|---|
 | `questioning-attitude.md` | no | Compact summary in this risk record is enough. | FlyFission |
 | `basis.md` | yes | Needs protected outcomes and grounded influence mapping. | FlyFission |
+| `plan.md` | yes | Multi-surface public and agent-facing changes need sequenced work, checkpoints, and rollback. | FlyFission |
+| `trace.md` | yes | Doctrine-spine claims need links from basis to controls, verification, and ship posture. | FlyFission |
 | `verification.md` | yes | Public/contract tests and boundary scans must be recorded. | FlyFission |
 | `ship.md` | yes | Acceptance and baseline posture must be explicit. | FlyFission |
 | `turnover.md` | no | Same owner/agent continues in-thread. | FlyFission |

--- a/.nuclear/changes/doctrine-spine-influence/risk.md
+++ b/.nuclear/changes/doctrine-spine-influence/risk.md
@@ -17,6 +17,7 @@
 - Owner: FlyFission
 - Date: 2026-05-30
 - Current lifecycle phase: Execute
+- Current work phase: audit
 - Summary: Convert owner-supplied operating influences into existing Nuclear-grade control surfaces without adding quotes, attribution, or a new doctrine page.
 
 ## Mission anchor
@@ -30,6 +31,7 @@
 ## Questioning-attitude summary
 
 - Decision question: How should these influences change Nuclear-grade's controls so users and downstream agents make better decisions without adding ceremony?
+- Evidence that would change the decision: tests fail, public wording inserts quotes or named attributions, agent-facing contracts break, reviewers find that fast exploration is slowed without acceptance value, or Copilot/human review finds unaddressed template drift.
 - Assumptions that changed the mode: Public workflow wording, skill triggers, command prompts, and templates are controlled items; a shallow doctrine update would be misleading; the prior review surprise warrants OPEX.
 - Facts still needing validation: Contract tests continue to pass after description and prompt changes; public boundary scans find no quote insertion or unsafe claims.
 - Stop or hold conditions: Stop if a change requires quote attribution, new public source lineage, validator behavior, dependency/model trust review, or a new public doctrine page.

--- a/.nuclear/changes/doctrine-spine-influence/ship.md
+++ b/.nuclear/changes/doctrine-spine-influence/ship.md
@@ -72,6 +72,7 @@
 - Decision: defer until PR review and requested Copilot review pass
 - Decision maker: FlyFission
 - Rationale: Controlled public workflow artifacts require slow acceptance after fast candidate edits.
+- Decision question answered by evidence? yes
 - Conditions attached: PR/Copilot review and any remote CI checks.
 - Decision posture: conservative enough
 - Abort or rollback trigger: quote insertion, unsafe assurance wording, contract test failure, or actionable review that is not addressed.

--- a/.nuclear/changes/doctrine-spine-influence/ship.md
+++ b/.nuclear/changes/doctrine-spine-influence/ship.md
@@ -1,0 +1,107 @@
+# Standard Ship Record
+
+**Purpose:** Make the acceptance decision explicit for the doctrine-spine influence update.
+
+**Activation threshold:** Use because this Standard change affects public docs, skills, command prompts, templates, and baseline posture.
+
+**Minimum useful version:** Evidence status, residual risks, rollback/restore, monitoring, handoff, release decision, and baseline trigger.
+
+**Overhead trap:** Do not treat tests alone as acceptance. Ship only when evidence matches the claims and public boundary wording is reviewed.
+
+---
+
+## Release identity
+
+- Change slug: doctrine-spine-influence
+- Version / release / baseline: branch `add-quotes-and-influence`
+- PR / commit / artifact: forthcoming PR
+- Owner: FlyFission
+- Date: 2026-05-30
+- Intended release window: after PR review and requested Copilot review
+
+## Scope and exclusions
+
+- Included: public docs, selected skills, command cards, Standard templates, skill-evaluation prompts, packet, CM/OPEX/baseline records.
+- Excluded: quotes, attributions, new doctrine page, CLI behavior, validator rules, dependencies, model/API/tool trust changes, release automation.
+- Known non-goals: no compliance, safety, security, certification, formal assurance, regulatory adequacy, or legal advice claim.
+
+## Evidence status summary
+
+| Evidence area | Status | Link | Notes |
+|---|---|---|---|
+| Risk classification | pass | `risk.md` | Standard with CM/OPEX/baseline activated |
+| Basis / requirements / claims | pass | `basis.md` | Control stack and non-goals explicit |
+| Verification | pass | `verification.md` | Packet validation, tests, doctor, and scan run |
+| Boundary wording | pass | `verification.md` | Scan reviewed for expected boundary-safe contexts |
+| AI-assisted work checks | pass | `verification.md` | Local deterministic checks passed; PR review pending |
+| Review / approval | planned | PR | Copilot/actionable review requested by user |
+
+## Residual risks and gaps
+
+| Risk / gap | Impact | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| Semantic doctrine quality is partly review-based | Tests cannot prove the wording is the best possible translation | mitigate | FlyFission | PR review or future OPEX |
+| Validator does not enforce doctrine-spine fields beyond current template checks | Future shallow updates could pass structure-only checks | defer | FlyFission | Repeated OPEX or reviewer finding |
+
+## Rollback / restore plan
+
+- Rollback method: revert the PR/commit.
+- Data migration reversal or restore notes: none.
+- Feature flag / kill switch: not applicable.
+- Owner on call: FlyFission.
+- Time to restore estimate: one revert.
+
+## Monitoring and post-release checks
+
+| Signal | Threshold / expected behavior | Owner | Where to inspect | Action if bad |
+|---|---|---|---|---|
+| User confusion | Users treat doctrine as extra ceremony or quotes are requested as public proof | FlyFission | Issues/PR comments | OPEX and targeted docs/templates adjustment |
+| Agent misuse | Agents skip decision question, overclaim evidence, or blur build/audit phases | FlyFission | PR packets and reviews | Update skill/evaluation prompts |
+| Boundary drift | Public wording implies assurance or source satisfaction | FlyFission | Doctor, scans, reviews | Block/revert and source/legal check |
+
+## Handoff
+
+- Operator/customer/support notes: not applicable.
+- Docs/runbook updated: adoption docs and entrypoints updated in this change.
+- Communication needed: PR summary should state no quotes/attributions or new assurance claims were added.
+- Turnover record if activated: not activated.
+- Follow-up date: after PR review.
+
+## Release decision
+
+- Decision: defer until PR review and requested Copilot review pass
+- Decision maker: FlyFission
+- Rationale: Controlled public workflow artifacts require slow acceptance after fast candidate edits.
+- Conditions attached: PR/Copilot review and any remote CI checks.
+- Decision posture: conservative enough
+- Abort or rollback trigger: quote insertion, unsafe assurance wording, contract test failure, or actionable review that is not addressed.
+- OPEX or post-release learning trigger: user or agent confusion about decision question, evidence grounding, or build/audit phase separation.
+
+## Baseline trigger
+
+- Baseline required? yes
+- Baseline record: `baseline.md`
+- Revalidation trigger: future changes to charter, lifecycle, HPI overlays, activation thresholds, selected skills/commands, Standard templates, evaluation prompts, or public boundary wording.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `verification.md`
+- PR/commit/release artifact: forthcoming PR
+- Monitoring/dashboard/log query: GitHub issues/PR feedback
+- Rollback/runbook: revert commit/PR
+
+## Exit criteria
+
+- Release decision is explicit.
+- Baseline trigger is explicit when controlled state changes.
+- Evidence status and gaps are visible.
+- Residual uncertainty is bounded, owned, or blocks/defer the decision.
+- Rollback/restore path exists or the lack is consciously accepted.
+- Monitoring/handoff covers the claims most likely to fail in operation.
+- Any accepted residual risk has an owner and recheck trigger.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record inspired by public configuration-management, release-readiness, secure-development, software-assurance, supply-chain, lifecycle, and operating-learning concepts mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/trace.md
+++ b/.nuclear/changes/doctrine-spine-influence/trace.md
@@ -1,0 +1,68 @@
+# Standard Trace Record
+
+**Purpose:** Link doctrine-spine claims to basis, controls, verification evidence, release posture, and gaps.
+
+**Activation threshold:** Use because reviewers need to see how influence mapping becomes public artifact behavior.
+
+**Minimum useful version:** Claim IDs, basis links, control/design features, evidence links, ship posture, and status labels.
+
+**Overhead trap:** Trace only the claims that matter for end-user and downstream-agent behavior.
+
+---
+
+## Change context
+
+- Slug: doctrine-spine-influence
+- Related basis record: `basis.md`
+- Related verification record: `verification.md`
+- Owner: FlyFission
+- Date: 2026-05-30
+
+## Trace summary
+
+Use status labels: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
+
+| ID | Claim | Basis link | Control / design feature | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|
+| C-001 | Public docs express the control stack without quotes or new attributions | `basis.md` | Existing-doc updates and boundary wording | `verification.md` | Boundary scan reviewed; no named attribution inserted | pass |
+| C-002 | Downstream-agent surfaces are harder to misuse | `basis.md` | Skill, command, template, and evaluation updates | `verification.md` | Contract tests pass | pass |
+| C-003 | The workflow preserves fast exploration and slow acceptance | `basis.md` | Quickstart, thresholds, lifecycle, ship/baseline edits | `verification.md` | Public docs and manual review support acceptance | pass |
+| C-004 | The review surprise becomes a durable control update | `basis.md` | `opex.md` plus affected artifact changes | `verification.md` | OPEX links to durable updates | pass |
+
+## Evidence chain
+
+```text
+Risk / need
+  -> owner-supplied influences and review surprise
+  -> doctrine-spine controls in basis.md
+  -> docs, skills, commands, templates, and evaluation prompts
+  -> validation, contract tests, doctor, boundary scans, and PR review
+  -> release decision, baseline trigger, and revalidation conditions
+```
+
+## Open trace gaps
+
+| Gap | Why it matters | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| No validator rule for doctrine-spine completeness | Existing tests check structure, not semantic completeness | defer | FlyFission | If future packets repeat shallow influence mapping |
+| Copilot review not yet available | User requested Copilot review before clean merge | block until PR stage | FlyFission | PR opened |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+- Implementation / docs / tests / evals: changed files in PR diff
+
+## Exit criteria
+
+- Each important claim has a status label.
+- Every shipped claim has evidence or an accepted residual risk.
+- Deferred/gap claims are not used as release evidence.
+- Reviewer can navigate claim -> specification/basis -> evidence -> release decision quickly.
+
+## Source-lineage note
+
+Original Nuclear-grade trace record inspired by public requirements traceability, verification, configuration-management, software assurance, secure-development, and release-readiness sources mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/trace.md
+++ b/.nuclear/changes/doctrine-spine-influence/trace.md
@@ -22,12 +22,12 @@
 
 Use status labels: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
 
-| ID | Claim | Basis link | Control / design feature | Verification evidence | Ship posture | Status |
-|---|---|---|---|---|---|---|
-| C-001 | Public docs express the control stack without quotes or new attributions | `basis.md` | Existing-doc updates and boundary wording | `verification.md` | Boundary scan reviewed; no named attribution inserted | pass |
-| C-002 | Downstream-agent surfaces are harder to misuse | `basis.md` | Skill, command, template, and evaluation updates | `verification.md` | Contract tests pass | pass |
-| C-003 | The workflow preserves fast exploration and slow acceptance | `basis.md` | Quickstart, thresholds, lifecycle, ship/baseline edits | `verification.md` | Public docs and manual review support acceptance | pass |
-| C-004 | The review surprise becomes a durable control update | `basis.md` | `opex.md` plus affected artifact changes | `verification.md` | OPEX links to durable updates | pass |
+| ID | Claim | Basis link | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|
+| C-001 | Public docs express the control stack without quotes or new attributions | `basis.md` | Existing-doc updates and boundary wording | local proof | `verification.md` | Boundary scan reviewed; no named attribution inserted | pass |
+| C-002 | Downstream-agent surfaces are harder to misuse | `basis.md` | Skill, command, template, and evaluation updates | local proof / peer review | `verification.md` | Contract tests pass | pass |
+| C-003 | The workflow preserves fast exploration and slow acceptance | `basis.md` | Quickstart, thresholds, lifecycle, ship/baseline edits | peer review | `verification.md` | Public docs and manual review support acceptance | pass |
+| C-004 | The review surprise becomes a durable control update | `basis.md` | `opex.md` plus affected artifact changes | local proof | `verification.md` | OPEX links to durable updates | pass |
 
 ## Evidence chain
 

--- a/.nuclear/changes/doctrine-spine-influence/verification.md
+++ b/.nuclear/changes/doctrine-spine-influence/verification.md
@@ -1,0 +1,95 @@
+# Standard Verification Record
+
+**Purpose:** Show that the doctrine-spine update has evidence proportionate to its public workflow impact.
+
+**Activation threshold:** Use because this Standard change affects public docs, skills, commands, templates, and downstream agent behavior.
+
+**Minimum useful version:** Claims, methods, acceptance criteria, commands/reviews, results, evidence links, and gaps.
+
+**Overhead trap:** Do not treat confidence in the prose as proof. Evidence must match the claim and be status-labeled.
+
+---
+
+## Verification context
+
+- Slug: doctrine-spine-influence
+- Related basis: `basis.md`
+- Owner: FlyFission
+- Date: 2026-05-30
+- Verification scope: packet, public docs, skills, command cards, Standard templates, evaluation prompts, and boundary wording.
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
+
+## Claim-to-evidence table
+
+| Claim / requirement ID | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|
+| C-001 | deterministic test / peer review | public-doc tests, doctor, boundary scan | No quotes/attributions added; unsafe claims only in boundary-safe context | pass | commands below | Boundary scan reviewed expected boundary-language hits and no named attribution insertion |
+| C-002 | deterministic test / peer review | skill and command contract tests plus manual diff review | Agent-facing contracts pass and changed text is operational | pass | commands below | none |
+| C-003 | peer review | Quickstart, thresholds, lifecycle, ship/baseline review | Fast exploration and slow acceptance are both visible | pass | changed docs | none |
+| C-004 | deterministic test / peer review | packet validation and OPEX review | OPEX links to durable changes | pass | `opex.md` | none |
+
+## Verification type guide
+
+| Type | Use when |
+|---|---|
+| self-check | critical action target and expected result matter |
+| peer-check | another reviewer should prevent wrong action before it happens |
+| concurrent verification | high-consequence action must be observed as it happens |
+| independent verification | final state must be checked separately from the performer claim |
+| peer review | artifact quality, maintainability, usability, or boundary wording matters |
+| deterministic test / eval | reproducible behavior evidence exists |
+
+## Commands, evals, and reviews
+
+| Method | Command / review / eval | Environment | Result | Evidence link |
+|---|---|---|---|---|
+| Packet validation | `python3 tools/ng.py validate .nuclear/changes/doctrine-spine-influence` | local | pass | `OK: .nuclear/changes/doctrine-spine-influence` |
+| Contract/public tests | `env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_public_docs.py tests/test_skill_contracts.py tests/test_command_contracts.py tests/test_ng_validate.py -q` | local | pass | `42 passed` |
+| Doctor | `python3 tools/ng.py doctor .` | local | pass | `OK: Nuclear-grade doctor` |
+| Boundary scan | `rg -n "quote|quotation|formal|certified|approval|compliant|regulatory adequacy|safe|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence` | local | pass | expected boundary-language and packet non-goal hits; no named attribution insertion |
+| PR review | Copilot review and actionable feedback pass | GitHub | planned | PR |
+
+## Negative / failure-mode checks
+
+| Failure mode | Check performed | Result | Evidence link |
+|---|---|---|---|
+| Public quote or named attribution inserted | Boundary scan for names and quote terms | pass | command output |
+| Public assurance overclaim | Doctor and boundary scan | pass | command output |
+| Agent contract regression | Skill/command tests | pass | pytest output |
+| Packet evidence theater | Packet validation and manual OPEX review | pass | this packet |
+
+## AI-assisted work checks
+
+- AI scope: docs, skills, commands, templates, and packet edits.
+- Model/tool used: Codex with shell/apply_patch tools.
+- Permissions/actions allowed: local repo edits, tests, git/PR flow after verification.
+- Independent checks performed: deterministic tests, validator, doctor, boundary scan, requested Copilot review.
+- Self-check / turnover records: compact controls in packet; no separate turnover activated.
+- Hallucination/slop screening: quote-exclusion, source-boundary, and claim-to-evidence checks.
+- Human approval gates exercised: user approved implementation plan and requested PR/Copilot review.
+
+## Security / dependency / supply-chain checks
+
+Not activated. No dependency, model, API, SaaS, generated artifact, credential, network, build, or release automation change.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `ship.md`
+- CI run / eval report / test logs / review notes: local command output and PR checks
+- Implementation diff / PR: forthcoming PR
+
+## Exit criteria
+
+- Each important claim has `pass`, `fail`, `gap`, `deferred`, or `not applicable` status.
+- Evidence is linked rather than pasted in full.
+- Gaps are explicit and reflected in `ship.md`.
+- Reviewer can tell whether the evidence supports the release decision.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record inspired by public software V&V, test-documentation, secure-development, software assurance, AI-risk, and application-security verification sources mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/doctrine-spine-influence/verification.md
+++ b/.nuclear/changes/doctrine-spine-influence/verification.md
@@ -49,8 +49,14 @@ Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
 | Packet validation | `python3 tools/ng.py validate .nuclear/changes/doctrine-spine-influence` | local | pass | `OK: .nuclear/changes/doctrine-spine-influence` |
 | Contract/public tests | `env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_public_docs.py tests/test_skill_contracts.py tests/test_command_contracts.py tests/test_ng_validate.py -q` | local | pass | `42 passed` |
 | Doctor | `python3 tools/ng.py doctor .` | local | pass | `OK: Nuclear-grade doctor` |
-| Boundary scan | `rg -n "quote\|quotation\|formal\|certified\|approval\|compliant\|regulatory adequacy\|safe\|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence` | local | pass | expected boundary-language and packet non-goal hits; no named attribution insertion |
+| Boundary scan | pasteable command below | local | pass | expected boundary-language and packet non-goal hits; no named attribution insertion |
 | PR review | Copilot review and actionable feedback pass | GitHub | planned | PR |
+
+Boundary scan command:
+
+```bash
+rg -n "quote|quotation|formal|certified|approval|compliant|regulatory adequacy|safe|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence
+```
 
 ## Negative / failure-mode checks
 

--- a/.nuclear/changes/doctrine-spine-influence/verification.md
+++ b/.nuclear/changes/doctrine-spine-influence/verification.md
@@ -24,12 +24,12 @@ Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
 
 ## Claim-to-evidence table
 
-| Claim / requirement ID | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
-|---|---|---|---|---|---|---|
-| C-001 | deterministic test / peer review | public-doc tests, doctor, boundary scan | No quotes/attributions added; unsafe claims only in boundary-safe context | pass | commands below | Boundary scan reviewed expected boundary-language hits and no named attribution insertion |
-| C-002 | deterministic test / peer review | skill and command contract tests plus manual diff review | Agent-facing contracts pass and changed text is operational | pass | commands below | none |
-| C-003 | peer review | Quickstart, thresholds, lifecycle, ship/baseline review | Fast exploration and slow acceptance are both visible | pass | changed docs | none |
-| C-004 | deterministic test / peer review | packet validation and OPEX review | OPEX links to durable changes | pass | `opex.md` | none |
+| Claim / requirement ID | Support type | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|---|
+| C-001 | local proof | deterministic test / peer review | public-doc tests, doctor, boundary scan | No quotes/attributions added; unsafe claims only in boundary-safe context | pass | commands below | Boundary scan reviewed expected boundary-language hits and no named attribution insertion |
+| C-002 | local proof / peer review | deterministic test / peer review | skill and command contract tests plus manual diff review | Agent-facing contracts pass and changed text is operational | pass | commands below | none |
+| C-003 | peer review | peer review | Quickstart, thresholds, lifecycle, ship/baseline review | Fast exploration and slow acceptance are both visible | pass | changed docs | none |
+| C-004 | local proof | deterministic test / peer review | packet validation and OPEX review | OPEX links to durable changes | pass | `opex.md` | none |
 
 ## Verification type guide
 

--- a/.nuclear/changes/doctrine-spine-influence/verification.md
+++ b/.nuclear/changes/doctrine-spine-influence/verification.md
@@ -49,7 +49,7 @@ Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
 | Packet validation | `python3 tools/ng.py validate .nuclear/changes/doctrine-spine-influence` | local | pass | `OK: .nuclear/changes/doctrine-spine-influence` |
 | Contract/public tests | `env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_public_docs.py tests/test_skill_contracts.py tests/test_command_contracts.py tests/test_ng_validate.py -q` | local | pass | `42 passed` |
 | Doctor | `python3 tools/ng.py doctor .` | local | pass | `OK: Nuclear-grade doctor` |
-| Boundary scan | `rg -n "quote|quotation|formal|certified|approval|compliant|regulatory adequacy|safe|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence` | local | pass | expected boundary-language and packet non-goal hits; no named attribution insertion |
+| Boundary scan | `rg -n "quote\|quotation\|formal\|certified\|approval\|compliant\|regulatory adequacy\|safe\|secure" README.md QUICKSTART.md WORKFLOWS.md docs skills commands templates .nuclear/changes/doctrine-spine-influence` | local | pass | expected boundary-language and packet non-goal hits; no named attribution insertion |
 | PR review | Copilot review and actionable feedback pass | GitHub | planned | PR |
 
 ## Negative / failure-mode checks

--- a/.nuclear/charter.md
+++ b/.nuclear/charter.md
@@ -1,8 +1,8 @@
 # Nuclear-grade Charter
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Ratified:** 2026-05-27
-**Last amended:** 2026-05-27
+**Last amended:** 2026-05-30
 
 The charter is the durable backbone: non-negotiable principles of how work is done here, independent of any single change. A mission anchor states what a given change is for; the charter states how all changes must be carried out. The charter is advisory in tooling today (the validator does not block on it) but it is the standard a reviewer and an agent are expected to hold.
 
@@ -20,9 +20,16 @@ Principles are scaled by mode. Quick changes honor the spirit; Standard and acti
 8. **Evidence over persuasion.** Claims carry reproducible evidence or a labeled gap, not prose that convinces.
 9. **Graded rigor.** Match controls to consequence. Quick for low-consequence reversible work; Standard and activated records as consequence rises.
 10. **Baseline discipline.** The accepted configuration is recorded, and changes to it are controlled and traceable.
+11. **Decision-question discipline.** Before meaningful work starts, name the decision the evidence must support. A well-run change spends enough effort on the question that the later proof is pointed at the right decision.
+12. **Operational unambiguity.** Write skills, commands, templates, and handoffs so they are hard to misuse under pressure, not merely possible to understand with care.
+13. **Mission-aligned small work.** Local edits, checks, and reviews must serve the mission anchor. Winning a small task while drifting from the objective is a control failure.
+14. **Grounded truth.** Separate fact, assumption, unknown, source claim, local proof, and decision authority. Confidence, fluency, preference, and vendor language are not proof.
+15. **Two-speed control.** Move quickly while exploring and building reversible candidates; slow down at acceptance gates for claims, baselines, public wording, releases, and other trust-bearing decisions.
+16. **Cut-point self-checking.** Measure critical targets before the cut: commands, public claims, dependency/model/API changes, release actions, and other wrong-target or hard-to-reverse steps.
 
 ## Amendment log
 
+- 1.1.0 (2026-05-30): Added doctrine-spine articles for decision-question discipline, operational unambiguity, mission-aligned small work, grounded truth, two-speed control, and cut-point self-checking.
 - 1.0.0 (2026-05-27): Initial charter.
 
 ## Source-lineage note

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,8 @@
 
 **Goal:** question a real AI-assisted change, create a useful controlled-change record in about 15 minutes, and prove one important claim.
 
+Nuclear-grade should make decisions faster, not paperwork heavier. Move quickly while exploring and building reversible candidates; slow down when you are accepting a claim, baseline, public statement, release decision, or authority change.
+
 > **Note on the demo:** the first time you run `validate` on a freshly scaffolded packet you should expect `FAILED: ... has unfilled template prompts`. Templates ship with empty prompts on purpose. Fill the prompts that matter, then re-run `validate`. The point of the validator is to refuse silent gaps.
 
 ## 1. Check the repo
@@ -38,6 +40,8 @@ Facts to verify: What would change the decision?
 Stop conditions: What would make us pause or escalate?
 Next artifact: Quick proof, Standard spec, context pack, CM record, or release decision.
 ```
+
+If the decision question is vague, stop there and sharpen it. The rest of the packet exists to answer that question with evidence.
 
 Add HPI controls only when they change the work:
 
@@ -111,7 +115,7 @@ This inserts a `## Selected mode` block into `risk.md` with an inferred default.
 
 Answer only what helps a reviewer decide:
 
-1. What are we questioning?
+1. What decision are we answering?
 2. What facts did we discover?
 3. What are we specifying?
 4. What evidence will prove the important claim?
@@ -120,6 +124,8 @@ Answer only what helps a reviewer decide:
 7. What decision is needed before release or merge?
 8. What baseline or revalidation trigger changes after the decision?
 9. What HPI control, if any, changes the next action or evidence obligation?
+
+Keep facts, assumptions, unknowns, source claims, local proof, and decision authority separate. Do not let confident prose do the work of evidence.
 
 ## 6. Prove one claim
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ AI agents no longer just suggest code. They edit files, change prompts, call too
 
 It also adds HPI for AI agents: small control behaviors that make fast agent work reviewable. Brief the work, self-check critical actions, turn over cleanly, verify independently when consequence demands it, decide conservatively, and learn from near misses.
 
+The operating spine is deliberately two-speed. Agents can explore and build reversible candidates quickly, but acceptance slows down when work becomes a claim, controlled item, public statement, baseline, release decision, or authority change. The first control is the decision question: what must this evidence prove, and what fact would change the decision?
+
 ```text
 Normal AI coding:
 prompt -> diff -> persuasion -> merge risk
@@ -76,6 +78,8 @@ prompt memory -> controlled change record
 agent authority -> focused context and evidence obligation
 green CI -> explicit release decision and baseline trigger
 ```
+
+That shift is practical, not decorative: instructions should be hard to misuse, small actions should serve the mission anchor, and confidence should be separated from fact, assumption, source claim, local proof, and decision authority.
 
 ## Core workflow
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -12,6 +12,8 @@ question -> specify -> execute -> verify -> decide -> baseline -> operation
 
 HPI for AI agents adds the micro-controls under that path: brief the work, self-check critical actions, turn over cleanly, verify independently when needed, decide conservatively, and learn from near misses.
 
+The workflow is two-speed. Exploration and reversible candidate work should stay fast; acceptance slows down when a candidate becomes evidence, a claim, a controlled item, public wording, a baseline, a release decision, or an agent-authority boundary.
+
 ## Workflow catalog
 
 | Workflow | Loop | Use when | Main artifact |
@@ -49,6 +51,8 @@ cp templates/golden-path/questioning-attitude.md .nuclear/changes/<slug>/
 ```
 
 The output should name assumptions, facts to verify, warning signs, evidence gaps, stop conditions, and the next artifact.
+
+The decision question is the first output, not an afterthought. If the question is wrong, the proof can be clean and still support the wrong decision.
 
 ## Standard change
 
@@ -97,6 +101,8 @@ cp templates/golden-path/self-check.md .nuclear/changes/<slug>/
 ```
 
 These records should stay short. They exist to stop bad action, not to explain HPI theory.
+
+Use self-checking at cut points: wrong target, wrong command, wrong public claim, wrong dependency/model/API trust change, irreversible state, or release action. Do not slow every reversible edit.
 
 ## Release readiness
 

--- a/commands/ng-classify.md
+++ b/commands/ng-classify.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Classify a proposed change into the smallest honest Nuclear-grade mode after questioning assumptions, and name the proof needed before work continues. This is a portable command prompt.
+Classify a proposed change into the smallest honest Nuclear-grade mode after identifying the decision question, and name the proof needed before work continues. This is a portable command prompt.
 
 ## Use when
 
@@ -34,6 +34,7 @@ Inputs:
 - User/security/dependency/data/AI/release impact: <known facts>
 
 Return:
+- decision question and evidence gate
 - selected mode: Quick, Standard, or human-reviewed stronger mode
 - consequence, reversibility, exposure, detectability, uncertainty
 - work mode and HPI control recommendation: none, context pack, turnover, self-check, independent verification, OPEX, or trust check
@@ -51,6 +52,7 @@ Return:
 ## Expected outputs
 
 - Selected mode.
+- Decision question and evidence gate.
 - Mode rationale.
 - Proof obligation.
 - HPI control recommendation when activated.
@@ -65,6 +67,7 @@ python tools/ng.py status .
 ## Failure modes
 
 - Classifying by effort instead of consequence.
+- Selecting mode before the decision question is clear.
 - Ignoring AI authority, dependency trust, data exposure, or release impact.
 - Selecting Quick while unresolved Standard triggers remain.
 

--- a/commands/ng-context-pack.md
+++ b/commands/ng-context-pack.md
@@ -19,7 +19,7 @@ Prepare focused context for a human or AI agent working from a packet. This is a
 ## Inputs
 
 - Packet path.
-- Role, objective, affected files, allowed commands, forbidden actions, approvals, and required evidence.
+- Role, decision question, objective, work phase, affected files, allowed commands, forbidden actions, approvals, and required evidence.
 - `docs/02-operating-system/context-packs.md`.
 
 ## Prompt text
@@ -30,7 +30,9 @@ Build a Nuclear-grade context pack for this work.
 Inputs:
 - packet: .nuclear/changes/<slug>/
 - role: <builder|reviewer|verifier|releaser|researcher>
+- decision question: <one sentence>
 - objective: <one paragraph>
+- work phase: <explore|candidate|audit|accept>
 - affected files: <list>
 - last completed action:
 - changed conditions:
@@ -41,7 +43,7 @@ Inputs:
 - approval gates: <list>
 - required evidence: <commands/links/reviews>
 
-Return a concise context pack with mode, objective, risk summary, basis summary, required evidence, authority boundaries, forbidden claims, open gaps, last completed action, changed conditions, critical next action, and next action. If responsibility transfers, add incoming-owner confirmation.
+Return a concise context pack with mode, decision question, objective, work phase, risk summary, basis summary, required evidence, authority boundaries, forbidden claims, open gaps, last completed action, changed conditions, critical next action, and next action. If responsibility transfers, add incoming-owner confirmation.
 ```
 
 ## Files created or modified
@@ -53,6 +55,7 @@ Return a concise context pack with mode, objective, risk summary, basis summary,
 
 - Focused context pack.
 - Clear authority boundaries.
+- Decision question and work phase.
 - Next action.
 - Resume point and incoming-owner confirmation when activated.
 
@@ -65,6 +68,7 @@ python tools/ng.py status .
 ## Failure modes
 
 - Loading the whole repo without an activated reason.
+- Omitting the decision question and forcing the agent to infer what evidence must support.
 - Leaving file, command, network, credential, or release authority unstated.
 - Omitting forbidden claims.
 - Omitting last completed action for resumed or delegated work.

--- a/commands/ng-drift-check.md
+++ b/commands/ng-drift-check.md
@@ -40,6 +40,7 @@ Do this:
 - Restate the anchor from the written record, not from memory.
 - Zoom out one layer; judge at the objective/architecture altitude.
 - Test the current action against the success criteria and non-goals.
+- Decide whether the action serves the mission or a substituted local goal.
 - Check the loop: if the same objective has failed 3 times, stop attempting the next variant.
 - Check standards drift against the charter and any countable tripwires.
 
@@ -75,6 +76,7 @@ python tools/ng.py validate .nuclear/changes/<slug>
 - Attempting the next variant after three failures instead of escalating.
 - Crossing a non-goal by editing rather than by a recorded decision.
 - Measuring progress in activity rather than in success criteria met.
+- Winning a local task while losing the mission.
 
 ## Legal/assurance boundary note
 

--- a/commands/ng-opex.md
+++ b/commands/ng-opex.md
@@ -2,12 +2,13 @@
 
 ## Purpose
 
-Convert operating experience, near misses, incidents, bad handoffs, review surprises, or user feedback into durable workflow updates. This is a portable command prompt.
+Convert operating experience, near misses, incidents, bad handoffs, shallow analysis, review surprises, or user feedback into durable workflow updates. This is a portable command prompt.
 
 ## Use when
 
 - An agent exceeded or nearly exceeded authority.
 - A bad handoff, hallucinated claim, escaped defect, weak review, stale baseline, or user confusion appeared.
+- A doctrine, source, or influence update produced prose without a durable control change.
 - A lesson should update a basis, test, validator, template, skill, command, doc, monitor, threshold, or baseline.
 
 ## Do not use when
@@ -48,6 +49,7 @@ Produce a no-blame OPEX record. Each finding must update a durable control or ex
 
 - Finding, impact, action or closure, verification, owner, and trigger.
 - Revalidation or re-baseline trigger if controlled state changed.
+- Durable control update when one is available.
 
 ## Verification command
 
@@ -58,6 +60,7 @@ python tools/ng.py validate .nuclear/changes/<slug>
 ## Failure modes
 
 - Lesson stays in chat history only.
+- Lesson records regret but changes no basis, test, validator, template, skill, command, doc, monitor, threshold, or baseline.
 - Record names a person or model as sole cause.
 - Finding has no durable update or closure rationale.
 

--- a/commands/ng-prove.md
+++ b/commands/ng-prove.md
@@ -32,7 +32,7 @@ Inputs:
 - known gaps: <list>
 
 Return:
-- claim -> basis -> control/design feature -> verification type -> evidence -> status -> ship posture
+- claim -> basis -> control/design feature -> support type -> verification type -> evidence -> status -> ship posture
 - narrowed wording for overbroad claims
 - explicit gaps, deferrals, or blockers
 - validator command to run
@@ -47,6 +47,7 @@ Return:
 ## Expected outputs
 
 - Claim-to-evidence table.
+- Fact / assumption / unknown / source-claim / local-proof distinction for important claims.
 - Evidence status.
 - Verification type: self-check, peer-check, concurrent verification, independent verification, peer review, test, or eval.
 - Updated release posture.
@@ -60,6 +61,7 @@ python tools/ng.py validate .nuclear/changes/<slug>
 ## Failure modes
 
 - Treating CI as proof of unrelated claims.
+- Treating confidence, source claims, or vendor language as local proof.
 - Treating a self-check as independent verification.
 - Hiding gaps.
 - Using "safe", "secure", "approved", or "compliant" beyond the evidence.

--- a/commands/ng-question.md
+++ b/commands/ng-question.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Apply a questioning attitude to a change before work, review, or release continues. This is a portable command prompt.
+Apply a questioning attitude to a change before work, review, or release continues by naming the decision question first. This is a portable command prompt.
 
 ## Use when
 
@@ -37,6 +37,7 @@ Inputs:
 
 Return:
 - decision question in one sentence
+- evidence that would change the decision
 - assumptions that must be true
 - known facts, unknowns, danger words, and source-quality concerns
 - facts to verify before work continues
@@ -56,6 +57,7 @@ Prefer facts over confidence. Do not imply formal assurance, compliance, certifi
 ## Expected outputs
 
 - Validated and unresolved assumptions.
+- Evidence that would change the decision.
 - Evidence gaps.
 - Stop/escalation conditions.
 - Next artifact recommendation.
@@ -70,6 +72,7 @@ python tools/ng.py validate .nuclear/changes/<slug>
 ## Failure modes
 
 - Turning questioning attitude into generic brainstorming.
+- Asking questions that do not change a decision.
 - Asking many questions without naming which facts change the decision.
 - Treating agent confidence or green CI as evidence for unrelated claims.
 - Hiding escalation triggers because the change seems small.

--- a/commands/ng-self-check.md
+++ b/commands/ng-self-check.md
@@ -2,12 +2,13 @@
 
 ## Purpose
 
-Run a compact self-check before and after a critical agent action. This is a portable command prompt.
+Run a compact self-check before and after a critical cut-point agent action. This is a portable command prompt.
 
 ## Use when
 
 - An edit, command, tool call, credential use, public claim, dependency/model/API change, migration, or release action could affect controlled state.
 - Wrong target, wrong scope, or mismatched evidence is plausible.
+- A fast candidate is about to become a public claim, accepted baseline, or release action.
 
 ## Do not use when
 
@@ -35,6 +36,7 @@ Inputs:
 - proof or after-action check:
 
 Return:
+- cut point being checked;
 - action and target;
 - expected result;
 - stop condition;
@@ -50,7 +52,7 @@ Return:
 ## Expected outputs
 
 - Proceed / pause / escalate decision.
-- Action, target, expected result, stop condition, and evidence requirement.
+- Cut point, action, target, expected result, stop condition, and evidence requirement.
 
 ## Verification command
 

--- a/commands/ng-ship-review.md
+++ b/commands/ng-ship-review.md
@@ -2,13 +2,14 @@
 
 ## Purpose
 
-Review release readiness and record ship, block, defer, or ship-with-risk decisions. This is a portable command prompt.
+Review release readiness as a slow-audit acceptance gate and record ship, block, defer, or ship-with-risk decisions. This is a portable command prompt.
 
 ## Use when
 
 - A Standard packet is approaching merge or release.
 - Evidence gaps, rollback, monitoring, or residual risks need a decision.
 - A PR changes trust posture.
+- A fast candidate is being promoted into a baseline, public claim, release, or accepted controlled state.
 - Turnover, support handoff, OPEX trigger, or conservative decision posture is unclear.
 
 ## Do not use when
@@ -37,6 +38,7 @@ Inputs:
 
 Return:
 - release decision: ship, block, defer, or ship with named residual risk
+- whether the decision question is answered by evidence
 - evidence summary
 - residual risks and owner
 - rollback and monitoring notes
@@ -52,6 +54,7 @@ Return:
 ## Expected outputs
 
 - Explicit release decision.
+- Evidence-backed answer to the decision question.
 - Residual risk statement.
 - Rollback and monitoring record.
 - Conservative posture, turnover, and learning trigger.
@@ -65,6 +68,7 @@ python tools/ng.py validate .nuclear/changes/<slug>
 ## Failure modes
 
 - Equating green CI with ship readiness.
+- Promoting a candidate to accepted configuration before audit gates.
 - Deferring evidence without owner or impact.
 - Missing rollback or monitoring.
 - Missing operational handoff or OPEX trigger.

--- a/docs/02-operating-system/activation-thresholds.md
+++ b/docs/02-operating-system/activation-thresholds.md
@@ -4,6 +4,8 @@
 
 **Rule:** Rigor must earn its keep. Activate artifacts by decision value and consequence, not by aesthetic desire for a complete binder.
 
+Exploration and candidate building may stay lightweight when the work is reversible. Escalate the acceptance gate, not every keystroke, when a candidate becomes a claim, controlled item, public statement, release decision, baseline, or authority boundary.
+
 ---
 
 ## Primary threshold dimensions
@@ -26,15 +28,15 @@ Score informally; do not over-math the decision.
 
 | Trigger | Minimum artifact | Minimum useful version | Exit criteria | Overhead trap |
 |---|---|---|---|---|
-| Any non-trivial change | `risk.md` | scope, consequence, mode, proof needed | Mode is justified. | Writing a risk essay for a tiny diff. |
+| Any non-trivial change | `risk.md` | decision question, scope, consequence, mode, proof needed | Mode is justified. | Writing a risk essay for a tiny diff. |
 | Low-risk reversible change | `proof.md` | command/check/eval and result | Evidence matches declared risk. | Treating test output as proof for unrelated claims. |
-| User-visible or durable behavior | Standard packet | basis, plan, trace, verification, ship | Important claims have evidence or explicit gaps. | Backfilling trace after release. |
+| User-visible or durable behavior | Standard packet | basis, plan, trace, verification, ship | Important claims have evidence or explicit gaps before acceptance. | Backfilling trace after release. |
 | New protected outcome or unacceptable outcome | `basis.md` / `design-basis.md` | what must remain true; assumptions; evidence required | Requirements/design features follow from basis. | Grand narrative without decisions. |
 | Important external dependency/model/API/SaaS | dependency trust basis section or record | intended use, consequence, source/version, evidence, revalidation trigger | Trust decision is scoped and revisit-able. | Package-name/version-only review. |
 | AI/agent tool authority changes | AI-control fields in packet | authority, permissions, approvals, independent checks | Agent cannot exceed intended envelope without detection/approval. | Letting AI document its own unchecked proof. |
 | Security/privacy/auth/data handling change | verification + ship security fields | threat/failure prompt, tests/reviews, rollback/monitoring | Security claim is evidence-backed. | Final scan treated as full assurance. |
 | Hard-to-detect or hard-to-reverse failure | Nuclear subset | change-impact, independent review, release readiness | Fresh reviewer can challenge basis and proof. | Creating every Nuclear artifact automatically. |
-| Release changes trust/ops/customer posture | `ship.md` / release readiness | baseline, evidence status, risks, rollback, monitoring, handoff | Ship/no-ship is explicit. | Shipping because CI passed once. |
+| Release changes trust/ops/customer posture | `ship.md` / release readiness | baseline, evidence status, risks, rollback, monitoring, handoff | Ship/no-ship is explicit after slow-audit review. | Shipping because CI passed once. |
 | Incident/near miss/eval failure | OPEX/corrective action | event, cause, action, verification, basis/test/control update | Lesson changes future behavior or is closed. | Postmortem theater. |
 
 ---

--- a/docs/02-operating-system/hpi-overlays.md
+++ b/docs/02-operating-system/hpi-overlays.md
@@ -6,6 +6,8 @@
 
 This is a software workflow translation. No compliance claim is made.
 
+The overlays should make agent work hard to misuse, not heavy by default. Use them to frame the decision question, separate fact from assumption and source claim, keep small actions tied to the mission anchor, and self-check the exact target at cut points. Candidate work can move quickly; acceptance of claims, baselines, public wording, and release posture should move deliberately.
+
 ---
 
 ## Core overlay
@@ -20,14 +22,14 @@ Add HPI controls only where they change the decision:
 
 | Lifecycle phase | HPI overlay | Software translation |
 |---|---|---|
-| Question | questioning attitude, pause when unsure | state the decision question, facts, unknowns, warning signs, and hold conditions |
+| Question | questioning attitude, pause when unsure | state the decision question, facts, unknowns, warning signs, evidence that would change the decision, and hold conditions |
 | Discover | task preview, repo-site review | check actual branch, files, tests, prior packets, source rows, and operating experience |
-| Specify | validate assumptions | label facts, assumptions, unknowns, invalidation triggers, and evidence needs |
+| Specify | validate assumptions | label facts, assumptions, unknowns, source claims, local proof, invalidation triggers, and evidence needs |
 | Plan | pre-job briefing, procedure adherence | name role, authority, critical actions, likely errors, controls, rollback, and proof |
-| Execute | self-checking, place-keeping, flagging | act only on named targets, record last completed action, and pause on mismatch |
+| Execute | self-checking, place-keeping, flagging | build candidates inside authority, act only on named targets, record last completed action, and pause on mismatch |
 | Verify | checking and verification practices | distinguish deterministic tests, peer-check, concurrent verification, independent verification, and peer review |
 | Review | work product review, independent oversight | challenge artifact usability, evidence fit, boundary wording, and process weakness |
-| Decide | conservative decision making | ship, block, defer, or accept residual risk with owner, condition, abort trigger, and baseline trigger |
+| Decide | conservative decision making | slow down at acceptance gates: ship, block, defer, or accept residual risk with owner, condition, abort trigger, and baseline trigger |
 | Baseline | accepted controlled state | record accepted configuration, evidence links, residual risk, and revalidation triggers |
 | Operate | observations, signals, near misses | watch for drift, user confusion, bad handoffs, stale evidence, and weak controls |
 | Learn | operating experience | update a durable control or explicitly close the lesson with rationale |
@@ -46,6 +48,17 @@ Use this screen when a task feels routine but has hidden consequence.
 | Human/model nature | overconfidence, anchoring, completion pressure, first-answer bias | questioning attitude, danger-word scan, reviewer challenge |
 
 Danger words for agents: "probably", "should", "seems", "obvious", "just docs", "safe", "secure", "compliant", "we can classify later". Treat them as prompts to find evidence or narrow the claim.
+
+## Doctrine-spine controls
+
+| Control | Agent behavior |
+|---|---|
+| Decision-question discipline | Spend enough time on the decision question that evidence is aimed at the right acceptance decision. |
+| Operational unambiguity | Prefer exact targets, status labels, stop conditions, and expected outputs over elegant prose. |
+| Mission-aligned small work | Check whether the current action serves a success criterion or a substituted local goal. |
+| Grounded truth | Keep fact, assumption, unknown, source claim, local proof, and decision authority separate. |
+| Two-speed control | Move quickly on reversible candidates; slow down before claims, baselines, release posture, or public wording. |
+| Cut-point self-checking | Self-check the exact target and expected result before commands, public claims, trust changes, or release actions. |
 
 ---
 

--- a/docs/02-operating-system/lifecycle.md
+++ b/docs/02-operating-system/lifecycle.md
@@ -14,21 +14,23 @@ This is an operating model, not a compliance program. `Classify` remains inside 
 
 HPI overlays add consequence-scaled control behaviors beneath the spine: task preview, repo-site review, pause when unsure, self-checking, turnover, verification selection, conservative decision making, and OPEX learning. Use `hpi-overlays.md` for the micro-controls; keep this lifecycle stable.
 
+The lifecycle is two-speed. Exploration and candidate building should stay fast and reversible; acceptance should slow down when a claim, controlled item, baseline, public statement, release decision, or authority boundary becomes trust-bearing. The early phases prevent wasted speed by finding the right decision question, and the later phases prevent fast candidates from becoming accepted configuration without evidence.
+
 ---
 
 ## Phase map
 
 | Phase | Decision being made | Minimum useful output | Exit criteria |
 |---|---|---|---|
-| Question | What assumptions, doubts, and stop conditions must be surfaced before work continues? | Decision question, assumptions, warning signs, evidence gaps. | Confidence is grounded in facts, not vibes. |
+| Question | What decision must the evidence support, and what assumptions, doubts, and stop conditions must be surfaced before work continues? | Decision question, assumptions, warning signs, evidence gaps, evidence that would change the decision. | Confidence is grounded in facts, not vibes. |
 | Discover | What sources and repo facts matter? | Public sources, prior packets, constraints, known gaps. | Specification is grounded, not invented. |
 | Specify | What state or behavior is required? | Requirements, claims, protected outcomes, assumptions, acceptance criteria. | Claims are testable or gap-labeled. |
 | Plan | How will controlled configuration change? | Steps, affected items, rollback, proof commands. | Work can proceed without rediscovering scope. |
-| Execute | Did implementation stay inside authority? | Diffs, commits, generated artifacts, self-checks, AI-assist notes. | Deviations are recorded, not hidden drift. |
-| Verify | What evidence supports the claims? | Tests/evals/reviews/results with status, verification type, and gaps. | Evidence matches the claim. |
-| Review | Can a skeptical reviewer accept this? | Claim-to-evidence review, work-product review, and residual risk disposition. | Accept/defer/block is reviewable. |
-| Decide | Should the change proceed, ship, block, defer, or continue with residual risk? | Decision, conditions, owner, baseline trigger. | Release decision is explicit. |
-| Baseline | What accepted state is now controlled? | Commit/release/artifact plus controlled item state and triggers. | Future drift can be detected. |
+| Execute | Did implementation stay inside authority while producing a candidate, not an accepted state? | Diffs, commits, generated artifacts, self-checks, AI-assist notes. | Deviations are recorded, not hidden drift. |
+| Verify | What objective evidence supports the claims, and what remains fact, assumption, unknown, source claim, or local proof? | Tests/evals/reviews/results with status, verification type, and gaps. | Evidence matches the claim. |
+| Review | Can a skeptical reviewer accept the artifact without relying on confidence or ambiguous instructions? | Claim-to-evidence review, work-product review, boundary wording review, and residual risk disposition. | Accept/defer/block is reviewable. |
+| Decide | Should the candidate become accepted configuration, ship, block, defer, or continue with residual risk? | Decision, conditions, owner, baseline trigger. | Release decision is explicit. |
+| Baseline | What accepted state is now controlled after slow-audit acceptance? | Commit/release/artifact plus controlled item state and triggers. | Future drift can be detected. |
 | Operate | What signals show drift or failure? | Monitors, support signals, incident triggers. | Operators know what to watch. |
 | Learn | What updates next time? | OPEX note linked to basis/test/control/template/baseline update. | Lesson changes something or is closed. |
 
@@ -54,7 +56,7 @@ Escalate beyond Quick when the change affects:
 For a small Standard change, the lifecycle is useful when the packet answers:
 
 ```text
-What should we question? What facts did we discover? What are we specifying? What changed? What proves it? What decision was made? What baseline now controls it?
+What decision are we answering? What facts did we discover? What are we specifying? What changed as a candidate? What objective evidence supports the claim? What decision accepted, blocked, deferred, or bounded it? What baseline now controls it?
 ```
 
 If the answer takes more than one screen before implementation starts, summarize it and link deeper evidence only where needed.

--- a/docs/02-operating-system/thin-evidence-spine.md
+++ b/docs/02-operating-system/thin-evidence-spine.md
@@ -30,6 +30,8 @@ The spine is intentionally incomplete compared with a full quality system. It ca
 4. What evidence proves the important claims?
 5. Is the change ready to ship, defer, or block?
 
+The spine is not meant to slow every candidate edit. It slows acceptance: the point where a candidate becomes a claim, controlled item, baseline, release decision, or public statement.
+
 ---
 
 ## 2. Activation threshold
@@ -85,6 +87,7 @@ Avoid:
 - claiming test coverage proves unrelated safety/security/reliability claims;
 - letting AI-generated documentation outrun independent evidence;
 - letting the same agent's confident claim substitute for independent verification when consequence demands separation.
+- slowing reversible exploration when only acceptance gates need stronger evidence.
 
 Use links, status labels, and explicit gaps instead.
 

--- a/docs/04-adoption/agent-authority-model.md
+++ b/docs/04-adoption/agent-authority-model.md
@@ -19,6 +19,7 @@
 For material agent authority, create a context pack that states:
 
 - objective;
+- decision question;
 - packet path;
 - allowed and forbidden actions;
 - approval gates;
@@ -28,6 +29,8 @@ For material agent authority, create a context pack that states:
 ## Denial rule
 
 If the requested action exceeds authority, the agent must stop and record the needed approval or escalation path.
+
+If the exact target, expected result, forbidden claim, or stop condition is ambiguous at a cut point, the agent must pause before acting. A cut point includes file writes, broad commands, public claims, dependency/model/API trust changes, release actions, and other hard-to-reverse steps.
 
 ## Exit criteria
 

--- a/docs/04-adoption/enterprise-rollout.md
+++ b/docs/04-adoption/enterprise-rollout.md
@@ -2,6 +2,8 @@
 
 **Purpose:** Adopt Nuclear-grade without turning every change into a process exercise.
 
+Adoption should preserve two speeds: teams move quickly while exploring reversible candidates, then slow down at acceptance gates for claims, controlled items, public wording, baselines, releases, and agent authority.
+
 ## Pilot path
 
 1. Pick one team and one change type with real consequence.
@@ -16,6 +18,7 @@
 - Standard packets are required for user, data, dependency, permission, AI-authority, operational, or release consequence.
 - Stronger modes require human review and project-specific controls.
 - AI-assisted changes must record agent scope, evidence, and independent checks when material.
+- Teams should not add Standard records to reversible Quick work only to look rigorous; the control should change a decision.
 
 ## PR adoption
 

--- a/docs/04-adoption/reviewer-playbook.md
+++ b/docs/04-adoption/reviewer-playbook.md
@@ -14,9 +14,14 @@
 
 ## What to challenge
 
+- Wrong or missing decision question.
+- Instructions that are understandable only if read charitably, but still easy for a tired agent to misuse.
 - Claims broader than evidence.
 - Unvalidated assumptions hidden behind confident prose.
+- Subjective confidence, source claims, or vendor language treated as local proof.
 - Quick mode hiding Standard triggers.
+- Fast candidate work treated as accepted configuration before audit gates.
+- Premature baseline or release decision before evidence, rollback, monitoring, and residual risk are visible.
 - Missing rollback or monitoring for release-facing work.
 - AI authority broader than recorded.
 - Public wording that implies compliance, certification, approval, safety, security, or formal verification.
@@ -41,6 +46,7 @@ Ask what kind of checking is being claimed:
 - Full source-family essays in every packet.
 - Nuclear-mode artifacts when consequence does not activate them.
 - Perfect prose before evidence is clear.
+- Slow procedure for reversible exploration when only acceptance needs stronger evidence.
 
 ## Exit criteria
 

--- a/docs/05-reference/skill-evaluation.md
+++ b/docs/05-reference/skill-evaluation.md
@@ -21,6 +21,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Before this agent changes the billing webhook, grill the assumptions and stop conditions.
 - Should trigger: Review this plan for hidden risks before we let the coding agent edit files.
 - Should trigger: What facts would change the release decision for this dependency update?
+- Should trigger: The agent is asking many plausible questions but has not named the decision question the evidence must answer.
 - Should not trigger: Fix a README typo and show the diff.
 - Should not trigger: Explain what this small Python helper function does.
 
@@ -61,6 +62,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Classify whether this API permission plus docs change is Quick, Standard, or stronger.
 - Should trigger: Pick the right mode for a dependency bump that changes authentication behavior.
 - Should trigger: This small diff touches agent authority; classify the risk and evidence obligation.
+- Should trigger: The decision question is clear, but we do not know whether Quick proof is enough to answer it.
 - Should not trigger: Fill out the verification table for already-selected Standard mode.
 - Should not trigger: Write the source-lineage note for a citation change.
 
@@ -77,6 +79,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Build a focused context pack for an agent that can edit tests and run commands.
 - Should trigger: Prepare one-screen reviewer context with authority, proof, and stop conditions.
 - Should trigger: Distill this long implementation thread into what the next agent may do and must prove.
+- Should trigger: Package this work for a downstream agent with the decision question, work phase, forbidden claims, and stop conditions.
 - Should not trigger: Run the packet validator.
 - Should not trigger: Classify the change mode only.
 
@@ -93,6 +96,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Before running this broad file move command, self-check the exact target, expected result, stop condition, and after-action proof.
 - Should trigger: Self-check this public README claim before release because it says the workflow is secure.
 - Should trigger: The agent is about to update dependency and API permission files; check the intended action and evidence first.
+- Should trigger: This candidate doc wording is about to become accepted public baseline wording; check the target, expected result, and stop condition.
 - Should not trigger: Explain what this shell command would do without running it.
 - Should not trigger: Create a whole Standard packet for a normal feature change.
 
@@ -101,6 +105,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Map these release claims to evidence, gaps, and narrowed non-claims.
 - Should trigger: Tests passed, but which claims do they actually prove?
 - Should trigger: Turn this basis and trace into a verification table with pass, gap, and deferred statuses.
+- Should trigger: Separate these claims into fact, assumption, unknown, source claim, local proof, and decision authority before ship review.
 - Should not trigger: Create the packet directory structure.
 - Should not trigger: Make the README more concise.
 
@@ -109,6 +114,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Review this Standard packet and decide ship, defer, block, or ship-with-risk.
 - Should trigger: CI is green; decide whether the dependency update is release-ready and name residual risk.
 - Should trigger: Is this agent-authority change ready to release with the evidence we have?
+- Should trigger: This fast candidate is being promoted to an accepted baseline; slow-audit the evidence, rollback, monitoring, and residual risk.
 - Should not trigger: Identify controlled items before implementation starts.
 - Should not trigger: Draft the risk.md threshold screen.
 
@@ -117,6 +123,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: An agent edited outside its context pack but tests caught it; create an OPEX record and durable control update.
 - Should trigger: A reviewer found a hallucinated source claim after merge; turn the near miss into a template or validator update.
 - Should trigger: Users misunderstood the release note and support needed a workaround; capture operating experience and rebaseline triggers.
+- Should trigger: A doctrine update produced nice prose but no durable control change; turn the review surprise into OPEX.
 - Should not trigger: Fix the failing unit test immediately during incident containment.
 - Should not trigger: Assign blame for who approved the PR.
 
@@ -149,6 +156,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: We are twenty steps into this task and I cannot tell if the current edit still serves the original goal.
 - Should trigger: The agent keeps adding features no one asked for; check whether we have drifted from the objective.
 - Should trigger: We have retried this fix three times without progress; should we re-anchor, escalate, or stop?
+- Should trigger: This small edit looks useful locally, but I cannot trace it to a mission success criterion.
 - Should not trigger: Fix a README typo and show the diff.
 - Should not trigger: Explain what this small helper function does.
 

--- a/skills/classifying-change-risk/SKILL.md
+++ b/skills/classifying-change-risk/SKILL.md
@@ -7,11 +7,12 @@ description: Selects Quick, Standard, or a stronger human-reviewed mode from con
 
 ## Overview
 
-Classify the change before building so rigor scales by consequence. The output is a mode decision with evidence obligations and escalation triggers.
+Classify the change before building so rigor scales by consequence and evidence need. The output is a mode decision tied to the decision question, proof obligations, and escalation triggers.
 
 ## When to Use
 
 - A change request is new, vague, or expanded.
+- The decision question is known but the evidence gate is unclear.
 - A PR has AI-generated code, tests, docs, prompts, or release artifacts.
 - Reviewers disagree about whether Quick evidence is enough.
 - Work is routine, procedural, novel, interrupted, resumed, delegated, or high consequence and needs the right HPI control.
@@ -30,16 +31,18 @@ Classify the change before building so rigor scales by consequence. The output i
 
 ## Process
 
-1. Identify consequence, reversibility, exposure, detectability, uncertainty, and agent authority.
-2. Screen work mode: routine, known procedure, novel/uncertain, interrupted/resumed, or critical action.
-3. Choose Quick only for local, reversible, easy-to-prove work with no new trust boundary.
-4. Choose Standard for user-visible, durable, dependency, permission, data, AI, operational, or release consequence.
-5. Mark Nuclear, Incident, Research Board, or Release as human-reviewed patterns when activated.
-6. Record escalation triggers and the minimum proof required.
+1. Restate the decision question and the evidence gate it needs.
+2. Identify consequence, reversibility, exposure, detectability, uncertainty, and agent authority.
+3. Screen work mode: routine, known procedure, novel/uncertain, interrupted/resumed, or critical action.
+4. Choose Quick only for local, reversible, easy-to-prove work with no new trust boundary.
+5. Choose Standard for user-visible, durable, dependency, permission, data, AI, operational, or release consequence.
+6. Mark Nuclear, Incident, Research Board, or Release as human-reviewed patterns when activated.
+7. Record escalation triggers and the minimum proof required.
 
 ## Outputs
 
 - Selected mode.
+- Decision question and evidence gate.
 - Mode rationale.
 - Required packet files.
 - Proof command or evidence gap.

--- a/skills/controlling-mission-drift/SKILL.md
+++ b/skills/controlling-mission-drift/SKILL.md
@@ -7,7 +7,7 @@ description: Tests current work against a durable mission anchor and forces a re
 
 ## Overview
 
-Mission drift is when an agent keeps shipping work that no longer serves the original objective. It has two faces: intent drift (scope creep, goal substitution, local optimization that wins the task and loses the mission) and standards drift (rigor erodes one accepted concession at a time, the normalization of deviance). This skill keeps a durable mission anchor in front of the work and forces a decision when an action stops serving it: re-anchor, escalate, or stop. The anchor is the objective, the success criteria, and the explicit non-goals. Ownership of the anchor stays with a named person, in the spirit of nuclear-culture accountability: someone is responsible for whether this change still serves its mission.
+Mission drift is when an agent keeps shipping work that no longer serves the original objective. It has two faces: intent drift (scope creep, goal substitution, local optimization that wins the task and loses the mission) and standards drift (rigor erodes one accepted concession at a time, the normalization of deviance). This skill keeps a durable mission anchor in front of the work and forces a decision when an action stops serving it: re-anchor, escalate, or stop. The anchor is the objective, the success criteria, and the explicit non-goals. Ownership of the anchor stays with a named person, in the spirit of nuclear-culture accountability: someone is responsible for whether this change still serves its mission. Small actions must still trace to that larger mission.
 
 ## When to Use
 
@@ -35,7 +35,7 @@ Mission drift is when an agent keeps shipping work that no longer serves the ori
 ## Process
 
 1. Restate the mission anchor from the written record, not from memory: objective, success criteria, and non-goals.
-2. Test the current action against the anchor. Ask plainly: does this action move a success criterion, or does it serve a goal that was substituted along the way?
+2. Test the current action against the anchor. Ask plainly: does this action move a success criterion, or does it serve a substituted local goal?
 3. Zoom out one layer before deciding. Look at the objective and the architecture, not the line in front of you, so the decision is made at the right altitude.
 4. Check the loop and attempt count. If the same objective has failed 3 times, or the same action or fix variant is being retried, stop attempting the next variant.
 5. Check standards drift against the charter and any countable tripwires (for example, a file or function crossing a size limit, a skipped verification, a weaker-than-agreed evidence standard). A single normalized concession is a finding, not a rounding error.

--- a/skills/learning-from-opex/SKILL.md
+++ b/skills/learning-from-opex/SKILL.md
@@ -7,13 +7,14 @@ description: Turns incidents, near misses, bad handoffs, review surprises, escap
 
 ## Overview
 
-Operating experience is only useful when it changes future work. Treat agent mistakes, near misses, review surprises, and support signals as control-system feedback.
+Operating experience is only useful when it changes future work. Treat agent mistakes, near misses, review surprises, shallow analysis, and support signals as control-system feedback.
 
 ## When to Use
 
 - A bad handoff, wrong-file edit, hallucinated claim, tool-scope overrun, escaped defect, or review surprise occurred.
 - Users or operators misunderstood a release, public claim, runbook, template, or baseline.
 - A prior packet, skill, command, test, validator, monitor, or template failed to guide behavior.
+- A doctrine, source, or influence update produced prose without a durable control change.
 
 ## When Not to Use
 
@@ -32,8 +33,9 @@ Operating experience is only useful when it changes future work. Treat agent mis
 1. State what happened without blame language.
 2. Identify the active error, weak or missing control, and affected baseline or artifact.
 3. Choose a durable update: basis, test, validator, template, skill, command, doc, monitor, threshold, or baseline.
-4. Verify the update or explicitly close the lesson with rationale.
-5. Feed the lesson into future questioning, planning, verification, or turnover.
+4. Reject closure that only records regret or explanation when a durable control can change.
+5. Verify the update or explicitly close the lesson with rationale.
+6. Feed the lesson into future questioning, planning, verification, or turnover.
 
 ## Outputs
 

--- a/skills/packing-agent-context/SKILL.md
+++ b/skills/packing-agent-context/SKILL.md
@@ -7,7 +7,7 @@ description: Prepares focused context for an AI agent, reviewer, verifier, or re
 
 ## Overview
 
-Context packs give agents and reviewers the right focused information: role, mode, objective, affected files, evidence obligations, approvals, forbidden actions, source lineage, critical next action, and turnover state.
+Context packs give agents and reviewers the right focused information: role, mode, decision question, objective, affected files, evidence obligations, approvals, forbidden actions, source lineage, critical next action, and turnover state.
 
 ## When to Use
 
@@ -30,13 +30,14 @@ Context packs give agents and reviewers the right focused information: role, mod
 
 ## Process
 
-1. Name the role and objective, and carry the mission anchor (objective, success criteria, non-goals) so it survives context resets. See `controlling-mission-drift`.
+1. Name the role, decision question, and objective, and carry the mission anchor (objective, success criteria, non-goals) so it survives context resets. See `controlling-mission-drift`.
 2. Include only the packet files, affected files, source rows, and evidence commands needed for the next decision.
 3. State last completed action, changed conditions, critical next action, likely error, and control.
-4. State file, command, network, credential, approval, and release authority.
-5. State forbidden claims, do-not-touch targets, stop conditions, and turnover need.
-6. Link the context pack back to the packet and relevant mode rules.
-7. Require incoming confirmation when responsibility transfers.
+4. State current work phase: explore, candidate, audit, or accept.
+5. State file, command, network, credential, approval, and release authority.
+6. State forbidden claims, do-not-touch targets, stop conditions, and turnover need.
+7. Link the context pack back to the packet and relevant mode rules.
+8. Require incoming confirmation when responsibility transfers.
 
 ## Outputs
 

--- a/skills/proving-claims/SKILL.md
+++ b/skills/proving-claims/SKILL.md
@@ -7,7 +7,7 @@ description: Maps claims to evidence, statuses, gaps, tests, evals, reviews, and
 
 ## Overview
 
-Evidence should answer named claims, not create a general feeling that the change is fine. This skill turns claims into traceable proof status.
+Evidence should answer named claims, not create a general feeling that the change is fine. This skill turns claims into traceable proof status and separates fact, assumption, unknown, source claim, local proof, and decision authority.
 
 ## When to Use
 
@@ -31,14 +31,16 @@ Evidence should answer named claims, not create a general feeling that the chang
 
 1. Extract each important claim.
 2. Select the verification type needed for each claim.
-3. Link each claim to basis, control/design feature, implementation, evidence, and ship posture.
-4. Assign evidence status: `pass`, `fail`, `gap`, `deferred`, `not applicable`, or `planned`.
-5. Narrow overbroad claims until the evidence genuinely supports them.
-6. Record gaps and release impact.
+3. Classify the support behind each claim as fact, assumption, unknown, source claim, local proof, or decision authority.
+4. Link each claim to basis, control/design feature, implementation, evidence, and ship posture.
+5. Assign evidence status: `pass`, `fail`, `gap`, `deferred`, `not applicable`, or `planned`.
+6. Narrow overbroad claims until the evidence genuinely supports them.
+7. Record gaps and release impact.
 
 ## Outputs
 
 - Claim-to-evidence rows in `trace.md` or `verification.md`.
+- Fact/source/proof distinction for each important claim.
 - Reproducible evidence commands or artifact links.
 - Verification type for each important claim.
 - Updated ship posture when evidence changes.

--- a/skills/questioning-attitude/SKILL.md
+++ b/skills/questioning-attitude/SKILL.md
@@ -7,7 +7,7 @@ description: Challenges assumptions with skeptical fact-finding before an agent 
 
 ## Overview
 
-Questioning attitude is the Nuclear-grade front door: challenge assumptions before an agent builds, merges, or releases. Prefer facts over confidence, surface uncertainty, and stop when a doubt changes the decision.
+Questioning attitude is the Nuclear-grade front door: find the decision question before an agent builds, merges, or releases. Prefer facts over confidence, surface uncertainty, and stop when a doubt changes the decision.
 
 ## When to Use
 
@@ -36,7 +36,7 @@ Questioning attitude is the Nuclear-grade front door: challenge assumptions befo
 2. List assumptions that must be true for the change to work.
 3. Separate known facts, assumptions, unknowns, and source quality.
 4. Identify uncertainty, danger words, warning signs, error-likely steps, and hidden Standard-mode triggers.
-5. Ask what evidence would change the decision.
+5. Ask what evidence would change the decision; if no evidence could change it, the question is not decision-useful yet.
 6. Validate facts before relying on memory, confidence, or agent-generated claims.
 7. Name pause conditions, hold conditions, and escalation triggers.
 8. Route the next artifact: Quick proof, Standard spec, context pack, turnover, self-check, CM record, mission anchor or drift check, or release decision.
@@ -48,6 +48,7 @@ Questioning attitude is the Nuclear-grade front door: challenge assumptions befo
 - Knowns, unknowns, danger words, and source-quality concerns.
 - Mode/escalation triggers.
 - Evidence needed before execute, verify, review, decide, or baseline.
+- Evidence that would change the decision.
 
 ## Verification
 

--- a/skills/reviewing-ship-readiness/SKILL.md
+++ b/skills/reviewing-ship-readiness/SKILL.md
@@ -7,13 +7,14 @@ description: Records a ship, block, defer, or ship-with-risk decision that ties 
 
 ## Overview
 
-Ship readiness is a decision record, not a mood. It ties baseline, evidence status, residual risk, rollback, monitoring, handoff, and release decision together.
+Ship readiness is a slow-audit decision record, not a mood. It ties baseline, evidence status, residual risk, rollback, monitoring, handoff, and release decision together before a candidate becomes accepted configuration.
 
 ## When to Use
 
 - A Standard packet is approaching merge or release.
 - A PR changes user behavior, security posture, dependencies, agent authority, or operational state.
 - Evidence gaps must be accepted or made blocking.
+- A fast candidate is being promoted into a baseline, public claim, release, or other trust-bearing state.
 - Turnover, support handoff, OPEX trigger, or conservative decision posture needs to be explicit.
 
 ## When Not to Use
@@ -29,12 +30,13 @@ Ship readiness is a decision record, not a mood. It ties baseline, evidence stat
 ## Process
 
 1. Confirm baseline and affected artifacts.
-2. Review each evidence status and unresolved gap, and check for accumulated drift: does the shipped change still serve the mission anchor, with non-goals uncrossed? See `controlling-mission-drift`.
-3. Confirm rollback or restore path.
-4. Confirm monitoring and post-release checks.
-5. State why the decision is conservative enough for remaining uncertainty.
-6. Record one decision: ship, block, defer, or ship with named residual risk.
-7. Name owner, abort trigger, turnover need, OPEX trigger, and baseline trigger.
+2. Confirm the decision question has been answered by evidence, not confidence.
+3. Review each evidence status and unresolved gap, and check for accumulated drift: does the shipped change still serve the mission anchor, with non-goals uncrossed? See `controlling-mission-drift`.
+4. Confirm rollback or restore path.
+5. Confirm monitoring and post-release checks.
+6. State why the decision is conservative enough for remaining uncertainty.
+7. Record one decision: ship, block, defer, or ship with named residual risk.
+8. Name owner, abort trigger, turnover need, OPEX trigger, and baseline trigger.
 
 ## Outputs
 

--- a/skills/self-checking-agent-actions/SKILL.md
+++ b/skills/self-checking-agent-actions/SKILL.md
@@ -7,13 +7,14 @@ description: Checks a critical agent action against its exact target, expected r
 
 ## Overview
 
-Self-checking makes a critical action deliberate: identify the target, expected result, stop condition, action, and after-action check before claiming success.
+Self-checking makes a cut-point action deliberate: identify the target, expected result, stop condition, action, and after-action check before claiming success.
 
 ## When to Use
 
 - A command can delete, move, publish, release, migrate, or affect external state.
 - An edit touches public claims, source lineage, permissions, credentials, dependencies, models, APIs, or release posture.
 - An agent is about to make a broad or repetitive change where wrong-target work is plausible.
+- A fast candidate is about to become a public claim, accepted baseline, or release action.
 
 ## When Not to Use
 
@@ -29,7 +30,7 @@ Self-checking makes a critical action deliberate: identify the target, expected 
 
 ## Process
 
-1. Stop and name the exact action and target.
+1. Stop at the cut point and name the exact action and target.
 2. Think through expected result, likely error, and what would make the action invalid.
 3. Act only inside the named authority boundary.
 4. Review actual result against expected result before making claims.

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -7,7 +7,7 @@ description: Turns an AI-assisted change into a focused evidence path by choosin
 
 ## Overview
 
-Use Nuclear-grade to turn AI-assisted software work into a focused evidence path: question assumptions, classify consequence inside the risk screen, create the smallest useful packet, specify intent, prove important claims, and make the release decision explicit. The repo charter (`.nuclear/charter.md`) states the durable principles all changes hold to; a per-change mission anchor states what a given change is for and guards against drift.
+Use Nuclear-grade to turn AI-assisted software work into a focused evidence path: frame the decision question, classify consequence inside the risk screen, create the smallest useful packet, specify intent, prove important claims, and make the release decision explicit. The repo charter (`.nuclear/charter.md`) states the durable principles all changes hold to; a per-change mission anchor states what a given change is for and guards against drift.
 
 ## When to Use
 
@@ -31,14 +31,15 @@ Use Nuclear-grade to turn AI-assisted software work into a focused evidence path
 
 ## Process
 
-1. Apply questioning attitude: decision question, assumptions, evidence gaps, stop conditions.
+1. Apply questioning attitude: decision question, assumptions, evidence that would change the decision, evidence gaps, stop conditions.
 2. Classify the change as Quick, Standard, or a human-reviewed stronger mode.
 3. Create or locate the packet under `.nuclear/changes/<slug>/`.
 4. Record the minimum specification/design basis, evidence obligation, affected files, and forbidden claims.
 5. Record deviations when the selected workflow or template no longer fits actual conditions.
 6. Keep implementation work linked to claims and evidence.
-7. Run the validator for Quick or Standard packets.
-8. Stop before release if evidence status, rollback, monitoring, decision, baseline trigger, or legal boundary wording is unclear.
+7. Move quickly on reversible candidates, but slow down before accepting claims, public wording, baselines, releases, or authority changes.
+8. Run the validator for Quick or Standard packets.
+9. Stop before release if evidence status, rollback, monitoring, decision, baseline trigger, or legal boundary wording is unclear.
 
 ## Outputs
 

--- a/templates/standard/basis.md
+++ b/templates/standard/basis.md
@@ -46,6 +46,14 @@ What must not happen?
 |---|---|---|---|---|
 | | | | | |
 
+## Grounding status
+
+Separate confidence from evidence before derived claims are accepted.
+
+| Statement | Fact / assumption / unknown / source claim / local proof / decision authority | Evidence or source | Decision impact |
+|---|---|---|---|
+| | | | |
+
 ## Interfaces and trust boundaries
 
 - Internal interfaces affected:

--- a/templates/standard/plan.md
+++ b/templates/standard/plan.md
@@ -43,6 +43,17 @@ Number the minimum steps needed to complete the change.
 2.
 3.
 
+## Two-speed work plan
+
+Separate fast candidate work from slower acceptance gates.
+
+| Work phase | Allowed actions | Acceptance gate |
+|---|---|---|
+| explore | | |
+| candidate | | |
+| audit | | |
+| accept | | |
+
 ## HPI task preview
 
 | Critical step | Likely error | Consequence | Control / contingency | Evidence |

--- a/templates/standard/risk.md
+++ b/templates/standard/risk.md
@@ -19,6 +19,7 @@
 - Owner:
 - Date:
 - Current lifecycle phase: Question / Specify / Plan / Execute / Verify / Review / Decide / Baseline / Operate / Learn
+- Current work phase: explore / candidate / audit / accept
 - Summary:
 
 ## Mission anchor
@@ -34,6 +35,7 @@ State what this change is for, so a long session can be tested against it. See `
 ## Questioning-attitude summary
 
 - Decision question:
+- Evidence that would change the decision:
 - Assumptions that changed the mode:
 - Facts still needing validation:
 - Stop or hold conditions:

--- a/templates/standard/ship.md
+++ b/templates/standard/ship.md
@@ -72,6 +72,7 @@
 - Decision: ship / do not ship / defer / ship with residual risk
 - Decision maker:
 - Rationale:
+- Decision question answered by evidence? yes/no:
 - Conditions attached:
 - Decision posture: conservative enough / not conservative enough:
 - Abort or rollback trigger:
@@ -95,6 +96,7 @@
 ## Exit criteria
 
 - Release decision is explicit.
+- Slow-audit acceptance is complete before baseline or public claims are accepted.
 - Baseline trigger is explicit when controlled state changes.
 - Evidence status and gaps are visible.
 - Residual uncertainty is bounded, owned, or blocks/defer the decision.

--- a/templates/standard/trace.md
+++ b/templates/standard/trace.md
@@ -24,9 +24,9 @@
 
 Use status labels: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
 
-| ID | Claim | Basis link | Control / design feature | Verification evidence | Ship posture | Status |
-|---|---|---|---|---|---|---|
-| C-001 | | `basis.md` | | `verification.md` | | planned |
+| ID | Claim | Basis link | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|
+| C-001 | | `basis.md` | | fact / assumption / unknown / source claim / local proof / decision authority | `verification.md` | | planned |
 
 ## Evidence chain
 
@@ -58,6 +58,7 @@ Risk / need
 ## Exit criteria
 
 - Each important claim has a status label.
+- Each important claim names its support type.
 - Every shipped claim has evidence or an accepted residual risk.
 - Deferred/gap claims are not used as release evidence.
 - Reviewer can navigate claim → specification/basis → evidence → release decision quickly.

--- a/templates/standard/verification.md
+++ b/templates/standard/verification.md
@@ -26,9 +26,9 @@ Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`.
 
 ## Claim-to-evidence table
 
-| Claim / requirement ID | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
-|---|---|---|---|---|---|---|
-| REQ-001 | deterministic test / eval / self-check / peer-check / concurrent verification / independent verification / peer review | | | | | |
+| Claim / requirement ID | Support type | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|---|
+| REQ-001 | fact / assumption / unknown / source claim / local proof / decision authority | deterministic test / eval / self-check / peer-check / concurrent verification / independent verification / peer review | | | | | |
 
 ## Verification type guide
 
@@ -87,6 +87,7 @@ Use if activated.
 ## Exit criteria
 
 - Each important claim has `pass`, `fail`, `gap`, `deferred`, or `not applicable` status.
+- Each important claim separates support type from verification type.
 - Evidence is linked rather than pasted in full.
 - Gaps are explicit and reflected in `ship.md`.
 - Reviewer can tell whether the evidence supports the release decision.


### PR DESCRIPTION
## Summary
- translate owner-supplied operating influences into existing Nuclear-grade doctrine, skills, commands, templates, and adoption surfaces without adding quotes or attributions
- add a Standard packet with CM, OPEX, verification, ship, and baseline records for the doctrine-spine update
- strengthen downstream-agent controls around decision questions, grounded proof, mission alignment, two-speed work, and cut-point self-checking

## Validation
- python3 tools/ng.py validate .nuclear/changes/doctrine-spine-influence
- env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_public_docs.py tests/test_skill_contracts.py tests/test_command_contracts.py tests/test_ng_validate.py -q
- python3 tools/ng.py doctor .
- rg attribution-name scan returned no tracked insertions of the owner-supplied names
- rg boundary scan reviewed expected boundary-safe hits only