### PR TITLE
Sharpen requirements discipline across templates

### DIFF
--- a/CORE.md
+++ b/CORE.md
@@ -98,6 +98,21 @@ user prompt
 The human is editor and approver, not typist. This is what makes Quick mode feel like a
 speed-up rather than a tax.
 
+For a Standard change the loop runs in **stages, with a gate between each** — the agent
+drafts a phase, the human approves it, and only then does the next phase open:
+
+```text
+requirements draft -> human approves
+  -> design draft   -> human approves
+  -> tasks/plan draft -> human approves
+  -> agent builds against the approved spec
+```
+
+Staging keeps a late discovery from silently rewriting an earlier decision, and it gives
+the human a small, reviewable artifact at each step instead of one large one at the end.
+The gates map to the `plan.md` review checkpoints (Requirements approved / Design approved
+/ Tasks approved).
+
 **Caution.** An agent that drafts its own spec *and* self-validates it against a structural
 check is the "ships green by editing its own test" trap in new clothing. Trust-bearing specs
 need an independent approver — a human, or an out-of-band check the agent cannot rewrite. See

--- a/docs/00-standards-foundation/source-map.md
+++ b/docs/00-standards-foundation/source-map.md
@@ -123,6 +123,7 @@ The confidence fields say how well a source family fits this repo. They do not s
 | OWASP Top 10 | https://owasp.org/www-project-top-ten/ | Supporting | verified-public | Common appsec risk awareness. | High | Failure-mode prompts. |
 | 18F Engineering Guide | https://engineering.18f.gov/ | Supporting | verified-public | Public government software delivery habits. | High | Usability/adoption/de-risking. |
 | 18F De-risking Government Technology | https://derisking-guide.18f.gov/ | Supporting | verified-public | Incremental delivery/de-risking. | High | Anti-overhead adoption strategy. |
+| EARS (Easy Approach to Requirements Syntax), Mavin | https://alistairmavin.com/ears/ | Supporting | verified-public | Controlled requirement grammar: ubiquitous / event (WHEN) / state (WHILE) / optional (WHERE) / unwanted (IF-THEN) trigger→response shapes for testable, unambiguous requirements. | High | Concept lineage for the requirement-grammar note in `basis.md` and `spec.md`; serves the operational-unambiguity charter article; public method page; no compliance claim. |
 
 ---
 

--- a/templates/golden-path/spec.md
+++ b/templates/golden-path/spec.md
@@ -35,9 +35,9 @@
 Write each requirement as one controlled, testable statement — a clear trigger and
 a clear response — so it reads the same to everyone and a test can check it. Prefer
 `THE SYSTEM SHALL <response>`; `WHEN <trigger> THE SYSTEM SHALL <response>`;
-`WHILE <state> …`; `WHERE <feature present> …`; `IF <unwanted condition> THEN THE
-SYSTEM SHALL <response>`. The requirement states the rule; the acceptance scenarios
-below exercise it.
+`WHILE <state> THE SYSTEM SHALL <response>`; `WHERE <feature present> THE SYSTEM
+SHALL <response>`; `IF <unwanted condition> THEN THE SYSTEM SHALL <response>`. The
+requirement states the rule; the acceptance scenarios below exercise it.
 
 | ID | Requirement / claim | Basis or source | Acceptance evidence |
 |---|---|---|---|

--- a/templates/golden-path/spec.md
+++ b/templates/golden-path/spec.md
@@ -32,6 +32,13 @@
 
 ## Requirements or claims
 
+Write each requirement as one controlled, testable statement — a clear trigger and
+a clear response — so it reads the same to everyone and a test can check it. Prefer
+`THE SYSTEM SHALL <response>`; `WHEN <trigger> THE SYSTEM SHALL <response>`;
+`WHILE <state> …`; `WHERE <feature present> …`; `IF <unwanted condition> THEN THE
+SYSTEM SHALL <response>`. The requirement states the rule; the acceptance scenarios
+below exercise it.
+
 | ID | Requirement / claim | Basis or source | Acceptance evidence |
 |---|---|---|---|
 | REQ-001 | | | |

