### PR TITLE
Reframe the core loop as seven control points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ These entries record public-facing changes. They do not claim the project is a m
 
 ## [Unreleased]
 
+### Changed
+
+- Reframed the core loop as seven control points in `WORKFLOWS.md`. Each step (`Question`, `Specify`, `Execute`, `Verify`, `Decide`, `Save approved version`, `Operate`) is now tabled with the failure mode it stops, the artifact it produces, and the abort condition for proceeding. A skipped step is now a named failure mode you chose to accept, not an unstated shortcut. The everyday seven-step form is reconciled with the full eleven-beat path used for standard and high-consequence work.
+- `README.md` keeps the canonical eleven-step path and original lifecycle diagram, with one new sentence introducing the control-point treatment and pointing to `WORKFLOWS.md` for the detail. No simplified-vs-full duplication on the landing page.
+
 ## [0.4.0] - 2026-05-31
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This is practical, not decorative. Instructions should be hard to misuse. Small 
 Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn
 ```
 
-Each step is a control point: it stops one specific failure mode and produces one artifact you can point at. A skipped step is not a shortcut — it is a named failure mode you chose to accept. The per-step "stops / produces / abort if" detail lives in [`WORKFLOWS.md`](WORKFLOWS.md).
+Each step is a control point: it stops one specific failure mode and produces one artifact you can point at. A skipped step is not a shortcut — it is a named failure mode you chose to accept. The control-point detail — stops / produces / abort-if — is tabled for the everyday seven-step form of this loop in [`WORKFLOWS.md`](WORKFLOWS.md), and the same control points apply when the loop fans out into all eleven beats.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -89,40 +89,27 @@ treat green tests as a yes -> make an explicit release decision and save the res
 
 This is practical, not decorative. Instructions should be hard to misuse. Small actions should still serve the goal. And "I'm confident" should never be confused with "here is the proof."
 
-## The core loop: seven control points
-
-Each step is a control point. Each one stops one specific failure mode. A skipped step is not a shortcut — it is a known failure mode you chose to accept.
-
-| # | Step | Stops | Produces | Abort if |
-|---|---|---|---|---|
-| 1 | **Question** — frame the decision before code moves | Solving the wrong problem, confidently | The fact that would change your mind | You cannot name a question that has an answer |
-| 2 | **Specify** — write what must be true and what must not break | Shifting goalposts; reviewers guessing intent from the diff | Intent, boundary, must-not-break list | The spec cannot be falsified |
-| 3 | **Execute** — build inside the boundary; agents work here, not before | Scope drift, surprise blast radius, silent dependency changes | The diff and the trace from spec to change | A step crosses the boundary without escalation |
-| 4 | **Verify** — test the claim against reality, not against confidence | Green-tests-but-wrong-feature; persuasion over proof | Evidence, named gaps, what was not tested | The evidence does not address the spec |
-| 5 | **Decide** — ship, defer, or stop, on purpose and on the record | Silent merges; evidence-shaped PRs with no decision | A decision with reasoning, leftover risk, rollback, monitoring | Nobody owns the decision |
-| 6 | **Save the approved version** (baseline) — lock what everyone agreed is correct | Drift; "the prompt changed and nobody knew" | Controlled record of code, prompts, models, tools, deps, evals, docs | You cannot say what the controlled items are |
-| 7 | **Operate** — run it in the real world; watch it; learn from it | Forgotten near misses; lessons dying in chat history | Signals, OPEX entries, triggers for a new baseline | There is no owner for what to watch |
-
-The loop closes when operation feeds the next question.
-
-```mermaid
-flowchart LR
-    Q[1 Question] --> S[2 Specify] --> E[3 Execute] --> V[4 Verify]
-    V --> Dec{5 Decide}
-    Dec -->|ship / defer| B[6 Save approved version] --> O[7 Operate]
-    Dec -->|block| S
-    O -.signals + OPEX feed the next question.-> Q
-```
-
-The expanded path — useful for standard and high-consequence work — fans the same loop out into eleven beats:
+## The full path
 
 ```text
 Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn
 ```
 
+Each step is a control point: it stops one specific failure mode and produces one artifact you can point at. A skipped step is not a shortcut — it is a named failure mode you chose to accept. The per-step "stops / produces / abort if" detail lives in [`WORKFLOWS.md`](WORKFLOWS.md).
+
+```mermaid
+flowchart LR
+    Q[Question] --> D[Discover] --> S[Specify] --> P[Plan]
+    P --> E[Execute] --> V[Verify] --> R[Review]
+    R --> Dec{Decide}
+    Dec -->|ship / defer| B[Baseline] --> O[Operate] --> L[Learn]
+    Dec -->|block| P
+    L -.feeds future basis.-> Q
+```
+
 More diagrams (mode decision tree, skill graph, packet artifact graph) are in [`docs/diagrams.md`](docs/diagrams.md).
 
-A "baseline" is just the version you have agreed is correct and want to protect. Small and standard change records are the Git-native way to walk a change through this loop. You sort the risk early so the simple path stays easy to teach. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them.
+A "baseline" is just the version you have agreed is correct and want to protect. Small and standard change records are the Git-native way to walk a change through this path. You sort the risk early so the simple path stays easy to teach. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them.
 
 Underneath the path sit a few habits borrowed from high-reliability work, what we call HPI for AI agents (Human Performance Improvement). Use them when they change the outcome: brief the work before a risky step, double-check critical actions, hand off cleanly, get a second set of eyes when trust is on the line, and capture the lesson after a near miss.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Normal AI coding:
 prompt -> diff -> persuasion -> merge risk
 
 Nuclear-grade:
-question -> specify -> execute -> verify -> decide -> save approved version -> operation
+question -> specify -> execute -> verify -> decide -> save approved version -> operate
 ```
 
 This first release (v0) is a working toolkit you can use today: skills an agent can follow, command prompts you can paste, templates for small and large changes, a small command-line tool, a checker, a public list of sources, one fully worked example, and one hands-on comparison study.

