### PR TITLE
Restructure adoption surface: CORE habits, decision matrix, starter kits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,19 @@
 
 <!-- What changed, why it matters, and what evidence should reviewers inspect. -->
 
+## Mode
+
+<!-- Quick / Standard / stronger. One line on why a lower mode is insufficient. -->
+
 ## Change packet
 
 <!-- For non-trivial changes, link .nuclear/changes/<slug>/. For trivial docs-only changes, write N/A and explain why. -->
+
+## Proof command + result
+
+```bash
+# the exact command(s) that prove this change, and the actual outcome (e.g. test names + status)
+```
 
 ## Verification
 

--- a/CORE.md
+++ b/CORE.md
@@ -1,0 +1,185 @@
+# Core habits and the decision matrix
+
+A strategic spine for adopting Nuclear-grade *without* adopting all of it.
+
+The full system has 27 skills, command prompts, templates, a checker, change-control packets,
+governance docs, and an operating model. Most projects need a few of those at once. This page
+names the **Core 7** habits every disciplined AI-agent change uses, and the **decision matrix**
+that says which **ancillary cluster** to invoke for which kind of change.
+
+Default is Core only. Ancillaries fire by trigger, not by default.
+
+---
+
+## The one idea
+
+> Go fast while you are exploring. Slow down the moment the work becomes a promise.
+> *(see [`README.md`](README.md) — "The one idea")*
+
+The Core 7 are the habits that make that slowdown cheap.
+
+---
+
+## The Core 7
+
+**Three always-on dispositions.** Every change uses these, no matter how small.
+
+| # | Skill | What it carries |
+|---|---|---|
+| 1 | [`questioning-attitude`](skills/questioning-attitude/SKILL.md) | The one fact that would change the decision. |
+| 2 | [`rating-change-risk`](skills/rating-change-risk/SKILL.md) | Quick / Standard / stronger — the fork that sets every downstream cost. |
+| 3 | [`proving-claims`](skills/proving-claims/SKILL.md) | Every claim maps to evidence, a gap, or an explicit non-claim. |
+
+**Four cut-point habits.** Universal as patterns; fire at specific moments.
+
+| # | Skill | Fires when |
+|---|---|---|
+| 4 | [`double-checking-before-acting`](skills/double-checking-before-acting/SKILL.md) | An irreversible cut-point is about to happen — file write, broad command, credential use, model swap, public claim, release action. |
+| 5 | [`staying-on-mission`](skills/staying-on-mission/SKILL.md) | Work drifts, the same fix repeats, or standards slip one small step at a time. |
+| 6 | [`checking-release-readiness`](skills/checking-release-readiness/SKILL.md) | A change approaches merge or release. Ship / block / defer / ship-with-named-risk — pick one and back it. |
+| 7 | [`learning-from-experience`](skills/learning-from-experience/SKILL.md) | Something went wrong or nearly did, and a safeguard should change. |
+
+**Core habits are dispositions, not artifacts.** Their cost matches the change. 30 seconds of
+thought on a tiny edit. Longer on a hard one.
+
+---
+
+## The decision matrix
+
+Scan the triggers. For every "yes," invoke that cluster. Default is Core only.
+
+| When this is true... | ...invoke this cluster | Skills |
+|---|---|---|
+| **Every change** (no trigger required) | **Core** | the 7 above |
+| Agent has write / run / network / approval authority over its own working set | **Agent authority** | [`deciding-who-decides`](skills/deciding-who-decides/SKILL.md), [`declaring-intent`](skills/declaring-intent/SKILL.md), [`stress-testing-agent-changes`](skills/stress-testing-agent-changes/SKILL.md), [`vetting-outside-code-and-models`](skills/vetting-outside-code-and-models/SKILL.md), [`recording-what-an-agent-did`](skills/recording-what-an-agent-did/SKILL.md), [`briefing-an-agent`](skills/briefing-an-agent/SKILL.md), [`handing-off-work`](skills/handing-off-work/SKILL.md) |
+| You produce controlled artifacts — packets, baselines, multi-PR threads, owned configurations | **Configuration management** | [`creating-change-records`](skills/creating-change-records/SKILL.md), [`choosing-what-to-control`](skills/choosing-what-to-control/SKILL.md), [`checking-what-a-change-affects`](skills/checking-what-a-change-affects/SKILL.md), [`recording-a-known-good-version`](skills/recording-a-known-good-version/SKILL.md), [`closing-stale-packets`](skills/closing-stale-packets/SKILL.md), [`breaking-down-the-work`](skills/breaking-down-the-work/SKILL.md) |
+| The change makes public claims about safety, security, compliance, licensing, or provenance | **Claims discipline** | [`checking-legal-and-safety-wording`](skills/checking-legal-and-safety-wording/SKILL.md), [`checking-source-claims`](skills/checking-source-claims/SKILL.md) |
+| Production failure, data loss, or agent-caused harm | **Incident & deficiency** | [`responding-to-incidents`](skills/responding-to-incidents/SKILL.md), [`tracking-deficiencies`](skills/tracking-deficiencies/SKILL.md) |
+| Repo layout / structure decision, or visible code-quality drift in a diff | **Hygiene** | [`organizing-project-folders`](skills/organizing-project-folders/SKILL.md), [`reviewing-code-quality`](skills/reviewing-code-quality/SKILL.md) |
+
+All 27 skills are accounted for: 7 Core + 19 ancillary across 5 clusters + 1 router
+([`using-nuclear-grade`](skills/using-nuclear-grade/SKILL.md)).
+
+### What each ancillary trigger feels like in practice
+
+- **Agent authority.** Your agent can write files, run commands, call APIs, hold credentials, or
+  approve actions in its working set. This cluster is *main-path*, not overlay, for that adopter
+  — the trigger is permanent for you. Start from the worked example at
+  [`docs/03-worked-examples/ai-agent-tool-permissions/`](docs/03-worked-examples/ai-agent-tool-permissions/);
+  read [`docs/04-adoption/agent-authority-model.md`](docs/04-adoption/agent-authority-model.md)
+  (especially its self-modification boundary section).
+- **Configuration management.** You have artifacts whose accepted version matters — prompts,
+  evals, dependency pins, model identifiers, release notes, public docs. The cluster keeps the
+  "what is the version we agreed on, and what would invalidate it" question answerable.
+- **Claims discipline.** Your repo says things in public that someone might rely on. The cluster
+  keeps wording inside its evidence and away from words it cannot back. See
+  [`DISCLAIMER.md`](DISCLAIMER.md) and
+  [`docs/00-standards-foundation/compliance-boundaries.md`](docs/00-standards-foundation/compliance-boundaries.md).
+- **Incident & deficiency.** Real failures (production outage, data loss, agent did harm) — not
+  ordinary bugs. The cluster also covers known problems that will outlive a single change.
+- **Hygiene.** Repo layout, naming, and code-quality drift inside a diff. Lightweight; runs
+  often.
+
+---
+
+## The agent-drafts-spec workflow
+
+The packet templates ship empty on purpose, but filling them by hand is *not* the intended
+loop. The intended loop is:
+
+```text
+user prompt
+  -> agent drafts risk.md / proof.md from the query
+  -> human edits and approves
+  -> agent writes code against the approved spec
+  -> human reviews via the validator + the Core habits
+```
+
+The human is editor and approver, not typist. This is what makes Quick mode feel like a
+speed-up rather than a tax.
+
+**Caution.** An agent that drafts its own spec *and* self-validates it against a structural
+check is the "ships green by editing its own test" trap in new clothing. Trust-bearing specs
+need an independent approver — a human, or an out-of-band check the agent cannot rewrite. See
+the self-modification boundary section in
+[`docs/04-adoption/agent-authority-model.md`](docs/04-adoption/agent-authority-model.md).
+
+---
+
+## Where doctrine lives
+
+Different files hold different layers of guidance. Keep each light.
+
+| Layer | Holds | Loaded |
+|---|---|---|
+| Always-on context (e.g. `CLAUDE.md`, system prompt) | One-line pointers to the vendored skills + a link to your charter | Always-on |
+| Adopter [`AGENTS.md`](AGENTS.md) | Authority boundaries + completion standard | When an agent reads repo guidance |
+| `.nuclear/charter.md` | The few lasting rules — authority envelope, mission anchor | Per change |
+| Per-task context pack | Role, mode, allowed/forbidden actions, required proof, stop conditions | Per task |
+
+This repo's own [`AGENTS.md`](AGENTS.md) is the reference shape: its **completion standard**
+(an agent is not done until it can name files changed, the change record, the evidence, the
+handoff used or why it was not needed, the intent declared, the gaps still open, and the
+boundary wording it checked) is the strongest exportable artifact. The starter kits ship it
+trimmed and `<fill-in>`-marked.
+
+---
+
+## The always-on packaging rule
+
+Vendor each Core skill as a file (e.g. `skills/<name>/SKILL.md`) so its **body loads only when
+the skill fires**. In always-on context put only a **one-line pointer per skill** — the
+description-sized cost.
+
+The framework's own measurement (see [`docs/05-reference/skills-token-audit.md`](docs/05-reference/skills-token-audit.md)):
+the 27 skill descriptions sit at ~104 tokens each (gated 80-500 characters), and the ~35k of
+skill *bodies* are loaded only on invocation. Pasting a fat doctrine block into always-on
+context multiplies that cost across every subagent in a fan-out. The framework rejects that
+pattern by measurement.
+
+---
+
+## Starter kits
+
+Files beat documentation. Commands beat files. Three drop-in directories:
+
+- [`starter-kit/core/`](starter-kit/core/) — minimum universal kit (Core 7 pointers,
+  `AGENTS.md` skeleton, `.nuclear/charter.md` skeleton, Quick templates).
+- [`starter-kit/agent-authority/`](starter-kit/agent-authority/) — Core + the Agent-authority
+  cluster vendored + context-pack template + a pre-filled PR template.
+- [`starter-kit/public-claims/`](starter-kit/public-claims/) — Core + the Claims-discipline
+  cluster vendored + a boundary-wording note + a DISCLAIMER skeleton.
+
+Each kit's `README.md` states the trigger condition and a five-line "drop this in" command.
+
+---
+
+## What the validator does and does not do
+
+`python tools/ng.py validate` is a structural lint — it checks that required sections are
+present, the placeholder marker is gone, internal links resolve, evidence statuses are set,
+and public wording stays inside its boundary. It is not a judgment on whether the code does
+what the change record claims. That judgment is [`proving-claims`](skills/proving-claims/SKILL.md)
+plus [`checking-release-readiness`](skills/checking-release-readiness/SKILL.md) plus a human
+review. See [`docs/02-operating-system/validators.md`](docs/02-operating-system/validators.md)
+("human judgment decides engineering adequacy; the validator checks whether the packet exposes
+the evidence needed for that judgment").
+
+---
+
+## A note on tone
+
+"Nuclear-grade" names the *standard of care*, not a compliance claim (see
+[`DISCLAIMER.md`](DISCLAIMER.md)). When you adopt this, you do not have to adopt the
+vocabulary. If the name would mis-calibrate your team — or sound like an assurance claim you
+cannot back — rename the local copy. Keep the discipline; drop the branding.
+
+---
+
+## Source-lineage note
+
+This page is an original synthesis of patterns from the wider Nuclear-grade repository. It
+does not create assurance, certification, audit evidence, or any guarantee about how a system
+should behave. See [`DISCLAIMER.md`](DISCLAIMER.md) and
+[`docs/00-standards-foundation/`](docs/00-standards-foundation/) for the boundary discipline
+this page sits inside.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,8 @@
 
 Nuclear-grade runs inside your repo. Public v0 does not need a package registry, a hosted service, or an agent marketplace plug-in.
 
+> The `ng` CLI scaffolds and checks packets, but Nuclear-grade is markdown-first. Many adopters only need [`CORE.md`](CORE.md) (the seven habits + the decision matrix) plus one [`starter-kit/`](starter-kit/) directory copied into their repo. The steps below set up the optional CLI.
+
 ## Requirements
 
 - Python 3.11 or newer (tested on 3.12).

--- a/MAXIMS.md
+++ b/MAXIMS.md
@@ -1,0 +1,87 @@
+# Maxims
+
+The principles people quote when they explain why this works. Most of these are stated in
+longer form elsewhere in the repository; this page is the short, share-friendly version.
+
+---
+
+> **Go fast while you are exploring. Slow down the moment the work becomes a promise.**
+
+Cheap iteration earns the right to spend time on careful evidence. Reverse the order and you
+get neither speed nor confidence. *(See [`README.md`](README.md) — "The one idea.")*
+
+---
+
+> **The name is the standard, not the vocabulary.**
+
+"Nuclear-grade" names the *standard of care*. When you adopt the discipline, you do not have
+to adopt the word. If the branding would mis-calibrate your team, rename the local copy. The
+habits travel; the label does not need to. *(See [`README.md`](README.md) and
+[`DISCLAIMER.md`](DISCLAIMER.md).)*
+
+---
+
+> **A guard inside the agent's writable set is not enforcement — it is a suggestion the agent
+> can edit.**
+
+If an agent has write authority over the tests, prompts, CI scripts, or approval policy that
+decide whether its work is acceptable, the agent can satisfy the check by changing the check.
+Move the gate out of the agent's writable working set. *(See
+[`docs/04-adoption/agent-authority-model.md`](docs/04-adoption/agent-authority-model.md) —
+"Self-modification boundary.")*
+
+---
+
+> **Human judgment decides engineering adequacy; the validator checks whether the packet
+> exposes the evidence needed for that judgment.**
+
+The structural checker is a lint, not a verdict. It says the evidence is reachable; it does
+not say the evidence is correct. The judgment is a human's, supported by
+[`proving-claims`](skills/proving-claims/SKILL.md) and
+[`checking-release-readiness`](skills/checking-release-readiness/SKILL.md). *(See
+[`docs/02-operating-system/validators.md`](docs/02-operating-system/validators.md).)*
+
+---
+
+> **The agent drafts; the human approves.**
+
+The intended loop is *user prompt → agent drafts the change record → human edits and approves
+→ agent writes code → human reviews*. The human is editor and approver, not typist. Filling
+empty templates by hand is what makes packets feel like a tax. *(See [`CORE.md`](CORE.md) —
+"The agent-drafts-spec workflow.")*
+
+---
+
+> **For an unattended agent there is no one to ask. "Ask first" degrades to stop, record the
+> needed approval, and halt.**
+
+Prose that prompts for permission only works when someone is reading. In an unattended
+subagent run, design the gate as block / escalate / record, not as a request for input that
+nothing will answer. *(See
+[`docs/04-adoption/agent-authority-model.md`](docs/04-adoption/agent-authority-model.md) —
+"Denial rule.")*
+
+---
+
+> **CI passing is not a release decision.**
+
+A green pipeline says the checks that exist did not fail. A release decision says ship, block,
+defer, or ship-with-named-risk — and names the residual risk, the rollback, the monitoring,
+and the baseline trigger. *(See
+[`skills/checking-release-readiness/SKILL.md`](skills/checking-release-readiness/SKILL.md).)*
+
+---
+
+> **Every surprise updates a control.**
+
+A near miss, an escaped bug, a bad handoff, an agent mistake — each should change a test, a
+template, a prompt, a monitor, a checker, or a baseline. Lessons that do not change a control
+disappear. *(See [`skills/learning-from-experience/SKILL.md`](skills/learning-from-experience/SKILL.md).)*
+
+---
+
+## Source-lineage note
+
+These maxims summarize patterns from the wider Nuclear-grade repository. They do not create
+assurance or certification — see [`DISCLAIMER.md`](DISCLAIMER.md) for the boundary discipline
+they sit inside.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,6 +6,26 @@ Nuclear-grade should make decisions faster, not pile on paperwork. Move fast whi
 
 > **Note on the demo:** the first time you run `validate` on a fresh packet, expect `FAILED: ... has unfilled template prompts`. Templates ship with empty prompts on purpose. Fill in the prompts that matter, then run `validate` again. The checker is supposed to refuse silent gaps.
 