--- a/templates/standard/basis.md
+++ b/templates/standard/basis.md
@@ -74,9 +74,39 @@ Use this section only when activated.
 
 Include only the important claims that need evidence.
 
+Write each requirement as one controlled, testable statement — a clear trigger
+and a clear response — so a builder and a reviewer read it the same way and a
+test can check it. This serves the "operational unambiguity" charter article.
+Prefer these shapes:
+
+- `THE SYSTEM SHALL <response>` — an always-true rule.
+- `WHEN <trigger> THE SYSTEM SHALL <response>` — an event.
+- `WHILE <state> THE SYSTEM SHALL <response>` — a continuous state.
+- `WHERE <feature is present> THE SYSTEM SHALL <response>` — an optional feature.
+- `IF <unwanted condition> THEN THE SYSTEM SHALL <response>` — a failure path.
+
+Worked example — REQ-001: `WHEN a draft packet fails the structural validator THE
+SYSTEM SHALL block the merge and name the first failing section.` One trigger, one
+response, testable. Keep the `REQ-NNN` IDs; `trace.md` and `plan.md` reference them.
+
 | ID | Requirement / claim | Basis | Design feature or control | Evidence planned |
 |---|---|---|---|---|
 | REQ-001 | | | | |
+
+## Design outline
+
+A short completeness check, not a design essay. Tick what this change actually
+needs; link the real design notes instead of restating them (see the overhead
+trap above).
+
+| Section | Covered? | Where it lives |
+|---|---|---|
+| Overview — what changes and why | yes / no / n/a | |
+| Architecture — shape and major parts | yes / no / n/a | |
+| Components and interfaces — boundaries above | yes / no / n/a | `Interfaces and trust boundaries` |
+| Data models — shapes, classes, ownership | yes / no / n/a | |
+| Error handling — failure paths and responses | yes / no / n/a | `Unacceptable outcomes` |
+| Testing strategy — how each claim is checked | yes / no / n/a | `verification.md` |
 
 ## Required links
 

--- a/templates/standard/plan.md
+++ b/templates/standard/plan.md
@@ -37,11 +37,17 @@ If you must cross a non-goal or a charter article, record why here:
 
 ## Build sequence
 
-Number the fewest steps needed to finish the change.
+Number the fewest steps needed to finish the change. Stamp each step with the
+requirement IDs it delivers (`REQ-NNN` from `basis.md` or `spec.md`) so the chain
+requirement → task → code → evidence stays unbroken. Every requirement should
+appear against at least one step; a step with no requirement is either scaffolding
+or scope creep — say which.
 
-1.
-2.
-3.
+| # | Task | Requirements covered |
+|---|---|---|
+| 1 | | REQ-001 |
+| 2 | | |
+| 3 | | |
 
 ## Two-speed work plan
 
@@ -71,9 +77,9 @@ Keep fast trial work apart from the slower gates where work is accepted.
 
 ## Affected files and assets
 
-| File / asset | Change expected | Why it matters | Owner |
-|---|---|---|---|
-| | | | |
+| File / asset | Change expected | Requirements covered | Why it matters | Owner |
+|---|---|---|---|---|
+| | | REQ-001 | | |
 
 ## Non-goals
 
@@ -92,8 +98,16 @@ Use only if activated.
 
 ## Review checkpoints
 
+Approve the work in stages, not all at once. Each gate is approved by a human (or
+an out-of-band check the agent cannot rewrite) before the next phase opens — an
+agent that drafts and self-approves its own spec is the "ships green by editing its
+own test" trap. See the agent-drafts-spec workflow in `CORE.md`.
+
 | Checkpoint | Required before moving on | Status |
 |---|---|---|