--- a/README.md
+++ b/README.md
@@ -89,31 +89,40 @@ treat green tests as a yes -> make an explicit release decision and save the res
 
 This is practical, not decorative. Instructions should be hard to misuse. Small actions should still serve the goal. And "I'm confident" should never be confused with "here is the proof."
 
-## The full path
+## The core loop: seven control points
+
+Each step is a control point. Each one stops one specific failure mode. A skipped step is not a shortcut — it is a known failure mode you chose to accept.
+
+| # | Step | Stops | Produces | Abort if |
+|---|---|---|---|---|
+| 1 | **Question** — frame the decision before code moves | Solving the wrong problem, confidently | The fact that would change your mind | You cannot name a question that has an answer |
+| 2 | **Specify** — write what must be true and what must not break | Shifting goalposts; reviewers guessing intent from the diff | Intent, boundary, must-not-break list | The spec cannot be falsified |
+| 3 | **Execute** — build inside the boundary; agents work here, not before | Scope drift, surprise blast radius, silent dependency changes | The diff and the trace from spec to change | A step crosses the boundary without escalation |
+| 4 | **Verify** — test the claim against reality, not against confidence | Green-tests-but-wrong-feature; persuasion over proof | Evidence, named gaps, what was not tested | The evidence does not address the spec |
+| 5 | **Decide** — ship, defer, or stop, on purpose and on the record | Silent merges; evidence-shaped PRs with no decision | A decision with reasoning, leftover risk, rollback, monitoring | Nobody owns the decision |
+| 6 | **Save the approved version** (baseline) — lock what everyone agreed is correct | Drift; "the prompt changed and nobody knew" | Controlled record of code, prompts, models, tools, deps, evals, docs | You cannot say what the controlled items are |
+| 7 | **Operate** — run it in the real world; watch it; learn from it | Forgotten near misses; lessons dying in chat history | Signals, OPEX entries, triggers for a new baseline | There is no owner for what to watch |
+
+The loop closes when operation feeds the next question.
+
+```mermaid
+flowchart LR
+    Q[1 Question] --> S[2 Specify] --> E[3 Execute] --> V[4 Verify]
+    V --> Dec{5 Decide}
+    Dec -->|ship / defer| B[6 Save approved version] --> O[7 Operate]
+    Dec -->|block| S
+    O -.signals + OPEX feed the next question.-> Q
+```
+
+The expanded path — useful for standard and high-consequence work — fans the same loop out into eleven beats:
 
 ```text
 Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn
 ```
 