+## 0. Choose how much to adopt, and let the agent draft
+
+You do not need the whole repository to get value. Most adopters need the **Core 7** habits and one ancillary cluster, picked by trigger. See [`CORE.md`](CORE.md) for the decision matrix and [`starter-kit/`](starter-kit/) for drop-in directories.
+
+The intended loop is **not** "human types out a packet." It is:
+
+```text
+user prompt
+  -> agent drafts risk.md / proof.md from the query
+  -> human edits and approves the draft
+  -> agent writes code against the approved spec
+  -> human reviews via the validator + the Core habits
+```
+
+The human is editor and approver, not typist. Hand-filling the templates step-by-step is the *learning* path below; the *working* path is to have your agent generate the draft from your request and review the draft against the Core habits.
+
+> *Caution.* An agent that drafts its own spec *and* self-validates against a structural check is the "ships green by editing its own test" trap in new clothing. Trust-bearing specs need an independent approver — a human, or a check the agent cannot rewrite. See [`docs/04-adoption/agent-authority-model.md`](docs/04-adoption/agent-authority-model.md).
+
+The numbered steps below walk through the loop by hand so the safety check, the validator, and the habits are visible.
+
 ## 1. Check the repo
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,32 +28,20 @@ question -> specify -> execute -> verify -> decide -> save approved version -> o
 
 This first release (v0) is a working toolkit you can use today: skills an agent can follow, command prompts you can paste, templates for small and large changes, a small command-line tool, a checker, a public list of sources, one fully worked example, and one hands-on comparison study.
 