+| Requirements approved | Each requirement is one clear trigger→response statement with a `REQ-NNN` ID, reviewed by a human. | planned / pass / gap |
+| Design approved | The design outline in `basis.md` is complete enough for this change and reviewed. | planned / pass / gap |
+| Tasks approved | Every build step carries the requirement IDs it delivers, and the sequence is reviewed. | planned / pass / gap |
 | Specification reviewed | The protected outcomes, the outcomes to prevent, and the assumptions are stated plainly. | planned / pass / gap |
 | Tests/evals defined | Each piece of evidence maps to a claim. | planned / pass / gap |
 | Build complete | The affected files match the plan. | planned / pass / gap |

--- a/templates/standard/trace.md
+++ b/templates/standard/trace.md
@@ -24,9 +24,14 @@
 
 Use status labels: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
 
-| ID | Claim | Basis link | Control / design feature | Support type | Verification evidence | Ship posture | Status |
-|---|---|---|---|---|---|---|---|
-| C-001 | | `basis.md` | | fact / assumption / unknown / source claim / local proof / decision authority | `verification.md` | | planned |
+Use the same `REQ-NNN` IDs the requirement carries in `basis.md` / `spec.md` so the
+chain reads end to end (`C-NNN` is an accepted alias for an older record). The
+`Task / code ref` column reaches the `plan.md` build step and the code path that
+delivers the claim, closing requirement → task → code → evidence.
+
+| ID | Claim | Basis link | Task / code ref | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|---|
+| REQ-001 | | `basis.md` | `plan.md` step 1 / `path/to/file` | | fact / assumption / unknown / source claim / local proof / decision authority | `verification.md` | | planned |
 
 ## Evidence chain
 


### PR DESCRIPTION
## What this does

Folds four requirements-engineering practices into the repo's **existing** materials, in the repo's own voice. No new docs, no new folders, and no external tool/IDE is named in any artifact.

Each practice sharpens an analog the repo already has:

1. **Controlled requirement grammar** — `basis.md` and `spec.md` now ask for each requirement as one testable trigger→response statement (`THE SYSTEM SHALL …`; `WHEN … SHALL …`; `WHILE …`; `WHERE …`; `IF … THEN …`), with a worked example. Serves the existing *operational unambiguity* charter article.
2. **Requirement IDs on every task** — `plan.md` build sequence becomes a table with a `Requirements covered` column, and the same column is added to *Affected files and assets*. Closes requirement → task → code → evidence.
3. **Design-outline checklist** — a light six-section completeness check in `basis.md` (Overview, Architecture, Components/Interfaces, Data models, Error handling, Testing strategy), honoring the existing "don't write a design essay" overhead trap.
4. **Staged approval gates** — the `CORE.md` agent-drafts-spec loop now runs requirements → design → tasks as human-approved stages, reinforcing the existing self-modification boundary. `plan.md` review checkpoints gain matching per-phase gate rows.

`trace.md` reconciles on `REQ-NNN` IDs (`C-NNN` kept as an alias) and gains a `Task / code ref` column so the chain reaches the build step and code path.

## Source lineage

EARS (Mavin, *Easy Approach to Requirements Syntax*) is added to `source-map.md` as a public requirements-syntax source — a method, not a tool — consistent with how the repo cites DOE/NRC/NIST sources. Every edited template keeps its `Source-lineage note` and the "No compliance claim is made." boundary.

## Files changed

- `templates/standard/basis.md` — requirement-grammar note + design-outline checklist
- `templates/golden-path/spec.md` — requirement-grammar note
- `templates/standard/plan.md` — requirements-covered columns + phase-gate checkpoints
- `templates/standard/trace.md` — ID reconcile + task/code-ref column
- `CORE.md` — staged approval gates
- `docs/00-standards-foundation/source-map.md` — EARS source row

## Verification

- `pytest tests/` — all 113 pass (incl. `test_public_docs.py`, contract tests).
- `python tools/ng.py validate templates/standard` — only the expected unfilled-placeholder findings (templates ship empty by design); no structural/missing-section errors against the new sections or columns.

https://claude.ai/code/session_01Q9tFCTyTkizDw41UmgYmWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9tFCTyTkizDw41UmgYmWZ)_