-Short version for everyday use:
-
-```text
-Question -> Specify -> Execute -> Verify -> Decide
-```
-
-```mermaid
-flowchart LR
-    Q[Question] --> D[Discover] --> S[Specify] --> P[Plan]
-    P --> E[Execute] --> V[Verify] --> R[Review]
-    R --> Dec{Decide}
-    Dec -->|ship / defer| B[Baseline] --> O[Operate] --> L[Learn]
-    Dec -->|block| P
-    L -.feeds future basis.-> Q
-```
-
 More diagrams (mode decision tree, skill graph, packet artifact graph) are in [`docs/diagrams.md`](docs/diagrams.md).
 
-A "baseline" is just the version you have agreed is correct and want to protect. Small and standard change records are the Git-native way to walk a change through this path. You sort the risk early so the simple path stays easy to teach. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them.
+A "baseline" is just the version you have agreed is correct and want to protect. Small and standard change records are the Git-native way to walk a change through this loop. You sort the risk early so the simple path stays easy to teach. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them.
 
 Underneath the path sit a few habits borrowed from high-reliability work, what we call HPI for AI agents (Human Performance Improvement). Use them when they change the outcome: brief the work before a risky step, double-check critical actions, hand off cleanly, get a second set of eyes when trust is on the line, and capture the lesson after a near miss.
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -7,14 +7,34 @@ Normal AI coding:
 prompt -> diff -> persuasion -> merge risk
 
 Nuclear-grade:
-question -> specify -> execute -> verify -> decide -> baseline -> operation
+question -> specify -> execute -> verify -> decide -> save approved version -> operation
 ```
 
-A "baseline" is the version everyone agreed is correct.
+A "baseline" — the saved approved version — is the version everyone agreed is correct.
+
+## The core loop: seven control points
+
+Each step is a control point. Each one stops one specific failure mode. Skip any of them and you ship a different kind of risk.
+
+| # | Step | Stops | Produces | Abort if |
+|---|---|---|---|---|
+| 1 | **Question** — frame the decision before code moves | Solving the wrong problem, confidently | The fact that would change your mind | You cannot name a question that has an answer |
+| 2 | **Specify** — write what must be true and what must not break | Shifting goalposts; reviewers guessing intent from the diff | Intent, boundary, must-not-break list | The spec cannot be falsified |
+| 3 | **Execute** — build inside the boundary; agents work here, not before | Scope drift, surprise blast radius, silent dependency changes | The diff and the trace from spec to change | A step crosses the boundary without escalation |
+| 4 | **Verify** — test the claim against reality, not against confidence | Green-tests-but-wrong-feature; persuasion over proof | Evidence, named gaps, what was not tested | The evidence does not address the spec |
+| 5 | **Decide** — ship, defer, or stop, on purpose and on the record | Silent merges; evidence-shaped PRs with no decision | A decision with reasoning, leftover risk, rollback, monitoring | Nobody owns the decision |
+| 6 | **Save the approved version** (baseline) — lock what everyone agreed is correct | Drift; "the prompt changed and nobody knew" | Controlled record of code, prompts, models, tools, deps, evals, docs | You cannot say what the controlled items are |
+| 7 | **Operate** — run it in the real world; watch it; learn from it | Forgotten near misses; lessons dying in chat history | Signals, OPEX entries, triggers for a new baseline | There is no owner for what to watch |
+
+The loop closes when operation feeds the next question.
+
+This is what "nuclear-grade" buys you over prompt-and-pray: every step has a job, an artifact, and a stop condition. A skipped step is not a shortcut — it is a known failure mode you chose to accept.
+
+## Two speeds, one loop
 
 For AI agents, we add a few small habits from Human Performance Improvement (HPI). Brief the work first. Double-check risky actions. Hand off cleanly. Get a second set of eyes when needed. Decide on the careful side. Learn from near misses.
 
-The workflow has two speeds. While you explore and try ideas you can throw away, move fast. Slow down when the work turns into something real: a piece of evidence, a claim, a file you must keep under control, public wording, a baseline, a release call, or a change to what the agent is allowed to do.
+The workflow has two speeds. While you explore and try ideas you can throw away, move fast — the loop still runs, but the artifacts are lightweight. Slow down when the work turns into something real: a piece of evidence, a claim, a file you must keep under control, public wording, a saved approved version, a release call, or a change to what the agent is allowed to do.
 
 ## Workflow catalog
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -7,7 +7,7 @@ Normal AI coding:
 prompt -> diff -> persuasion -> merge risk
 
 Nuclear-grade:
-question -> specify -> execute -> verify -> decide -> save approved version -> operation
+question -> specify -> execute -> verify -> decide -> save approved version -> operate
 ```
 
 A "baseline" — the saved approved version — is the version everyone agreed is correct.

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -18,7 +18,7 @@ Each step is a control point. Each one stops one specific failure mode. Skip any
 
 | # | Step | Stops | Produces | Abort if |
 |---|---|---|---|---|