-## Try it in 60 seconds
+## Watch an AI agent prove it stayed in its workspace
 
 ```bash
-python tools/ng.py doctor .
-python tools/ng.py list
-python tools/ng.py new demo-change --mode quick
-python tools/ng.py validate .nuclear/changes/demo-change
-```
-
-The fourth command is *supposed* to print `FAILED: ...` with `still contains the placeholder marker`. That is the safety check doing its job. Every template ships with a `NUCLEAR-GRADE-PLACEHOLDER` line, and the checker refuses to pass until you delete it. So fill in the parts that matter, delete the marker line, and run `validate` again:
-
-```bash
-# In .nuclear/changes/demo-change/risk.md and proof.md, replace the prompts with
-# real content, then delete the line that starts with "<!-- NUCLEAR-GRADE-PLACEHOLDER".
-python tools/ng.py validate .nuclear/changes/demo-change
-# OK: .nuclear/changes/demo-change
-```
-
-Look at the included real example:
-
-```bash
-python -m pytest docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py -q
+python -m pytest docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py -v
+# 4 passed — every write attempt outside the agent's workspace was denied and logged.
 python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions
+# OK — the change record exposes the evidence behind that result.
 ```
 
-If your shell only has `python3`, use `python3`.
+That packet is your template, not a curiosity. See [`CORE.md`](CORE.md) for the seven habits behind it and the decision matrix that picks up the rest by trigger; copy [`docs/03-worked-examples/ai-agent-tool-permissions/`](docs/03-worked-examples/ai-agent-tool-permissions/) to start your own.
+
+The longer guided tour — including the safety-check learning device — lives in [`QUICKSTART.md`](QUICKSTART.md). If your shell only has `python3`, use `python3`.
+
+> *A note on tone.* "Nuclear-grade" names the *standard of care*, not a compliance claim (see [`DISCLAIMER.md`](DISCLAIMER.md)). When you adopt this, you do not have to adopt the vocabulary — if the name would mis-calibrate your team or sound like an assurance claim you cannot back, rename the local copy. Keep the discipline; drop the branding.
 
 ## What you get
 
@@ -196,12 +184,20 @@ Included now:
 - a hands-on comparison across twelve real use cases (see `docs/03-worked-examples/skill-workflow-comparison/`);
 - tests for the checker, the tool, the skill and command contracts, the public docs, and the example code.
 
+The comparison is honest about its limits: it is author-judged across twelve scenarios, design evidence not proof of effectiveness. See [`docs/03-worked-examples/skill-workflow-comparison/methodology.md`](docs/03-worked-examples/skill-workflow-comparison/methodology.md) for what the trials measure and what they do not.
+
 Not included yet:
 
 - a packaged plug-in for one specific agent platform;
 - full worked examples for external API controls and human approval steps;
 - deep automated checking for the heavier change patterns;
 - a production sandbox, a compliance package, or any regulated-use assurance workflow.
+
+## Across tools
+
+Cursor, Claude Code, Aider, Codex, and Copilot each read slightly different files for their reasoning and rules. `.nuclear/`, `AGENTS.md`, and the `SKILL.md` contract are a **shared, tool-agnostic shape** that all of them can import as plain markdown: a portable surface for agent authority, change records, and evidence. No matter which IDE ships reasoning steps natively, the packets and habits travel with the repository.
+
+See [`MAXIMS.md`](MAXIMS.md) for the principles in short form, and [`CORE.md`](CORE.md) for the decision matrix that picks the right kit for your project.
 
 ## License and limits
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,10 @@ Nuclear-grade Public v0 is a workflow you can use today, not a finished platform
 
 - More worked examples for API controls and human approval steps.
 - Optional packaging for specific agent platforms.
+- Cross-tool renderers: official `.cursorrules`, Claude-Code-skill, Aider-conventions, and Copilot-instructions exports that consume the same `SKILL.md` source of truth, so the same discipline reads natively in each IDE.
+- Optional MCP server over `.nuclear/`: agents query past risk and decision records before proposing changes; opt-in, preserves deterministic CI as the default.
+- Optional semantic check above the deterministic validator: an opt-in LLM-as-Judge layer that asks whether the code satisfies `proof.md`. Per-change LLM auditing is the principled non-default (see `docs/02-operating-system/validators.md` line 3); opt-in is the principled extension.
+- GitHub template repository (`nuclear-grade-starter`) so adopters can click "Use this template" for the Agent-authority kit (see `starter-kit/`).
 - Richer status reports for active packets.
 - Checks for release mode and incident mode once those patterns settle.
 - Optional repeatable checking for HPI records, once real use proves the templates.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -38,6 +38,8 @@ A skill is a self-contained set of instructions an agent can follow. Each one li
 
 `using-nuclear-grade` is the way in and the router. From there the main path runs question -> rate risk -> create -> prove -> check release -> baseline -> learn, and the heavier overlays switch on only when the stakes call for them. Reach for an overlay when its trigger fires, not by default.
 
+The diagram below is the full-system view. For cherry-pick adoption see [`CORE.md`](CORE.md): seven core habits (`questioning-attitude`, `rating-change-risk`, `proving-claims`, `double-checking-before-acting`, `staying-on-mission`, `checking-release-readiness`, `learning-from-experience`) plus the decision matrix that invokes the ancillary clusters by trigger.
+
 ```mermaid
 flowchart TD
     UNG([using-nuclear-grade<br/>router / entry point])
@@ -61,6 +63,9 @@ flowchart TD
       CMD[staying-on-mission]
       RCQ[reviewing-code-quality]
       CSP[closing-stale-packets]
+      DWD[deciding-who-decides]
+      DI[declaring-intent]
+      VOC[vetting-outside-code-and-models]
     end
 
     CCP -.delegate / resume.-> PAC
@@ -71,7 +76,12 @@ flowchart TD
     QA -.long drifting session.-> CMD
     PC -.standards drift in diff.-> RCQ
     LFO -.stale packet sweep.-> CSP
+    CCR -.irreversible action.-> DWD
+    DWD --> DI
+    CCR -.outside dependency / model.-> VOC
 ```
+
+**Consequence note.** If your agent has write, run, network, or approval authority over its own working set, treat `deciding-who-decides`, `declaring-intent`, `stress-testing-agent-changes`, `vetting-outside-code-and-models`, `recording-what-an-agent-did`, `briefing-an-agent`, and `handing-off-work` as **main-path, not overlay** — the trigger is always on for you. The agent-tool-permissions worked example is your template. See the Agent-authority row in [`CORE.md`](CORE.md)'s decision matrix.
 
 See [`docs/diagrams.md`](docs/diagrams.md) for the lifecycle, mode, and packet diagrams.
 See [`docs/05-reference/skills-token-audit.md`](docs/05-reference/skills-token-audit.md) for the measured token cost of these skills and the `ng tokens` budget gate.

--- a/docs/03-worked-examples/ai-agent-tool-permissions/README.md
+++ b/docs/03-worked-examples/ai-agent-tool-permissions/README.md
@@ -4,6 +4,8 @@
 
 **Example status:** Worked example v0. This directory now includes a finished Standard-mode packet at `.nuclear/changes/add-agent-tool-permissions/`, a small sample build, and pytest proof for C-001.
 
+**For adopters: this packet is your template, not just an illustration.** If your agent has write, run, network, or approval authority over its own working set, see the Agent-authority row in [`../../../CORE.md`](../../../CORE.md)'s decision matrix and start by copying this packet's shape.
+
 **Boundary:** This example is for teaching and is built for software. It is not a compliance package, a regulated safety analysis, a formal QA record, or a certification claim.
 
 ---

--- a/docs/04-adoption/README.md
+++ b/docs/04-adoption/README.md
@@ -1,9 +1,9 @@
 # Adoption Docs
 
-Start here when you bring Nuclear-grade to a team or an agent workflow.
+Most adopters should start one level up at [`../../CORE.md`](../../CORE.md) — the seven core habits and the decision matrix that triggers the ancillary clusters — and only descend into the docs below when a profile points here.
 
 - `enterprise-rollout.md`