-| 1 | **Question** — frame the decision before code moves | Solving the wrong problem, confidently | The fact that would change your mind | You cannot name a question that has an answer |
+| 1 | **Question** — frame the decision before code moves | Solving the wrong problem, confidently | The fact that would change your mind | No answer would change what you do |
 | 2 | **Specify** — write what must be true and what must not break | Shifting goalposts; reviewers guessing intent from the diff | Intent, boundary, must-not-break list | The spec cannot be falsified |
 | 3 | **Execute** — build inside the boundary; agents work here, not before | Scope drift, surprise blast radius, silent dependency changes | The diff and the trace from spec to change | A step crosses the boundary without escalation |
 | 4 | **Verify** — test the claim against reality, not against confidence | Green-tests-but-wrong-feature; persuasion over proof | Evidence, named gaps, what was not tested | The evidence does not address the spec |
@@ -29,6 +29,8 @@ Each step is a control point. Each one stops one specific failure mode. Skip any
 The loop closes when operation feeds the next question.
 
 This is what "nuclear-grade" buys you over prompt-and-pray: every step has a job, an artifact, and a stop condition. A skipped step is not a shortcut — it is a known failure mode you chose to accept.
+
+These seven are the everyday form of the loop. For standard and high-consequence work the same loop fans out into eleven beats — `Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn` — splitting Question into Question/Discover, Specify into Specify/Plan, Decide into Review/Decide, and Operate into Operate/Learn. Same control points, more beats.
 
 ## Two speeds, one loop
 


### PR DESCRIPTION
## Summary

The core loop — `Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn` — was reading as a plain checklist where every step looked interchangeable. That hid what makes it nuclear-grade.

This reframes each step as a **control point** with three concrete attributes:

- **Stops** — the specific failure mode it prevents (e.g. "solving the wrong problem, confidently", "green-tests-but-wrong-feature", "silent merges")
- **Produces** — the artifact you can actually point at (the falsifiable spec, the trace, the named gaps, the controlled record)
- **Abort if** — the precondition for proceeding ("the spec cannot be falsified", "nobody owns the decision", "you cannot say what the controlled items are")

A skipped control point is no longer a shortcut — it is a named failure mode you chose to accept.

## Changes

- **`WORKFLOWS.md`** — adds a "core loop: seven control points" table with stops / produces / abort-if per step, plus a "Two speeds, one loop" subhead that attaches the existing fast/slow story to the new framing. Clarifies that baselines = the saved approved version.
- **`README.md`** — keeps the existing canonical 11-step path and mermaid diagram intact (no simplified-vs-full split on the landing page). Adds one sentence: each step is a control point that stops one failure mode and produces one artifact, with a pointer to `WORKFLOWS.md` for the per-step detail.

## Test plan

- [x] `python tools/ng.py doctor .` → `OK`
- [x] `python -m pytest tests/ -q` → all 107 tests pass
- [ ] Reviewer reads the new `WORKFLOWS.md` headline cold and can name what each control point stops, produces, and aborts on
- [ ] Reviewer confirms README still leads with the canonical 11-step loop, with no simplified/full duplication