-- `agent-authority-model.md`
+- `agent-authority-model.md` — includes the self-modification boundary and the enforcement rung-ladder for agents with authority over their own working set.
 - `reviewer-playbook.md`
 
 ## Source-lineage note

--- a/docs/04-adoption/agent-authority-model.md
+++ b/docs/04-adoption/agent-authority-model.md
@@ -32,9 +32,29 @@ If an action goes beyond what the agent is allowed to do, the agent must stop. I
 
 At a cut point, the agent must pause before acting if any of these is unclear: the exact target, the expected result, the forbidden claim, or the stop condition. A cut point includes file writes, broad commands, public claims, changes to trust in a dependency, model, or API, release actions, and other steps that are hard to undo.
 
+For an **unattended** agent there is no human to ask mid-run. "Ask first" degrades to **stop, record the needed approval, and halt** (or hard-block the action). Design the gate as block / escalate / record, not as a prompt for permission that nothing will answer.
+
+## Self-modification boundary
+
+An agent with write or run authority over its own tests, prompts, approval policy, or CI config can satisfy a gate by changing the gate. "Ships green by editing its own test" is not proof; it is the control failing silently. A guard inside the agent's writable working set is not enforcement — it is a suggestion the agent can edit.
+
+The rule: the control that decides whether the agent's work is acceptable must sit where the agent cannot rewrite it.
+
+### Enforcement rungs (weak to strong)
+
+| Rung | Mechanism | Agent can defeat by | Use when |
+|---|---|---|---|
+| 1 | Advisory print or log | ignoring the output | drafting only |
+| 2 | Exit code in a script the agent can edit | editing the script | reversible local work |
+| 3 | Tests the agent can edit | rewriting the test | low stakes, trusted loop |
+| 4 | Out-of-band CI the agent cannot push to | nothing in-repo | authority over its own working set |
+| 5 | Branch protection or required human review | nothing | irreversible or trust-bearing |
+
+Match the rung to the authority. An agent that can edit files at rungs 1-3 has no real gate; promote to rung 4-5 before granting write or run authority over its own controls.
+
 ## Exit criteria
 
-Agent authority is acceptable when a reviewer can see four things: what the agent was allowed to do, what it actually changed, what evidence it produced, and what it was forbidden to claim.
+Agent authority is acceptable when a reviewer can see five things: what the agent was allowed to do, what it actually changed, what evidence it produced, what it was forbidden to claim, and **where the controls that gate its work live relative to its writable set** (rung 4 or higher when the agent has authority over its own tests, prompts, or CI).
 
 ## Source-lineage note
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 
 | Need | Start |
 |---|---|
+| Pick a starter set (adopt lightly) | [`../CORE.md`](../CORE.md) |
 | Try the workflow | [`../QUICKSTART.md`](../QUICKSTART.md) |
 | Install or initialize | [`../INSTALL.md`](../INSTALL.md) |
 | Pick a workflow | [`../WORKFLOWS.md`](../WORKFLOWS.md) |
@@ -39,9 +40,10 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 ## Suggested first path
 
 1. [`../README.md`](../README.md)
-2. [`../QUICKSTART.md`](../QUICKSTART.md)
-3. [`../WORKFLOWS.md`](../WORKFLOWS.md)
-4. [`02-operating-system/change-control-packets.md`](02-operating-system/change-control-packets.md)
-5. [`03-worked-examples/ai-agent-tool-permissions/README.md`](03-worked-examples/ai-agent-tool-permissions/README.md)
+2. [`../CORE.md`](../CORE.md) — pick the seven habits and the ancillary clusters you actually need.
+3. [`../QUICKSTART.md`](../QUICKSTART.md)
+4. [`../WORKFLOWS.md`](../WORKFLOWS.md)
+5. [`02-operating-system/change-control-packets.md`](02-operating-system/change-control-packets.md)
+6. [`03-worked-examples/ai-agent-tool-permissions/README.md`](03-worked-examples/ai-agent-tool-permissions/README.md) — if your agent has authority over its own working set, read this **first**, as the template.
 
 One reminder about limits. This repo borrows ideas from public sources. It does not claim to meet any standard. See [`../DISCLAIMER.md`](../DISCLAIMER.md).

--- a/nuclear_grade/cli.py
+++ b/nuclear_grade/cli.py
@@ -18,6 +18,7 @@ if __package__ in (None, ""):
 from nuclear_grade.efficacy import run_all as run_efficacy
 from nuclear_grade.ng_validate import (
     PLACEHOLDER_MARKER,
+    check_internal_links,
     detect_packet_mode,
     has_closure_note,
     validate_packet,
@@ -94,6 +95,8 @@ REQUIRED_PUBLIC_FILES = (
     "SECURITY.md",
     "CONTRIBUTING.md",
     "CODE_OF_CONDUCT.md",
+    "CORE.md",
+    "MAXIMS.md",
 )
 REQUIRED_SKILL_SECTIONS = (
     "## Overview",
@@ -597,6 +600,8 @@ def collect_doctor_failures(repo: Path) -> list[str]:
         failures.append(f"missing commands directory: {commands_dir.name}")
     else:
         failures.extend(check_command_contracts(commands_dir))
+
+    failures.extend(check_internal_links(repo, list(REQUIRED_PUBLIC_FILES)))
     return failures
 
 

--- a/nuclear_grade/ng_validate.py
+++ b/nuclear_grade/ng_validate.py
@@ -323,6 +323,31 @@ def _check_relative_links(packet_path: Path, md_file: Path, text: str, messages:
             messages.append(f"{rel_file} has broken relative link: {target}")
 
 
+def check_internal_links(repo: Path, files: list[str]) -> list[str]:
+    """Check that internal markdown links in `files` resolve from each file's directory.
+
+    External URLs (http(s)://, mailto:) and pure anchors (#section) are ignored.
+    Returns a list of failure messages, one per broken link.
+    """
+
+    failures: list[str] = []
+    for relative_name in files:
+        md_file = repo / relative_name
+        if not md_file.exists():
+            continue
+        text = md_file.read_text(encoding="utf-8")
+        for match in MARKDOWN_LINK_PATTERN.finditer(text):
+            target = match.group(1).strip()
+            if _is_external_or_anchor(target):
+                continue
+            target_path = target.strip("<>").split("#", 1)[0]
+            if not target_path:
+                continue
+            if not (md_file.parent / target_path).exists():
+                failures.append(f"{relative_name} has broken relative link: {target}")
+    return failures
+
+
 def _is_external_or_anchor(target: str) -> bool:
     lowered = target.lower()
     return (

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -35,6 +35,7 @@ The repo charter (`.nuclear/charter.md`) holds the lasting rules every change fo
 
 1. Start with a questioning attitude. Name the decision question, the assumptions, the fact that would change the decision, the gaps in evidence, and when to stop.
 2. Sort the change into Quick, Standard, or a stronger mode that a human reviews.
+   - If you are adopting Nuclear-grade for the first time, pick the Core 7 habits from `CORE.md` and invoke ancillary clusters by trigger rather than enabling everything at once.
 3. Create or find the change record under `.nuclear/changes/<slug>/`.
 4. Write down the least you need: what the change must do, what it must prove, the files it touches, and the claims it must not make.
 5. If the chosen workflow or template stops fitting the real situation, write down where you went off it and why.

--- a/starter-kit/README.md
+++ b/starter-kit/README.md
@@ -1,0 +1,19 @@
+# Starter kits
+
+Copy-paste-ready directories for the three most common adoption contexts. Each kit is a thin
+shape, not a full vendored snapshot — you keep the skill files in their original locations (or
+copy the ones your kit lists) and avoid maintaining duplicate copies as the framework evolves.
+
+| Kit | Trigger | What it gives you |
+|---|---|---|
+| [`core/`](core/) | Every project | The seven core habits + an `AGENTS.md` skeleton + a `.nuclear/charter.md` skeleton + Quick-mode packet pointers. The base every other kit extends. |
+| [`agent-authority/`](agent-authority/) | Your agent has write / run / network / approval authority over its own working set | Core + the Agent-authority cluster + a context-pack template + a pre-filled PR template that names the rung-ladder. |
+| [`public-claims/`](public-claims/) | Your repo makes public claims about safety, security, compliance, licensing, or provenance | Core + the Claims-discipline cluster + a `BOUNDARY-WORDING.md` derived from `docs/00-standards-foundation/` + a DISCLAIMER skeleton. |
+
+Each kit's `README.md` carries a five-line "drop this into your repo" command and lists the skills it expects you to copy.
+
+See [`../CORE.md`](../CORE.md) for the decision matrix that picks the right kit, and the always-on packaging rule (vendor each chosen skill as a file; in always-on context put a one-line pointer per skill — not a fat doctrine block).
+
+## Source-lineage note
+
+These kits are an original packaging of patterns from this repository. They do not create assurance or any guarantee about how a system should behave. See [`../DISCLAIMER.md`](../DISCLAIMER.md).

--- a/starter-kit/agent-authority/.github/PULL_REQUEST_TEMPLATE.md
+++ b/starter-kit/agent-authority/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!-- What changed, why it matters, and what evidence reviewers should inspect. -->
+
+## Mode
+
+<!-- Quick / Standard / stronger. One line on why a lower mode is insufficient. -->
+
+## Change packet
+
+<!-- Link `.nuclear/changes/<slug>/`. For trivial docs-only changes write N/A and state why. -->
+
+## Proof command + result
+
+```bash
+# the exact command(s) that prove the change, and the actual outcome
+```
+
+## Enforcement rung
+
+<!-- Where do the controls that gate this work live, relative to the agent's writable set?
+     Rung 1 advisory print, 2 editable exit-code, 3 editable test, 4 out-of-band CI,
+     5 branch protection / human review. Rung 4+ is required when the agent has authority
+     over its own tests, prompts, or CI. -->
+
+## Verification
+
+- [ ] Tests and validator pass locally.
+- [ ] Packet validation passes if this PR creates or changes a `.nuclear/changes/<slug>/`
+      packet.
+- [ ] HPI records are updated if turnover, self-check, OPEX, or dependency / model / API trust
+      was activated.
+- [ ] New claims avoid compliance, certification, regulator approval, production sandbox, or
+      formal QA overclaiming.
+- [ ] New source-lineage entries use public, open, linkable sources or are explicitly marked
+      unresolved.
+- [ ] Boundary wording was checked; residual risks are stated below.
+
+## Residual risks or gaps
+
+<!-- Accepted gaps, deferred work, and anything reviewers should not infer from this PR. -->

--- a/starter-kit/agent-authority/CONTEXT-PACK.md
+++ b/starter-kit/agent-authority/CONTEXT-PACK.md
@@ -1,0 +1,63 @@
+# Context pack: `<task name>`
+
+A focused brief for an AI agent that holds real authority on a single task. Fill in every
+section before granting authority. Keep this short — a context pack is not a project plan.
+
+## Objective
+
+`<fill-in: one sentence on what this task accomplishes>`
+
+## Decision question
+
+`<fill-in: the falsifiable question this task answers>`
+
+## Packet path
+
+`<fill-in: path to the .nuclear/changes/<slug>/ packet that holds this task's evidence, or N/A
+with the reason>`
+
+## Allowed actions
+
+The agent may:
+
+- `<fill-in: file paths or globs it may write>`;
+- `<fill-in: commands it may run>`;
+- `<fill-in: network calls it may make, with hosts>`;
+- `<fill-in: credentials it may use, with rotation policy>`.
+
+## Forbidden actions
+
+The agent may not:
+
+- write outside the allowed paths;
+- run any command not listed above;
+- make a public claim;
+- change the release stance;
+- edit its own tests, prompts, or this context pack;
+- `<fill-in: project-specific forbidden actions>`.
+
+## Approval gates
+
+- `<fill-in: which actions require explicit human approval before execution>`.
+
+## Required proof
+
+The agent must produce, before the work is accepted:
+
+- `<fill-in: the exact tests, commands, or evidence artifacts that must run and their
+  expected status>`.
+
+## Stop conditions
+
+The agent must stop and surface (not "ask first" — see denial rule) when:
+
+- a forbidden action is attempted;
+- a required-proof artifact does not run;
+- a step the agent took is not reproducible;
+- `<fill-in: project-specific stop conditions>`.
+
+## Source-lineage note
+
+This template is derived from the context-pack pattern described in
+`docs/02-operating-system/context-packs.md` of the Nuclear-grade repository. It does not create
+assurance.

--- a/starter-kit/agent-authority/README.md
+++ b/starter-kit/agent-authority/README.md
@@ -1,0 +1,65 @@
+# Starter kit: Agent-authority
+
+Use this when your AI agent has write, run, network, or approval authority over its own
+working set. The agent-tool-permissions worked example
+([`../../docs/03-worked-examples/ai-agent-tool-permissions/`](../../docs/03-worked-examples/ai-agent-tool-permissions/))
+is the reference packet for this kit.
+
+## When this trigger fires
+
+Any "yes" puts you in this kit:
+
+- the agent writes files in your repo or a workspace it shares with humans;
+- the agent runs shell commands or network calls in production paths;
+- the agent holds credentials, API keys, or model access tokens;
+- the agent can approve, merge, deploy, publish, or release;
+- the agent has authority over its own tests, prompts, CI config, or approval policy.
+
+If the last one is true, read the **self-modification boundary** in
+[`../../docs/04-adoption/agent-authority-model.md`](../../docs/04-adoption/agent-authority-model.md)
+before anything else. Guards inside the agent's writable set are not enforcement.
+
+## Drop this into your repo
+
+```bash
+# from this repo's root, into your repo at $TARGET:
+# 1. Start from Core.
+cp -r starter-kit/core/{AGENTS.md,.nuclear} "$TARGET"/
+cp -r starter-kit/agent-authority/{CONTEXT-PACK.md,.github} "$TARGET"/
+# 2. Add Core 7 skills (see starter-kit/core/README.md).
+# 3. Add the Agent-authority cluster:
+for s in deciding-who-decides declaring-intent stress-testing-agent-changes \
+         vetting-outside-code-and-models recording-what-an-agent-did \
+         briefing-an-agent handing-off-work; do
+  mkdir -p "$TARGET/skills/$s"
+  cp "skills/$s/SKILL.md" "$TARGET/skills/$s/SKILL.md"
+done
+# 4. Copy the agent-authority adoption doc as required reading:
+mkdir -p "$TARGET/docs/04-adoption"
+cp docs/04-adoption/agent-authority-model.md "$TARGET/docs/04-adoption/"
+```
+
+## What this kit contains
+
+- [`CONTEXT-PACK.md`](CONTEXT-PACK.md) — a fill-in template for the per-task context pack
+  required when an agent gets real authority (per
+  [`../../docs/02-operating-system/context-packs.md`](../../docs/02-operating-system/context-packs.md)).
+- [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — pre-filled with
+  explicit Mode + Proof-command fields and the rung-ladder reminder.
+
+## The Agent-authority cluster (in trigger order)
+
+| Skill | When to invoke |
+|---|---|
+| `deciding-who-decides` | At the start: who holds authority for this change — agent at the edge, or human gate? |
+| `declaring-intent` | Before each irreversible action: state expected result, abort criteria, rollback. |
+| `briefing-an-agent` | Hand the agent a focused context pack, not the whole repo. |
+| `recording-what-an-agent-did` | Capture the agent's scope, permissions, approvals, and independent checks. |
+| `vetting-outside-code-and-models` | When a dependency, model, API, or vendor claim is on the trust path. |
+| `stress-testing-agent-changes` | Red-team the change before merge — hostile inputs, escape attempts, authority overflow. |
+| `handing-off-work` | When a session ends, the work pauses, or another agent or human takes over. |
+
+## Source-lineage note
+
+This kit packages original patterns from this repository. It does not create assurance. See
+[`../../DISCLAIMER.md`](../../DISCLAIMER.md).

--- a/starter-kit/core/.nuclear/README.md
+++ b/starter-kit/core/.nuclear/README.md
@@ -1,0 +1,5 @@
+# Nuclear-grade workspace
+
+Change records live in `changes/<slug>/`.
+
+This workspace stores evidence for engineering review. It does not create compliance, formal V&V, safety, security, or regulatory adequacy.

--- a/starter-kit/core/.nuclear/charter.md
+++ b/starter-kit/core/.nuclear/charter.md
@@ -1,0 +1,41 @@
+# Charter for `<your repo name>`
+
+The few lasting rules every change in this repo follows. Keep this short — five articles is a
+good ceiling. The point of a charter is that it does not change with the work.
+
+Derived from the Nuclear-grade charter pattern; trim to what your project actually needs.
+
+## 1. Questioning attitude before commitment
+
+Before any change that creates a promise — a public claim, an accepted version, a release, a
+new agent authority — name the one fact that would change the decision. Confidence is not
+evidence.
+
+## 2. Two-speed control
+
+Go fast while exploring. Slow down the moment the work becomes a promise. Reversible, well-
+evidenced work is decided at the edge; anything irreversible, trust-bearing, or thinly
+evidenced escalates to a human gate.
+
+## 3. Authority follows information
+
+The person or agent closest to the work declares intent and reasoning before a critical action.
+Anyone may halt unclear work. Bad news is surfaced, not punished. Authority does not skip
+gates.
+
+## 4. Boundary discipline
+
+This repo does not by itself produce assurance, certification, or any safety, security, or
+regulatory adequacy claim. Public claims stay inside their evidence.
+
+## 5. `<fill-in: your project-specific lasting rule>`
+
+`<fill-in: a rule that applies to every change in your project — naming convention, an
+inviolable invariant, a domain-specific guard.>`
+
+---
+
+## Source-lineage note
+
+This charter shape is derived from the public Nuclear-grade pattern. It does not create
+assurance. Adapt to your project's actual lasting rules.

--- a/starter-kit/core/AGENTS.md
+++ b/starter-kit/core/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent guidance for `<your repo name>`
+
+This file tells an AI agent — and any human reviewing the agent's work — what authority the
+agent has in this repo and what "done" means here. Derived from the Nuclear-grade adopter
+template; trim what you do not need.
+
+## Authority boundaries
+
+An agent working in this repo may not, without an authorized human:
+
+- change the release stance of any artifact without a release-readiness record;
+- enlarge a claim about source lineage, evidence, or assurance;
+- add a compliance claim, certification claim, or formal verification and validation claim;
+- edit security, credential, network, or production material;
+- invoke "authority to information" to skip a required human gate;
+- treat green CI as proof of any claim beyond what the checks actually cover;
+- overwrite a change record without recording the overwrite.
+
+Add or remove rules as your context requires. State each `<fill-in>` boundary in the negative.
+
+## Recommended skills (Core 7)
+
+- `skills/questioning-attitude/SKILL.md`
+- `skills/rating-change-risk/SKILL.md`
+- `skills/proving-claims/SKILL.md`
+- `skills/double-checking-before-acting/SKILL.md`
+- `skills/staying-on-mission/SKILL.md`
+- `skills/checking-release-readiness/SKILL.md`
+- `skills/learning-from-experience/SKILL.md`
+
+Add ancillary clusters (Agent-authority, Configuration management, Claims discipline, Incident,
+Hygiene) by trigger from the decision matrix in `CORE.md`.
+
+## Completion standard
+
+An agent is not done until it can name:
+
+- the files it changed;
+- the change record or reasoning it used;
+- the evidence it ran;
+- the handoff, self-check, OPEX, or trust record it used, or why it did not need one;
+- the intent it declared and the decision rights or escalation it used for any critical action;
+- the gaps still open;
+- the boundary wording it checked;
+- `<fill-in: any project-specific completion criteria>`.
+
+## Boundary note
+
+Work in this repo does not by itself create formal verification and validation, regulatory
+approval, certification, safety-basis evidence, procurement evidence, or legal advice. Public
+claims must stay inside their evidence — see `<fill-in: link to your DISCLAIMER or boundary
+doc>`.
+
+## Source-lineage note
+
+This file is derived from the public Nuclear-grade adopter template. It does not create
+assurance. Original Nuclear-grade source-lineage discipline applies.

--- a/starter-kit/core/README.md
+++ b/starter-kit/core/README.md
@@ -29,6 +29,9 @@ Then fill in the `<fill-in>` markers in `AGENTS.md` and `.nuclear/charter.md`.
   repo's own AGENTS.md (its strongest exportable artifact) and trimmed with `<fill-in>` markers.
 - [`.nuclear/charter.md`](.nuclear/charter.md) — a five-article charter skeleton: lasting rules
   every change follows.
+- [`.nuclear/README.md`](.nuclear/README.md) and an empty `.nuclear/changes/` — the workspace
+  skeleton `ng doctor` looks for. Equivalent to what `ng init` would create, so the kit-as-shipped
+  passes `ng doctor` without requiring the CLI.
 
 ## The Core 7
 

--- a/starter-kit/core/README.md
+++ b/starter-kit/core/README.md
@@ -1,0 +1,54 @@
+# Starter kit: Core
+
+Use this when you want the discipline without the full system. The Core 7 habits apply to every
+disciplined AI-agent change; ancillary clusters from [`../../CORE.md`](../../CORE.md) layer on
+when their triggers fire.
+
+## Drop this into your repo
+
+```bash
+# from this repo's root, into your repo at $TARGET:
+cp -r starter-kit/core/{AGENTS.md,.nuclear} "$TARGET"/
+# then copy the seven core skill files:
+for s in questioning-attitude rating-change-risk proving-claims \
+         double-checking-before-acting staying-on-mission \
+         checking-release-readiness learning-from-experience; do
+  mkdir -p "$TARGET/skills/$s"
+  cp "skills/$s/SKILL.md" "$TARGET/skills/$s/SKILL.md"
+done
+# and the two Quick-mode templates:
+mkdir -p "$TARGET/templates/quick"
+cp templates/quick/{risk.md,proof.md} "$TARGET/templates/quick/"
+```
+
+Then fill in the `<fill-in>` markers in `AGENTS.md` and `.nuclear/charter.md`.
+
+## What this kit contains
+
+- [`AGENTS.md`](AGENTS.md) — authority boundaries and a completion standard, derived from this
+  repo's own AGENTS.md (its strongest exportable artifact) and trimmed with `<fill-in>` markers.
+- [`.nuclear/charter.md`](.nuclear/charter.md) — a five-article charter skeleton: lasting rules
+  every change follows.
+
+## The Core 7
+
+| Skill | One-liner |
+|---|---|
+| `questioning-attitude` | The one fact that would change the decision. |
+| `rating-change-risk` | Quick / Standard / stronger — the fork that sets every downstream cost. |
+| `proving-claims` | Every claim maps to evidence, a gap, or an explicit non-claim. |
+| `double-checking-before-acting` | Target / expected / stop, at every irreversible cut-point. |
+| `staying-on-mission` | Three-strike anti-drift; re-anchor, escalate, or stop. |
+| `checking-release-readiness` | Ship / block / defer / ship-with-named-risk — pick one and back it. |
+| `learning-from-experience` | Every surprise updates a control. |
+
+## Always-on packaging rule
+
+In always-on context (CLAUDE.md, system prompt, agent config) put one-line pointers per skill —
+not the skill bodies. The bodies load when the skill fires. See [`../../CORE.md`](../../CORE.md)
+for the token-audit citation.
+
+## Source-lineage note
+
+This kit packages original patterns from this repository. It does not create assurance. See
+[`../../DISCLAIMER.md`](../../DISCLAIMER.md).

--- a/starter-kit/public-claims/BOUNDARY-WORDING.md
+++ b/starter-kit/public-claims/BOUNDARY-WORDING.md
@@ -1,0 +1,62 @@
+# Boundary wording
+
+How to write public-facing claims in this repo without overclaiming. Read once before editing
+any README, release note, marketing copy, or regulator-adjacent document; consult again before
+shipping.
+
+## The rule
+
+Public wording must stay inside its evidence and away from words it cannot back. Specifically:
+do not say "compliant," "certified," "approved," "audited," "qualified," "regulator-approved,"
+or "meets `<standard>`" unless an authorized organization has separately reviewed and approved
+that claim under its own process. The framework's validator (`ng validate`) scans for these
+patterns; use it as a tripwire, not as proof the wording is correct.
+
+## Prohibited claim phrases (defensive list)
+
+These phrases are flagged by the deterministic checker. Use them only inside a disclaimer or a
+do-not-claim context:
+
+- `formal verification and validation`, `formal V&V`
+- `NQA-1 evidence`, `NQA-1 record`
+- `certified quality assurance program`
+- `regulatory approval`
+- `commercial-grade dedication package`
+- `<standards body> compliant` (NQA-1, ASME, EPRI, IEEE, IEC, ISO, ANSI, ANS, NEI, NRC, DOE,
+  NASA, NIST, CISA, …) — and the verb-stem paraphrases (`meets`, `conforms to`, `satisfies`,
+  `implements per`, `complies with`).
+
+Add domain-specific phrases your project should avoid: `<fill-in>`.
+
+## Allowed phrasings
+
+Prefer wording like:
+
+- "public-source-inspired";
+- "original software workflow";
+- "evidence-oriented";
+- "non-compliance-claiming";
+- "inspired by";
+- "we do not claim X";
+- "out of scope for this release";
+- "non-goal."
+
+## Source-lineage discipline
+
+When you say where an idea comes from:
+
+- cite a public, open, linkable source (URL preferred) — or mark the lineage as unresolved;
+- do not cite paywalled, draft, or contested sources as if they were settled;
+- describe the relationship as inspiration, not implementation: "inspired by," "influenced
+  by," not "implements" or "meets."
+
+## Disclaimer convention
+
+Every public document should end with a one-paragraph source-lineage note that names what the
+document is and what it does not create. See [`DISCLAIMER.md`](DISCLAIMER.md) for the skeleton.
+
+## Source-lineage note
+
+This guide is derived from the public Nuclear-grade boundary discipline in
+`docs/00-standards-foundation/compliance-boundaries.md` and `do-not-cite-directly.md` of the
+parent repository. It does not create assurance.

--- a/starter-kit/public-claims/DISCLAIMER.md
+++ b/starter-kit/public-claims/DISCLAIMER.md
@@ -1,0 +1,39 @@
+# Disclaimer
+
+`<your repo name>` is `<fill-in: one sentence on what this repo is>`.
+
+It is not a compliance program, a certification, a regulated quality-assurance system, a safety
+analysis, a production sandbox, a regulatory submission, legal advice, or a substitute for
+qualified engineering, legal, security, safety, or compliance review.
+
+It does not claim that any system is safe, secure, compliant, approved, certified, or fit for
+regulated use.
+
+## What this repo does claim
+
+- `<fill-in: the narrow, evidenced thing this repo actually does>`.
+- `<fill-in: the kinds of artifacts it produces and how they should be read>`.
+
+## What this repo does not claim
+
+- formal verification and validation, NQA-1 evidence, NQA-1 record, compliance, certification,
+  regulatory approval, or any safety, security, procurement, production, warranty, or support
+  guarantee;
+- to meet any standard not explicitly named with a public, open, linkable lineage;
+- to replace independent review by qualified humans.
+
+## Source lineage
+
+This repo is `<fill-in: original software work | a derivative work of X | a translation of
+public ideas Y>`. Sources are mapped at `<fill-in: path to your source-map.md or N/A>`.
+
+## License limits
+
+The license under which this repo is released does not promise quality, fitness, or assurance.
+See `LICENSE`.
+
+## Source-lineage note
+
+This skeleton is derived from the public Nuclear-grade DISCLAIMER pattern. Adapt the
+`<fill-in>` markers to your project; keep the defensive register so the wording stays inside
+its evidence.

--- a/starter-kit/public-claims/README.md
+++ b/starter-kit/public-claims/README.md
@@ -1,0 +1,55 @@
+# Starter kit: Public-claims
+
+Use this when your repo says things in public that someone might rely on — claims about
+safety, security, compliance, licensing, provenance, or how an AI system behaves.
+
+## When this trigger fires
+
+Any "yes" puts you in this kit:
+
+- the repo's README, docs, or release notes make assurance-adjacent claims;
+- the repo cites standards, regulations, or specifications by name;
+- the repo describes an AI system's behavior in ways a user, customer, or auditor would rely
+  on;
+- the repo is published under a license whose obligations need careful wording;
+- the repo's source lineage is contested, paywalled, or non-public.
+
+## Drop this into your repo
+
+```bash
+# from this repo's root, into your repo at $TARGET:
+cp -r starter-kit/core/{AGENTS.md,.nuclear} "$TARGET"/
+cp starter-kit/public-claims/{BOUNDARY-WORDING.md,DISCLAIMER.md} "$TARGET"/
+# Add the Claims-discipline cluster:
+for s in checking-legal-and-safety-wording checking-source-claims; do
+  mkdir -p "$TARGET/skills/$s"
+  cp "skills/$s/SKILL.md" "$TARGET/skills/$s/SKILL.md"
+done
+# Add the boundary docs as required reading:
+mkdir -p "$TARGET/docs/00-standards-foundation"
+cp docs/00-standards-foundation/{compliance-boundaries.md,do-not-cite-directly.md,public-citation-strategy.md} \
+   "$TARGET/docs/00-standards-foundation/"
+```
+
+## What this kit contains
+
+- [`BOUNDARY-WORDING.md`](BOUNDARY-WORDING.md) — a guide and a prohibited-phrase reference,
+  derived from `docs/00-standards-foundation/compliance-boundaries.md` and `do-not-cite-
+  directly.md`, plus a small house-style example list.
+- [`DISCLAIMER.md`](DISCLAIMER.md) — a skeleton disclaimer with `<fill-in>` markers, in the
+  defensive register the framework's test suite enforces.
+
+## The Claims-discipline cluster
+
+| Skill | When to invoke |
+|---|---|
+| `checking-legal-and-safety-wording` | Before a public claim ships — README edits, release notes, marketing copy, regulator-facing material. |
+| `checking-source-claims` | When the repo says where an idea comes from or what standard it tracks. |
+
+Both invoke [`proving-claims`](../../skills/proving-claims/SKILL.md) from Core, which is the
+universal map-each-claim-to-evidence-or-a-gap discipline.
+
+## Source-lineage note
+
+This kit packages original patterns from this repository. It does not create assurance. See
+[`../../DISCLAIMER.md`](../../DISCLAIMER.md).

--- a/tests/test_ng_validate.py
+++ b/tests/test_ng_validate.py
@@ -343,3 +343,65 @@ def test_unresolved_clarification_marker_fails(tmp_path):
 
     assert not result.ok
     assert any("[NEEDS CLARIFICATION]" in m for m in result.messages)
+
+
+# Internal link checker -----------------------------------------------------
+
+from tools.ng_validate import check_internal_links  # noqa: E402
+
+
+def test_check_internal_links_passes_when_targets_resolve(tmp_path):
+    write(tmp_path / "a.md", "see [b](b.md)")
+    write(tmp_path / "b.md", "ok")
+
+    failures = check_internal_links(tmp_path, ["a.md"])
+
+    assert failures == []
+
+
+def test_check_internal_links_flags_missing_target(tmp_path):
+    write(tmp_path / "a.md", "see [missing](does-not-exist.md)")
+
+    failures = check_internal_links(tmp_path, ["a.md"])
+
+    assert len(failures) == 1
+    assert "does-not-exist.md" in failures[0]
+    assert "a.md" in failures[0]
+
+
+def test_check_internal_links_ignores_anchors(tmp_path):
+    write(tmp_path / "a.md", "[here](#section) and [also](other.md#section)")
+    write(tmp_path / "other.md", "ok")
+
+    failures = check_internal_links(tmp_path, ["a.md"])
+
+    assert failures == []
+
+
+def test_check_internal_links_ignores_external_urls(tmp_path):
+    write(
+        tmp_path / "a.md",
+        "[http](http://example.com) [https](https://example.com) [mail](mailto:x@y.z)",
+    )
+
+    failures = check_internal_links(tmp_path, ["a.md"])
+
+    assert failures == []
+
+
+def test_check_internal_links_resolves_relative_to_each_file(tmp_path):
+    # nested file links to a sibling; should resolve to docs/sibling.md, not <root>/sibling.md
+    write(tmp_path / "docs" / "nested.md", "[sibling](sibling.md)")
+    write(tmp_path / "docs" / "sibling.md", "ok")
+
+    failures = check_internal_links(tmp_path, ["docs/nested.md"])
+
+    assert failures == []
+
+
+def test_check_internal_links_skips_files_that_do_not_exist(tmp_path):
+    # Files in the list that don't exist on disk are silently skipped --
+    # the existence check is the doctor's REQUIRED_PUBLIC_FILES job, not this checker's.
+    failures = check_internal_links(tmp_path, ["never-created.md"])
+
+    assert failures == []

--- a/tests/test_public_docs.py
+++ b/tests/test_public_docs.py
@@ -14,6 +14,8 @@ PUBLIC_DOCS = (
     "SUPPORT.md",
     "GOVERNANCE.md",
     "AGENTS.md",
+    "CORE.md",
+    "MAXIMS.md",
 )
 
 UNSAFE_RESIDUE = (

--- a/tools/ng_validate.py
+++ b/tools/ng_validate.py
@@ -9,12 +9,19 @@ if str(ROOT) not in sys.path:
 
 from nuclear_grade.ng_validate import (
     ValidationResult,
+    check_internal_links,
     detect_packet_mode,
     main,
     validate_packet,
 )
 
-__all__ = ["ValidationResult", "detect_packet_mode", "main", "validate_packet"]
+__all__ = [
+    "ValidationResult",
+    "check_internal_links",
+    "detect_packet_mode",
+    "main",
+    "validate_packet",
+]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Four independent reviews of this framework (Claude, Codex, Grok, Gemini — three as adopters, one architecture) converged on one diagnosis: **the framework's content is sound; its adoption surface is mis-calibrated for everyone but the rarest adopter** (a regulated team using the full lifecycle). Sophisticated adopters were independently reverse-engineering the same lightweight path the repo did not document, and the highest-value cluster (agent-authority) was buried under "heavier overlays — switch on by consequence" — i.e. the framing actively told the agent-authority adopter to skip the thing they most need.

This PR makes the cherry-pick path first-class without changing the content or the skill catalog. No skill is added or removed; the 27-skill `EXPECTED_SKILLS` set is untouched.

## Mode

**Standard.** Touches public docs that adopters land on first (README, QUICKSTART, INSTALL, SKILLS), introduces two new top-level docs (`CORE.md`, `MAXIMS.md`) and a new `starter-kit/` directory, and adds one CLI capability (an internal-link checker in `ng doctor`). Quick would not be honest: this changes how people enter the framework.

## Change packet

`N/A` for now — this PR is the dogfood test of the new doctrine. The reasoning, alternatives, and adversarial passes that produced it are captured in the PR description below and in the multi-reviewer synthesis that led here.

## Proof command + result

```bash
$ python -m pytest -q
117 passed in 4.21s    # was 111; +6 new link-checker tests
$ python tools/ng.py doctor .
OK: Nuclear-grade doctor
$ python tools/ng.py tokens .
OK: token budget
$ python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions
OK: …/add-agent-tool-permissions
$ python -m pytest docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py -v
4 passed in 0.02s      # the new README headliner demo runs as advertised
```

## What changes

### Strategic spine (new)

- **`CORE.md`** — the keystone. **Seven core habits** (3 always-on dispositions: `questioning-attitude`, `rating-change-risk`, `proving-claims`; 4 cut-point habits: `double-checking-before-acting`, `staying-on-mission`, `checking-release-readiness`, `learning-from-experience`) and a **6-row decision matrix** that routes the other 19 skills into 5 trigger-conditioned ancillary clusters (Agent-authority, Configuration management, Claims discipline, Incident & deficiency, Hygiene). All 27 existing skills accounted for.
- **`MAXIMS.md`** — quotable principles in short form, including two new ones this PR surfaces:
  - *"A guard inside the agent's writable set is not enforcement — it is a suggestion the agent can edit."*
  - *"The agent drafts; the human approves."*

### Starter kits (new — copy-paste-ready, not just docs)

- **`starter-kit/core/`** — `AGENTS.md` skeleton + `.nuclear/charter.md` skeleton + drop-in instructions.
- **`starter-kit/agent-authority/`** — Core + a context-pack template + a pre-filled PR template that names the rung-ladder.
- **`starter-kit/public-claims/`** — Core + a `BOUNDARY-WORDING.md` derived from the standards-foundation docs + a `DISCLAIMER.md` skeleton.

Skeleton-files-only design (not vendored skill copies) to avoid duplicate-maintenance debt. Each kit's README has a five-line `cp` command listing exactly which skills to copy from the main repo.

### Headliner swap and tone

- **README** "Try it in 60 seconds" → **"Watch an AI agent prove it stayed in its workspace."** Replaces the deliberate placeholder-error demo (educational but anti-viral) with the agent-tool-permissions worked example (4 passing pytest tests). The placeholder demo lives in QUICKSTART as a learning device.
- **Tone note** after the existing "name is the standard, not the vocabulary": when adopting, you do not have to adopt the vocabulary.
- **"Across tools"** subsection positions `.nuclear/`, `AGENTS.md`, and the `SKILL.md` contract as the **shared tool-agnostic surface** across Cursor / Claude Code / Aider / Codex / Copilot.
- **QUICKSTART step 0** documents the **agent-drafts-spec workflow** — user prompt → agent drafts `risk.md`/`proof.md` → human edits/approves → agent codes → human reviews. Hand-filling templates is the *learning* path; agent-drafts-spec is the *working* path.

### Content gap (new section)

`docs/04-adoption/agent-authority-model.md` grows from 41 → ~60 lines:

- **Self-modification boundary** + **enforcement rung-ladder** (advisory print → exit code → editable test → out-of-band CI → branch protection). Names "ships green by editing its own test" as a failure mode.
- **Unattended-execution clarification** in the Denial rule: "ask first" degrades to **stop, record the needed approval, halt** — there is no human to ask mid-run.
- Exit criteria require naming where controls live relative to the agent's writable set (rung 4+ when the agent has authority over its own tests/prompts/CI).

### Validator upgrade (the one CLI change)

- `nuclear_grade/ng_validate.py` adds `check_internal_links()`. `ng doctor` now catches broken relative links across `REQUIRED_PUBLIC_FILES`. Closes the link-integrity gap previously left to manual grep.
- Stdlib-only, no new dependencies (respects `docs/02-operating-system/validators.md:3`).
- Six new tests in `tests/test_ng_validate.py` (resolves, doesn't-resolve, ignores anchors, ignores external URLs, resolves per-file directory, skips missing files).

### Agent-authority elevation

- **SKILLS.md** mermaid overlay subgraph gains `deciding-who-decides`, `declaring-intent`, `vetting-outside-code-and-models` (they were absent).
- **Consequence note** under the diagram: *"If your agent has write/run/network/approval authority over its own working set, treat the agent cluster as **main-path, not overlay** — the trigger is always on for you."*
- The agent-tool-permissions worked example README is reframed as "your template, not just an illustration."

### Polish

- `.github/PULL_REQUEST_TEMPLATE.md` adds explicit **Mode** and **Proof command + result** fields (the two true gaps; packet link, validator command, overclaim check, residual risks already existed).
- `ROADMAP.md` v0.2 records cross-tool exports, opt-in MCP-over-`.nuclear/`, opt-in LLM-as-Judge, and a GitHub template repo as forward-looking work. **Building** those is explicitly deferred.
- README links to `skill-workflow-comparison/methodology.md` so adopters meet the "author-judged, design evidence not proof" framing up front (the repo was already honest about it — this just surfaces it).

## Enforcement rung

This PR is itself a Rung 4 example: the new internal-link checker runs in `ng doctor`, which CI enforces. An agent (me) could not have shipped this with broken internal links — `python tools/ng.py doctor .` would have failed. Going forward, link integrity stays automatic instead of relying on the manual grep I had to do mid-implementation.

## Verification

- [x] Tests and validator pass locally:
  ```bash
  python -m pytest -q                       # 117 passed (was 111; +6 link-checker)
  python tools/ng.py doctor .                # OK
  python tools/ng.py tokens .                # OK
  ```
- [x] Worked-example packet still validates:
  ```bash
  python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions
  # OK
  ```
- [x] New headliner demo runs end-to-end (4 passing tests + packet OK).
- [x] Internal links across all markdown resolve (now enforced by `ng doctor`).
- [x] New public docs (`CORE.md`, `MAXIMS.md`) gated by `test_public_docs.py` and pass the boundary-phrase check.
- [x] `EXPECTED_SKILLS` set unchanged; no skill added or removed.
- [x] Token budget unchanged (no skill *description* changes; bodies and new top-level docs scanned as prose).
- [x] `using-nuclear-grade` router still satisfies the 11-section contract and stays ≤500 lines.
- [x] New claims avoid compliance, certification, regulator approval, production sandbox, or formal QA overclaiming (the test enforces this; the new docs use "compliance/certified/approved" only in defensive `not`/`without`/`does not` contexts).

## Residual risks or gaps

- **Starter kits are skeletons, not vendored snapshots.** Adopters still need to run a small `cp` loop. Deliberate trade-off — vendored copies of 14+ skill files would create maintenance debt. A future GitHub template repo (`ROADMAP.md` v0.2) gives the one-click experience without that debt.
- **The "Across tools" framing is positioning, not integration.** Cursor / Aider / Copilot don't natively read `AGENTS.md` or `.nuclear/` today. Cross-tool renderers are recorded in ROADMAP v0.2.
- **Link-checker is structural only.** It says links resolve; it does not check that the linked content is correct. Per the framework's own discipline (`validators.md:16-18`), that judgment is `proving-claims` + a human review.
- **No efficacy data added.** The repo's existing self-acknowledgment (`methodology.md:48-53` — author-judged, n=12, no outside panel) is now linked from README rather than being a separately discoverable caveat. Real efficacy work is roadmap-scale and deliberately deferred.
- **`ng_validate.py`'s placeholder-marker check is still gameable** (four reviewers flagged it). This PR does not generalize the over-claim linter pluggably (term-pack architecture); it adds the higher-confidence link-checker instead. The over-claim linter generalization is a separate, larger, code-touching decision.

https://claude.ai/code/session_01SqJrGka8hqEQjqdxevEcQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqJrGka8hqEQjqdxevEcQ5)_