### PR TITLE
Fold generic planning lessons into existing controls

### DIFF
--- a/.nuclear/changes/incorporate-planning-lessons/basis.md
+++ b/.nuclear/changes/incorporate-planning-lessons/basis.md
@@ -1,0 +1,67 @@
+# Basis
+
+## Protected outcomes
+
+- The repo stays lean: no new always-on skill, no new registered template or command, no `references/` pattern (its tooling is unbuilt — see the `skill-contract-modernization` ship record).
+- The work-type lens stays orthogonal to the Quick/Standard/Nuclear rigor modes.
+- All boundary wording stays inside its limits (no compliance or assurance overclaim).
+
+## Requirements
+
+- REQ-001: `questioning-attitude` names the work type (greenfield/brownfield/defect/refactor-migration) and the questions it forces, with a doc holding the depth.
+- REQ-002: `checking-what-a-change-affects` and the cm template screen runtime/data blast radius (schema/state, API consumers, backward-compat, rollback-of-state), not just repo artifacts.
+- REQ-003: `plan.md` build-sequence steps can carry prereqs, per-slice proof, and a stop/done condition so a step is a delegable handoff contract (not a schedule); `breaking-down-the-work` points leaves at those slices.
+- REQ-004: the agent-authority model names the read-only plan phase vs the write-enabled build phase.
+- REQ-005: `skill-evaluation.md` keeps >=3 trigger / >=2 near-miss prompts per edited skill, exercising the new behavior.
+- REQ-006: this packet records the decision and validates clean.
+
+## Adopt-vs-decline ledger
+
+The external review studied 21 repos to design a VS-Code planning agent. This repo was one of the 21, cited as the exemplar for evidence-first operation. Most of the research only validated what is already here; the table records the disposition of every idea.
+
+| Research idea | Disposition | Where it lands, or why declined |
+|---|---|---|
+| Grill / clarifying questions before planning | Already present | `questioning-attitude` (Core 7) |
+| Spec packet with explicit sections | Already present | `templates/standard/` and `golden-path/` |
+| Evidence-first / verification gates | Already present | `proving-claims`, `verification.md` |
+| Decision records | Already present | `golden-path/decision.md`, `ship.md` |
+| Compound learning (durable lesson per session) | Already present | `learning-from-experience`, `cm/opex.md` |
+| Human approval at trust boundaries | Already present | `deciding-who-decides`, staged `plan.md` gates |
+| Domain glossary | Already present | `docs/glossary.md` |
+| Work-type lens (green/brown/defect/refactor) | Adopt (REQ-001) | `questioning-attitude` + `docs/02-operating-system/work-type-lens.md` |
+| Brownfield / migration impact depth | Adopt (REQ-002) | `checking-what-a-change-affects` + cm template + change-impact doc |
+| Execution-ready task slices | Adopt (REQ-003) | `plan.md` build-sequence columns + `breaking-down-the-work` |
+| Read-only planner vs write implementer | Adopt, minimal (REQ-004) | named in `agent-authority-model.md`; kernel already in `CORE.md` |
+| VS-Code mechanics (agents, instructions, prompts, hooks, plugins, cloud agent) | Decline | tool-specific; this repo is tool-agnostic markdown |
+| Parallel specialist-subagent fan-out | Decline | harness-specific; overlaps `stress-testing-agent-changes`, `reviewing-code-quality`, `deciding-who-decides` |
+| Standalone scored planning-eval harness | Decline (defer) | biggest, most meta lift; replaced by a light baseline-vs-skill note in `verification.md` |
+
+## Assumptions
+
+| Assumption | Why it matters | Validation source | Status |
+|---|---|---|---|
+| Editing a Core-7 skill needs no starter-kit body sync | Bounds the blast radius | Kits reference skills by pointer (`starter-kit/core/` has no SKILL bodies) | pass |
+| `references/` tooling is unbuilt | Justifies inlining instead | `skill-contract-modernization` ship record names it a deferred follow-up | pass |
+| Adding columns/rows keeps templates valid | Avoids a validator break | Validator checks sections, not columns; synthetic fixtures untouched | pass |
+
+## Acceptance scenarios
+
+- Given the prompt "add a field to the user record" on a live service, the revised front door classifies it brownfield and surfaces migration and rollback-of-state questions a generic plan would skip.
+- Given a multi-agent build, each WBS leaf becomes a `plan.md` slice with prereqs, per-slice proof, and a stop condition.
+
+## Required links
+
+- `risk.md`
+- `plan.md`
+- `verification.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Every research idea has a recorded disposition.
+- Each adopted requirement maps to evidence in `verification.md`.
+- Declined ideas name why.
+
+## Source-lineage note
+
+Original Nuclear-grade basis record. The external review is treated as influence, not authority; public software-lifecycle and configuration-management lineage is mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/.nuclear/changes/incorporate-planning-lessons/plan.md
+++ b/.nuclear/changes/incorporate-planning-lessons/plan.md
@@ -1,0 +1,90 @@
+# Plan
+
+## Change context
+
+- Slug: incorporate-planning-lessons
+- Owner: maintainer
+- Date: 2026-06-05
+- Current lifecycle phase: Verify
+
+## Charter and anchor check
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes
+- Re-checked before Verify? yes
+- Charter articles in play: rising standards, evidence over persuasion, graded rigor.
+
+## Build sequence
+
+This packet dogfoods the new slice columns: each step is a delegable handoff contract with its prereqs, the proof that closes it, and a stop/done condition. It is a handoff contract, not a schedule.
+
+| # | Task | Requirements covered | Prereqs / blocked-by | Proof for this step | Stop / done condition |
+|---|---|---|---|---|---|
+| 1 | Work-type lens in skill + golden-path field + new doc | REQ-001 | none | `ng tokens` green; 11 sections kept | lens in Process+Outputs and doc exists |
+| 2 | Runtime blast-radius in skill + cm template + impact doc | REQ-002 | none | template parses; doc renders | runtime row + skill step + doc subsection present |
+| 3 | Slice columns in plan template + breaking-down pointers | REQ-003 | none | skills keep sections | slice columns + handoff pointers present |
+| 4 | Name plan-vs-build authority in agent-authority model | REQ-004 | none | docs read cleanly | subsection present |
+| 5 | Refresh skill-evaluation prompts for 3 edited skills | REQ-005 | steps 1-3 | `test_skill_contracts.py` green | each block keeps >=3 / >=2 |
+| 6 | Record this packet | REQ-006 | steps 1-5 | `ng validate` green on packet | packet validates clean |
+
+## Affected files and assets
+
+| File / asset | Change expected | Requirements covered | Why it matters | Owner |
+|---|---|---|---|---|
+| `skills/questioning-attitude/SKILL.md` | add work-type step + output | REQ-001 | Core-7 front door | maintainer |
+| `skills/checking-what-a-change-affects/SKILL.md` | add runtime screen | REQ-002 | impact discipline | maintainer |
+| `skills/breaking-down-the-work/SKILL.md` | add slice pointers | REQ-003 | delegation legibility | maintainer |
+| `templates/standard/plan.md` | add slice columns | REQ-003 | handoff contract | maintainer |
+| `templates/cm/change-impact.md` | add runtime row | REQ-002 | blast radius | maintainer |
+| `docs/02-operating-system/work-type-lens.md` | new doc | REQ-001 | lens depth | maintainer |
+
+## Non-goals
+
+- No new always-on skill, registered template, or command.
+- No version bump and no `references/` subfolders.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Requirements approved | Each REQ is a clear trigger-to-response statement, human-reviewed. | pass |
+| Tasks approved | Every build step carries its requirement IDs and a stop condition. | pass |
+| Build complete | Affected files match the plan. | pass |
+| Verification complete | Evidence linked in `verification.md`. | pass |
+| Release decision ready | Leftover risk and rollback recorded in `ship.md`. | pass |
+
+## Rollback approach
+
+- Rollback method: revert the branch; all edits are markdown/template.
+- State/data reversal notes: none — no data or schema change.
+- Feature flag / kill switch: not applicable — doctrine content.
+- Owner: maintainer.
+- Time to restore estimate: minutes (single revert).
+
+## Proof commands
+
+```bash
+python -m pytest -q
+ruff check .
+python tools/ng.py tokens .
+python tools/ng.py doctor .
+python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- The work is bounded; non-goals keep scope from creeping.
+- Review checkpoints are named and passed.
+- Rollback is thought through before release.
+
+## Source-lineage note
+
+Original Nuclear-grade plan record influenced by public software-lifecycle and release-readiness practice mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/.nuclear/changes/incorporate-planning-lessons/risk.md
+++ b/.nuclear/changes/incorporate-planning-lessons/risk.md
@@ -3,7 +3,7 @@
 ## Change identity
 
 - Slug: incorporate-planning-lessons
-- PR / issue: (TBD on push)
+- PR / issue: #26
 - Owner: maintainer
 - Date: 2026-06-05
 - Current lifecycle phase: Verify

--- a/.nuclear/changes/incorporate-planning-lessons/risk.md
+++ b/.nuclear/changes/incorporate-planning-lessons/risk.md
@@ -1,0 +1,97 @@
+# Risk
+
+## Change identity
+
+- Slug: incorporate-planning-lessons
+- PR / issue: (TBD on push)
+- Owner: maintainer
+- Date: 2026-06-05
+- Current lifecycle phase: Verify
+- Summary: Fold a few generic, tool-agnostic planning lessons from an external review of 21 agent repos into existing controls, and record on the ledger what was deliberately declined. Four additive upgrades: a work-type lens (greenfield/brownfield/defect/refactor-migration) in `questioning-attitude`; a runtime blast-radius screen in `checking-what-a-change-affects`; delegable build-sequence slices in `plan.md` and `breaking-down-the-work`; and a named plan-phase vs build-phase authority boundary in the agent-authority model.
+
+## Mission anchor
+
+- Objective: Make planning sharper for brownfield changes and for delegated execution — the two thinnest spots in the current corpus — without adding always-on bulk.
+- Success criteria: All gates green (pytest, ruff, `ng tokens`, `ng doctor`, `ng validate` on this packet); every edited skill keeps its 11-section contract and stays under the token budget; the work-type lens is orthogonal to Quick/Standard/Nuclear, not a competing mode; the decline decisions are recorded here.
+- Non-goals / forbidden directions: Out of scope are all VS-Code-specific mechanics (custom agents, instructions files, prompt files, hooks JSON, plugins, cloud agent), a parallel specialist-subagent fan-out, a new scored eval harness, any new always-on skill, and any version bump. Forbidden is introducing the unbuilt `references/` skill-subfolder pattern.
+- Drift check: re-anchor / escalate / stop when an edit stops serving brownfield or delegated-execution clarity.
+- Traces to: the external 21-repo planning research and `.nuclear/charter.md` (rising standards, evidence over persuasion).
+
+## Questioning-attitude summary
+
+- Decision question: Of the research's ideas, which are generic gaps here versus already-present or tool-specific noise, and can the gaps be filled without bloat?
+- Assumptions that changed the mode: The change edits a Core-7 always-on skill (`questioning-attitude`) and user-facing templates, so it is user-facing and lasting — a Standard change.
+- Facts still needing validation: That the edits keep the token budget green (confirmed by `ng tokens`), keep the skill contract intact (confirmed by `test_skill_contracts.py`), and add no overclaiming language (confirmed by `test_public_docs.py`).
+- Stop or hold conditions: Stop if any edit forces a skill rename, a new registered artifact, or a version-sync across files; none was needed.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Reference |
+|---|---|---|---|
+| questioning-attitude | Skill (Core 7) | Front-door work-type classification; ripples to every adopter | `skills/questioning-attitude/SKILL.md` |
+| checking-what-a-change-affects | Skill | Adds runtime blast-radius screen | `skills/checking-what-a-change-affects/SKILL.md` |
+| breaking-down-the-work | Skill | Points WBS leaves at delegable plan slices | `skills/breaking-down-the-work/SKILL.md` |
+| standard plan template | Template | Build sequence gains slice columns | `templates/standard/plan.md` |
+| cm change-impact template | Template | Adds a runtime/data blast-radius row | `templates/cm/change-impact.md` |
+| golden-path questioning template | Template | Adds a work-type field | `templates/golden-path/questioning-attitude.md` |
+| work-type lens doc | Docs (new) | Holds the four-type depth | `docs/02-operating-system/work-type-lens.md` |
+| change-impact doc | Docs | Holds runtime blast-radius depth | `docs/02-operating-system/change-impact.md` |
+| agent-authority model | Docs | Names plan-vs-build authority | `docs/04-adoption/agent-authority-model.md` |
+| skill-evaluation prompts | Docs | Trigger prompts for the 3 edited skills | `docs/05-reference/skill-evaluation.md` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Edits a Core-7 always-on skill and public templates. |
+| Reversibility | high | Markdown and template edits; revert the branch cleanly. No data migration. |
+| Detectability | high | Contract, token, public-docs tests and the validator catch regressions. |
+| Exposure | medium | Public repo; skill and template surface is agent-facing. |
+| Uncertainty | low | Additive refinements within existing lifecycle beats. |
+| Dependency trust | low | No new dependencies. |
+| AI authority | low | No new agent write permissions; the authority note tightens, not loosens. |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** Edits a Core-7 always-on skill and user-facing templates that every adopter reads.
+- **Why lighter mode is not enough:** Quick cannot record the adopt-vs-decline ledger or the claim-to-evidence mapping for a doctrine change.
+- **Why heavier mode is not yet required:** Additive and non-breaking; no regulated use, safety basis, or new trust boundary.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| questioning-attitude.md | no | Captured inline in this risk record. | maintainer |
+| basis.md | yes | Holds the adopt-vs-decline ledger. | maintainer |
+| verification.md | yes | Per-claim evidence status plus a light efficacy note. | maintainer |
+| ship.md | yes | Release decision and self-justification guard. | maintainer |
+| turnover.md | no | Single-author packet. | maintainer |
+| self-check.md | no | No high-consequence irreversible action. | maintainer |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: Confirm each idea is a genuine gap, not already-present or tool-specific (recorded in `basis.md`).
+- Minimum evidence before merge: pytest green; ruff clean; `ng tokens` and `ng doctor` OK; this packet validates; edited skills keep all 11 sections.
+- Independent review needed? no for this PR; the adversarial review is recorded in `basis.md`.
+
+## Required links
+
+- Packet: `.nuclear/changes/incorporate-planning-lessons/`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Mode is justified as Standard.
+- The mission anchor names objective, success criteria, and non-goals.
+- Claims map to evidence in `verification.md`.
+- No hidden trigger for a stronger mode.
+
+## Source-lineage note
+
+Original Nuclear-grade packet influenced by public software-lifecycle and configuration-management practice mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/.nuclear/changes/incorporate-planning-lessons/risk.md
+++ b/.nuclear/changes/incorporate-planning-lessons/risk.md
@@ -40,6 +40,9 @@
 | skill-evaluation prompts | Docs | Trigger prompts for the 3 edited skills | `docs/05-reference/skill-evaluation.md` |
 | ng-question / ng-impact / ng-breakdown | Commands | Mirror the new lenses on the paste-ready surface | `commands/` |
 | CHANGELOG.md | Docs | Records this change | `CHANGELOG.md` |
+| rating-change-risk | Skill (Core 7) | Cross-links work type as orthogonal to mode | `skills/rating-change-risk/SKILL.md` |
+| risk-tiers-and-modes doc | Docs | Points to the work-type lens from the mode side | `docs/02-operating-system/risk-tiers-and-modes.md` |
+| docs index | Docs | Makes the work-type lens discoverable | `docs/README.md` |
 
 ## Threshold screen
 

--- a/.nuclear/changes/incorporate-planning-lessons/risk.md
+++ b/.nuclear/changes/incorporate-planning-lessons/risk.md
@@ -38,6 +38,8 @@
 | change-impact doc | Docs | Holds runtime blast-radius depth | `docs/02-operating-system/change-impact.md` |
 | agent-authority model | Docs | Names plan-vs-build authority | `docs/04-adoption/agent-authority-model.md` |
 | skill-evaluation prompts | Docs | Trigger prompts for the 3 edited skills | `docs/05-reference/skill-evaluation.md` |
+| ng-question / ng-impact / ng-breakdown | Commands | Mirror the new lenses on the paste-ready surface | `commands/` |
+| CHANGELOG.md | Docs | Records this change | `CHANGELOG.md` |
 
 ## Threshold screen
 

--- a/.nuclear/changes/incorporate-planning-lessons/ship.md
+++ b/.nuclear/changes/incorporate-planning-lessons/ship.md
@@ -1,0 +1,57 @@
+# Ship
+
+## Release decision
+
+- **Decision:** ship once CI is green.
+- **Rationale:** Additive, non-breaking doctrine refinements that sharpen brownfield questioning and delegated-execution legibility. No new registered artifact and no contract change, so the manifest stays accurate at 0.5.0 with no version bump.
+- **Pre-merge gates:**
+  - `python -m pytest -q` green (117 passed)
+  - `ruff check .` clean
+  - `python tools/ng.py tokens .` OK
+  - `python tools/ng.py doctor .` OK
+  - `python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons` OK
+
+## Evidence status summary
+
+| Area | Status | Reference |
+|---|---|---|
+| Verification | pass | `verification.md` |
+| Trace | pass | `trace.md` |
+| Token budget | pass | `python tools/ng.py tokens .` |
+| Packet self-validation | pass | `python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons` |
+
+## Self-justification guard
+
+This packet's validator only lints structure — it cannot judge whether the additions are good. Engineering merit was gated out-of-band: an adversarial review (recorded in `basis.md`), the human approval of the plan, and the full test suite the agent cannot rewrite to a pass. This avoids the "ship green by editing your own test" trap the agent-authority model warns about.
+
+## Rollback / restore plan
+
+- Revert the branch; all edits are markdown and templates. No data migration and no rollback-of-state needed.
+- If a single addition reads poorly in practice, edit that one file; nothing else depends on it.
+
+## Monitoring and post-release checks
+
+- Watch the triggering behavior of the three refreshed eval prompts; refine an individual prompt if it over- or under-triggers.
+- Watch whether the work-type lens gets confused with the rigor mode in adopter use; the orthogonality sentence and the lens doc are the guard.
+
+## Maintainer follow-ups
+
+- Optional: a CHANGELOG entry for the doctrine refinement.
+- Optional stretches recorded in `basis.md`: a scored planning-eval harness and a standalone brownfield worked example.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Release decision recorded; rollback named; monitoring named.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record influenced by release-readiness practice mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/.nuclear/changes/incorporate-planning-lessons/ship.md
+++ b/.nuclear/changes/incorporate-planning-lessons/ship.md
@@ -36,7 +36,7 @@ This packet's validator only lints structure — it cannot judge whether the add
 
 ## Maintainer follow-ups
 
-- Optional: a CHANGELOG entry for the doctrine refinement.
+- The CHANGELOG `[Unreleased]` entry for this refinement shipped with the change; no separate follow-up remains.
 - Optional stretches recorded in `basis.md`: a scored planning-eval harness and a standalone brownfield worked example.
 
 ## Required links

--- a/.nuclear/changes/incorporate-planning-lessons/ship.md
+++ b/.nuclear/changes/incorporate-planning-lessons/ship.md
@@ -32,7 +32,7 @@ This packet's validator only lints structure — it cannot judge whether the add
 ## Monitoring and post-release checks
 
 - Watch the triggering behavior of the three refreshed eval prompts; refine an individual prompt if it over- or under-triggers.
-- Watch whether the work-type lens gets confused with the rigor mode in adopter use; the orthogonality sentence and the lens doc are the guard.
+- Watch whether the work-type lens gets confused with the rigor mode in adopter use; the orthogonality sentence, the lens doc, and the mode-side cross-links (`rating-change-risk`, `risk-tiers-and-modes.md`, docs index) are the guard.
 
 ## Maintainer follow-ups
 

--- a/.nuclear/changes/incorporate-planning-lessons/trace.md
+++ b/.nuclear/changes/incorporate-planning-lessons/trace.md
@@ -11,6 +11,7 @@
 | 5 | REQ-005 | Added one trigger prompt to each of the three edited skill blocks | `docs/05-reference/skill-evaluation.md` |
 | 6 | REQ-006 | Wrote this packet | `.nuclear/changes/incorporate-planning-lessons/` |
 | 7 | REQ-001/002/003 | Mirrored the lenses on the command surface; added a CHANGELOG entry | `commands/ng-question.md`, `commands/ng-impact.md`, `commands/ng-breakdown.md`, `CHANGELOG.md` |
+| 8 | REQ-001 | Adversarial-review follow-up: cross-linked the work-type lens from the mode side to guard work-type/mode confusion | `docs/02-operating-system/risk-tiers-and-modes.md`, `skills/rating-change-risk/SKILL.md`, `docs/README.md` |
 
 ## Decisions during execution
 

--- a/.nuclear/changes/incorporate-planning-lessons/trace.md
+++ b/.nuclear/changes/incorporate-planning-lessons/trace.md
@@ -12,6 +12,8 @@
 | 6 | REQ-006 | Wrote this packet | `.nuclear/changes/incorporate-planning-lessons/` |
 | 7 | REQ-001/002/003 | Mirrored the lenses on the command surface; added a CHANGELOG entry | `commands/ng-question.md`, `commands/ng-impact.md`, `commands/ng-breakdown.md`, `CHANGELOG.md` |
 | 8 | REQ-001 | Adversarial-review follow-up: cross-linked the work-type lens from the mode side to guard work-type/mode confusion | `docs/02-operating-system/risk-tiers-and-modes.md`, `skills/rating-change-risk/SKILL.md`, `docs/README.md` |
+| 9 | — | Addressed PR #26 Copilot review: filled the PR number, corrected the stale CHANGELOG follow-up, and used the concrete mode name (Quick/Standard/Nuclear) | `risk.md`, `ship.md`, `docs/02-operating-system/work-type-lens.md`, `skills/questioning-attitude/SKILL.md` |
+| 10 | REQ-001 | Addressed PR #26 Codex review: made the work-type lens additive (types can overlap; ask the union of questions) so one label cannot excuse another's questions | `skills/questioning-attitude/SKILL.md`, `docs/02-operating-system/work-type-lens.md`, `templates/golden-path/questioning-attitude.md`, `commands/ng-question.md` |
 
 ## Decisions during execution
 

--- a/.nuclear/changes/incorporate-planning-lessons/trace.md
+++ b/.nuclear/changes/incorporate-planning-lessons/trace.md
@@ -1,0 +1,33 @@
+# Trace
+
+## What was done
+
+| Step | Requirement | Action taken | Files touched |
+|---|---|---|---|
+| 1 | REQ-001 | Added a work-type classification clause to Process step 4 and an Outputs bullet; added a golden-path `Work type` field; created the lens doc | `skills/questioning-attitude/SKILL.md`, `templates/golden-path/questioning-attitude.md`, `docs/02-operating-system/work-type-lens.md` |
+| 2 | REQ-002 | Added a runtime blast-radius clause to Process step 1 and a When-to-Use bullet; added a runtime/data row to the cm template; added a runtime subsection to the impact doc | `skills/checking-what-a-change-affects/SKILL.md`, `templates/cm/change-impact.md`, `docs/02-operating-system/change-impact.md` |
+| 3 | REQ-003 | Added prereqs/proof/stop columns and a handoff-contract note to the build sequence; added a slice pointer to the WBS skill Process and Outputs | `templates/standard/plan.md`, `skills/breaking-down-the-work/SKILL.md` |
+| 4 | REQ-004 | Added a "Plan-phase vs build-phase authority" subsection before Exit criteria | `docs/04-adoption/agent-authority-model.md` |
+| 5 | REQ-005 | Added one trigger prompt to each of the three edited skill blocks | `docs/05-reference/skill-evaluation.md` |
+| 6 | REQ-006 | Wrote this packet | `.nuclear/changes/incorporate-planning-lessons/` |
+
+## Decisions during execution
+
+- Inlined depth into skill bodies plus docs rather than `references/` subfolders, because the `references/` tooling is unbuilt and the additions fit the token budget.
+- Extended `plan.md` columns instead of creating an `execution-slices.md` template, to avoid overlap with `briefing-an-agent` and `handing-off-work` and to avoid new validator/manifest surface.
+- Kept the runtime impact to one gated row plus doc depth, to respect the change-impact template's overhead trap.
+
+## Required links
+
+- `plan.md`
+- `verification.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Every executed step maps to a requirement and the files it touched.
+- Execution decisions that shaped the result are recorded.
+
+## Source-lineage note
+
+Original Nuclear-grade trace record influenced by configuration-management and agent-trace practice mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/.nuclear/changes/incorporate-planning-lessons/trace.md
+++ b/.nuclear/changes/incorporate-planning-lessons/trace.md
@@ -14,6 +14,7 @@
 | 8 | REQ-001 | Adversarial-review follow-up: cross-linked the work-type lens from the mode side to guard work-type/mode confusion | `docs/02-operating-system/risk-tiers-and-modes.md`, `skills/rating-change-risk/SKILL.md`, `docs/README.md` |
 | 9 | — | Addressed PR #26 Copilot review: filled the PR number, corrected the stale CHANGELOG follow-up, and used the concrete mode name (Quick/Standard/Nuclear) | `risk.md`, `ship.md`, `docs/02-operating-system/work-type-lens.md`, `skills/questioning-attitude/SKILL.md` |
 | 10 | REQ-001 | Addressed PR #26 Codex review: made the work-type lens additive (types can overlap; ask the union of questions) so one label cannot excuse another's questions | `skills/questioning-attitude/SKILL.md`, `docs/02-operating-system/work-type-lens.md`, `templates/golden-path/questioning-attitude.md`, `commands/ng-question.md` |
+| 11 | REQ-001 | Codex follow-up: gave the golden-path template a Work-type questions section and exit criterion so a packet captures the union of forced questions, not just the labels | `templates/golden-path/questioning-attitude.md` |
 
 ## Decisions during execution
 

--- a/.nuclear/changes/incorporate-planning-lessons/trace.md
+++ b/.nuclear/changes/incorporate-planning-lessons/trace.md
@@ -10,6 +10,7 @@
 | 4 | REQ-004 | Added a "Plan-phase vs build-phase authority" subsection before Exit criteria | `docs/04-adoption/agent-authority-model.md` |
 | 5 | REQ-005 | Added one trigger prompt to each of the three edited skill blocks | `docs/05-reference/skill-evaluation.md` |
 | 6 | REQ-006 | Wrote this packet | `.nuclear/changes/incorporate-planning-lessons/` |
+| 7 | REQ-001/002/003 | Mirrored the lenses on the command surface; added a CHANGELOG entry | `commands/ng-question.md`, `commands/ng-impact.md`, `commands/ng-breakdown.md`, `CHANGELOG.md` |
 
 ## Decisions during execution
 

--- a/.nuclear/changes/incorporate-planning-lessons/verification.md
+++ b/.nuclear/changes/incorporate-planning-lessons/verification.md
@@ -12,6 +12,7 @@
 | Full suite and lint clean | `python -m pytest` (117 passed); `ruff check .` | pass |
 | This packet validates | `python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons` | pass |
 | No new always-on cost | no new skill/template/command; manifest unchanged | pass |
+| Work-type/mode confusion guarded by cross-links | mode-side docs and `rating-change-risk` point to `work-type-lens.md` | pass |
 
 ## Light efficacy note (baseline vs skill)
 

--- a/.nuclear/changes/incorporate-planning-lessons/verification.md
+++ b/.nuclear/changes/incorporate-planning-lessons/verification.md
@@ -1,0 +1,37 @@
+# Verification
+
+## Claim-to-evidence
+
+| Claim | Evidence | Status |
+|---|---|---|
+| Edits keep every skill's 11-section contract | `python -m pytest -q tests/test_skill_contracts.py` | pass |
+| Skill bodies stay under the token budget | `python tools/ng.py tokens .` (OK: token budget) | pass |
+| No overclaiming language introduced | `tests/test_public_docs.py` green | pass |
+| Eval blocks keep >=3 trigger / >=2 near-miss | `test_skill_evaluation_prompts_cover_every_skill` | pass |
+| Templates still validate with new fields | synthetic fixtures untouched; full suite green | pass |
+| Full suite and lint clean | `python -m pytest` (117 passed); `ruff check .` | pass |
+| This packet validates | `python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons` | pass |
+| No new always-on cost | no new skill/template/command; manifest unchanged | pass |
+
+## Light efficacy note (baseline vs skill)
+
+Per the `docs/05-reference/skill-evaluation.md` method, a qualitative baseline-vs-skill check on the prompt "add a field to the user record in the billing service": a baseline plan lists the code edit. With the revised `questioning-attitude`, the agent first classifies the work as brownfield and surfaces the schema-migration, backward-compatibility, and rollback-of-state questions, then screens the runtime blast radius. The behavior delta is the migration and rollback questions a generic plan omits. Status: pass (qualitative; no automated score — a scored harness is a declined/deferred stretch).
+
+## Gaps
+
+- No automated planning-behavior score. Status: deferred — recorded as an optional stretch, not a blocker.
+
+## Required links
+
+- `plan.md`
+- `ship.md`
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- Each claim maps to evidence with a status.
+- Open gaps are labeled and dispositioned.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record influenced by software-assurance and skill-evaluation practice mapped in `docs/00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ These entries record public-facing changes. They do not claim the project is a m
 
 ## [Unreleased]
 
+### Changed
+
+- Folded generic, tool-agnostic planning lessons from an external multi-repo review into existing controls, declining the tool-specific mechanics on the record. `questioning-attitude` now classifies the work type (greenfield/brownfield/defect-fix/refactor-migration) at the front door, orthogonal to the rigor modes; `checking-what-a-change-affects` and the CM change-impact template screen runtime/data blast radius (schema/state, API consumers, backward-compatibility, rollback-of-state); the Standard plan build sequence gains delegable handoff-slice columns (prerequisites, per-slice proof, stop/done condition) mirrored in `breaking-down-the-work`; and `docs/04-adoption/agent-authority-model.md` names the read-only plan phase versus the write-enabled build phase. Adds `docs/02-operating-system/work-type-lens.md`; command prompts and skill-evaluation prompts updated to match. No new always-on skill, template, or command, and the manifest is unchanged. Recorded as a dogfooded packet (`.nuclear/changes/incorporate-planning-lessons/`). (#26)
+
 ## [0.5.0] - 2026-06-04
 
 ### Added

--- a/commands/ng-breakdown.md
+++ b/commands/ng-breakdown.md
@@ -72,6 +72,7 @@ Then hand off to ng-folders.
 - A dictionary row per part, with its scope, deliverable, how it is accepted, owner, and dependencies.
 - Named common parts and an explicit deferred-scope or gap line.
 - A self-check that the parts add up to the whole (the 100% rule) and do not overlap.
+- For delegated execution, a per-leaf note of prerequisites, the proof that closes it, and a stop/done condition, so `plan.md` can carry it as a slice (a handoff contract, not a schedule).
 
 ## Verification command
 

--- a/commands/ng-impact.md
+++ b/commands/ng-impact.md
@@ -30,7 +30,7 @@ Inputs:
 - controlled items:
 - planned or actual diff:
 
-For each family of files, decide one of: update, leave as is, defer, or block. Name the updates needed, the controls now stale, the evidence links, the owners, and what should trigger a re-check. Pay close attention to public claims, validator behavior, source-lineage notes, handoffs, trust checks, lessons from operation (OPEX), and the release.
+For each family of files, decide one of: update, leave as is, defer, or block. Name the updates needed, the controls now stale, the evidence links, the owners, and what should trigger a re-check. Pay close attention to public claims, validator behavior, source-lineage notes, handoffs, trust checks, lessons from operation (OPEX), and the release. When the change touches a running system or stored data, also screen the runtime blast radius: schema and state migration, API consumers that depend on the contract, backward-compatibility, and rollback-of-state.
 
 ## Files created or modified
 

--- a/commands/ng-question.md
+++ b/commands/ng-question.md
@@ -37,6 +37,7 @@ Inputs:
 
 Return:
 - the decision question in one sentence
+- the work type (greenfield, brownfield, defect-fix, or refactor-migration) and the questions that type forces
 - the evidence that would change the decision
 - the assumptions that must be true
 - known facts, unknowns, danger words, and worries about how good the sources are

--- a/commands/ng-question.md
+++ b/commands/ng-question.md
@@ -37,7 +37,7 @@ Inputs:
 
 Return:
 - the decision question in one sentence
-- the work type (greenfield, brownfield, defect-fix, or refactor-migration) and the questions that type forces
+- the work type(s), all that apply (a production defect is brownfield and defect-fix), and the questions each forces
 - the evidence that would change the decision
 - the assumptions that must be true
 - known facts, unknowns, danger words, and worries about how good the sources are

--- a/docs/02-operating-system/change-impact.md
+++ b/docs/02-operating-system/change-impact.md
@@ -12,6 +12,18 @@ Ask whether the change affects:
 - release notes, support posture, monitoring, rollback, or handoff;
 - the wording about where ideas came from, or the wording that marks the limits of what you claim.
 
+## Runtime and migration blast radius
+
+For brownfield and migration work (see `work-type-lens.md`), screen the running system, not just the repo's files:
+
+- **Schema and state** — data or schema migrations, and whether they are forward-only or reversible.
+- **API consumers** — callers that depend on the current contract; whether the change is backward-compatible or needs a versioned or phased rollout.
+- **Concurrency and load** — behavior under existing traffic, ordering, and retries.
+- **Security surface** — new inputs, permissions, or trust boundaries the change exposes.
+- **Rollback-of-state** — how to undo after partial progress, not just how to revert the code.
+
+Record each as update / no-op / defer / block with an owner and a re-check trigger, the same as the artifact screen.
+
 ## Exit criteria
 
 The impact screen is complete when each affected group of files is updated, linked to a follow-up, or clearly marked not applicable.

--- a/docs/02-operating-system/risk-tiers-and-modes.md
+++ b/docs/02-operating-system/risk-tiers-and-modes.md
@@ -17,7 +17,7 @@ The mistake is to apply critical-systems ceremony to a button-color change. The 
 | Tier 2 — normal | feature work, API extension, UI release | Standard or Quick | standard review, automated tests, feature flags where useful |
 | Tier 3 — experimental | prototype, internal tool, throwaway exploration | Quick | lightweight review, time-boxed, no production authority |
 
-How to use it: rate consequence and reversibility with `rating-change-risk`, pick the mode, and — for Tier 0/1 — add the intent release brief (`authority-and-intent.md`) and, at Tier 0, the critical-systems controls (`critical-systems.md`). Do not invent a separate "tier" record; the mode is the record.
+How to use it: classify the work type with the work-type lens (`work-type-lens.md`) — orthogonal to the tier, it shapes which questions you ask, not how much rigor — then rate consequence and reversibility with `rating-change-risk`, pick the mode, and — for Tier 0/1 — add the intent release brief (`authority-and-intent.md`) and, at Tier 0, the critical-systems controls (`critical-systems.md`). Do not invent a separate "tier" record; the mode is the record.
 
 ## Design review at the higher tiers
 

--- a/docs/02-operating-system/work-type-lens.md
+++ b/docs/02-operating-system/work-type-lens.md
@@ -1,6 +1,6 @@
 # Work-Type Lens
 
-**Purpose:** Classify what *kind* of change this is, so the front-door questions match the work. The work type is orthogonal to the Quick/Standard/stronger mode: the mode grades how much rigor a change earns by consequence; the work type sets which questions and outputs matter by kind. A brownfield change can be Quick; a greenfield change can be Standard.
+**Purpose:** Classify what *kind* of change this is, so the front-door questions match the work. The work type is orthogonal to the Quick/Standard/Nuclear rigor mode: the mode grades how much rigor a change earns by consequence; the work type sets which questions and outputs matter by kind. A brownfield change can be Quick; a greenfield change can be Standard.
 
 Use this from `questioning-attitude`, before picking a mode in `rating-change-risk`.
 
@@ -11,13 +11,15 @@ Use this from `questioning-attitude`, before picking a mode in `rating-change-ri
 - **Defect-fix** — repair of wrong behavior. Force a reproduction first, then a regression guard: a failing test that captures the defect before the fix, and the narrowest change that turns it green.
 - **Refactor-migration** — behavior held constant while structure, storage, or platform moves. Force rollback-of-state and cutover questions: how to move data or traffic in reversible steps, and how to roll back after partial progress.
 
+**Types can overlap.** A change is often several at once — a production defect fix is brownfield and defect-fix; a live migration is brownfield and refactor-migration. Name every type that fits and ask the union of the questions they force; do not let one label excuse the questions another would raise.
+
 ## Why it changes the questions
 
 The same prompt — "add a field to the user record" — is a greenfield acceptance question on a new service and a backward-compatibility-plus-migration question on a live one. Naming the type up front is what surfaces the migration and rollback questions a generic plan would skip. For the runtime detail a brownfield or migration change must screen, see `change-impact.md`.
 
 ## Exit criteria
 
-The work type is named, and the questions that type forces are asked before a mode is chosen or a plan is written.
+Every applicable work type is named, and the union of the questions they force is asked before a mode is chosen or a plan is written.
 
 ## Source-lineage note
 

--- a/docs/02-operating-system/work-type-lens.md
+++ b/docs/02-operating-system/work-type-lens.md
@@ -1,0 +1,24 @@
+# Work-Type Lens
+
+**Purpose:** Classify what *kind* of change this is, so the front-door questions match the work. The work type is orthogonal to the Quick/Standard/stronger mode: the mode grades how much rigor a change earns by consequence; the work type sets which questions and outputs matter by kind. A brownfield change can be Quick; a greenfield change can be Standard.
+
+Use this from `questioning-attitude`, before picking a mode in `rating-change-risk`.
+
+## The four types
+
+- **Greenfield** — net-new code or a new subsystem with few existing callers. Force interface, contract, and acceptance questions: what "done" looks like, who consumes it, what is explicitly out of scope.
+- **Brownfield** — a change inside an existing, depended-on system. Force blast-radius questions: which callers, schemas, and stored state are touched, and what must stay backward-compatible.
+- **Defect-fix** — repair of wrong behavior. Force a reproduction first, then a regression guard: a failing test that captures the defect before the fix, and the narrowest change that turns it green.
+- **Refactor-migration** — behavior held constant while structure, storage, or platform moves. Force rollback-of-state and cutover questions: how to move data or traffic in reversible steps, and how to roll back after partial progress.
+
+## Why it changes the questions
+
+The same prompt — "add a field to the user record" — is a greenfield acceptance question on a new service and a backward-compatibility-plus-migration question on a live one. Naming the type up front is what surfaces the migration and rollback questions a generic plan would skip. For the runtime detail a brownfield or migration change must screen, see `change-impact.md`.
+
+## Exit criteria
+
+The work type is named, and the questions that type forces are asked before a mode is chosen or a plan is written.
+
+## Source-lineage note
+
+This lens is an original Nuclear-grade workflow distinction. It draws on public software-lifecycle and configuration-management practice mapped in `../00-standards-foundation/source-map.md`. It does not create formal assurance or compliance.

--- a/docs/04-adoption/agent-authority-model.md
+++ b/docs/04-adoption/agent-authority-model.md
@@ -52,6 +52,18 @@ The rule: the control that decides whether the agent's work is acceptable must s
 
 Match the rung to the authority. An agent that can edit files at rungs 1-3 has no real gate; promote to rung 4-5 before granting write or run authority over its own controls.
 
+## Plan-phase vs build-phase authority
+
+Planning and building are different authority phases, and naming the line keeps a
+read-only planner from sliding into an unreviewed writer. During the question,
+specification, and plan phases the agent is read-only over product code: its writes are
+confined to the change-record packet, and it prepares, but does not take, release
+actions. Build authority over product code opens only after the plan clears its
+human-approved gate (the `plan.md` review checkpoints — Requirements / Design / Tasks
+approved). This is the self-modification boundary above, applied in time: the control
+that approves the plan must sit where the planning agent cannot rewrite it. See the
+agent-drafts-spec workflow in `CORE.md`.
+
 ## Exit criteria
 
 Agent authority is acceptable when a reviewer can see five things: what the agent was allowed to do, what it actually changed, what evidence it produced, what it was forbidden to claim, and **where the controls that gate its work live relative to its writable set** (rung 4 or higher when the agent has authority over its own tests, prompts, or CI).

--- a/docs/05-reference/skill-evaluation.md
+++ b/docs/05-reference/skill-evaluation.md
@@ -22,6 +22,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Review this plan for hidden risks before we let the coding agent edit files.
 - Should trigger: What facts would change the release decision for this dependency update?
 - Should trigger: The agent is asking many plausible questions but has not named the decision question the evidence must answer.
+- Should trigger: This is a brownfield change to the billing schema — classify the work type and name the migration and rollback questions it forces.
 - Should not trigger: Fix a README typo and show the diff.
 - Should not trigger: Explain what this small Python helper function does.
 
@@ -46,6 +47,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: This lifecycle rename may stale docs, skills, commands, validators, and examples; screen the impact.
 - Should trigger: If we change the packet template, what downstream artifacts need revalidation?
 - Should trigger: Does a prompt/model baseline update affect release docs or evidence?
+- Should trigger: This change alters a database schema other services read — screen the runtime blast radius and backward-compatibility, not just repo docs.
 - Should not trigger: Create an empty Standard packet folder.
 - Should not trigger: What does the changelog say changed last week?
 
@@ -188,6 +190,7 @@ Do not treat this file as proof that a skill is effective. It is the minimum pro
 - Should trigger: Break this billing-revamp epic into a clean deliverable breakdown that covers all the scope with no overlaps before we plan.
 - Should trigger: We keep discovering work mid-sprint; give me a product WBS with a dictionary for this new ingestion subsystem.
 - Should trigger: Decompose this feature into work packages and check that the children actually sum to the whole.
+- Should trigger: We are handing these work packages to separate agents — turn the WBS leaves into delegable build-sequence slices with prereqs, per-slice proof, and stop conditions.
 - Should not trigger: Fix this typo in the README and show the diff.
 - Should not trigger: This backlog item is already broken down and owned; just start coding it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 | Lead people and agents the high-reliability way | [`01-field-guide/leadership-and-high-reliability.md`](01-field-guide/leadership-and-high-reliability.md) |
 | Place authority and declare intent | [`02-operating-system/authority-and-intent.md`](02-operating-system/authority-and-intent.md) |
 | Scale rigor by risk tier | [`02-operating-system/risk-tiers-and-modes.md`](02-operating-system/risk-tiers-and-modes.md) |
+| Classify the kind of change (work type) | [`02-operating-system/work-type-lens.md`](02-operating-system/work-type-lens.md) |
 | Run an incident, track deficiencies | [`02-operating-system/incident-response.md`](02-operating-system/incident-response.md), [`02-operating-system/deficiency-register.md`](02-operating-system/deficiency-register.md) |
 | Understand CLI behavior | [`05-reference/cli-reference.md`](05-reference/cli-reference.md) |
 | See the workflow as diagrams | [`diagrams.md`](diagrams.md) |

--- a/skills/breaking-down-the-work/SKILL.md
+++ b/skills/breaking-down-the-work/SKILL.md
@@ -44,7 +44,7 @@ Three things can wreck it. Under-coverage: some scope is orphaned and no one own
 6. Number with outline traceability (`1`, `1.2`, `1.2.3`). The number is the lasting ID that the folder map, the dictionary, and cross-references all key on.
 7. Write the dictionary. For each piece, record the scope, what is in and out of scope, the deliverable, the interfaces, the acceptance criteria, a rough size, the owner, and the dependencies. A piece with no dictionary entry cannot be estimated or owned.
 8. Use the same taxonomy everywhere. The work breakdown is the one taxonomy you reuse for ownership, folder grouping, CI grouping, and risk labels. That keeps one source of truth.
-9. Self-check (see Verification), then output the work-breakdown table plus the dictionary. Hand off to `organizing-project-folders` to turn it into a folder structure.
+9. Self-check (see Verification), then output the work-breakdown table plus the dictionary. Hand off to `organizing-project-folders` to turn it into a folder structure. When the work will be built by another agent or session, also hand each leaf to `plan.md` as a delegable build-sequence slice with its prerequisites, the proof that closes it, and a stop or done condition.
 
 ## Outputs
 
@@ -53,6 +53,7 @@ Three things can wreck it. Under-coverage: some scope is orphaned and no one own
 - Named common pieces held once, not copied across siblings.
 - A clear put-off-scope or gap line wherever the 100% rule was bounded.
 - A handoff note to folder structuring.
+- For delegated execution, a pointer from each leaf work-package to its `plan.md` build-sequence slice (prerequisites, per-slice proof, stop/done condition). See `briefing-an-agent` and `handing-off-work`.
 
 ## Verification
 

--- a/skills/checking-what-a-change-affects/SKILL.md
+++ b/skills/checking-what-a-change-affects/SKILL.md
@@ -12,6 +12,7 @@ An impact screen asks a simple question. When a controlled item changes, what el
 ## When to Use
 
 - A change affects more than one kind of artifact.
+- A change touches a running system, a schema, stored data, or an API other code depends on (brownfield or migration work).
 - Public claims, where ideas came from, checkers, tests, templates, skills, commands, dependencies, prompts, or the release may need updates.
 - A saved version or a re-check trigger may change.
 - A near miss, a weak control, or a lesson from real operation (OPEX) hints at hidden ripple effects.
@@ -29,7 +30,7 @@ An impact screen asks a simple question. When a controlled item changes, what el
 
 ## Process
 
-1. Name the kinds of artifacts the change might affect.
+1. Name the kinds of artifacts the change might affect. When the change touches a running system or stored data, screen the runtime blast radius too — schema and state migration, API consumers that depend on the contract, backward-compatibility, and rollback-of-state — not just repo artifacts. See `docs/02-operating-system/change-impact.md`.
 2. For each kind, pick one action: update it, leave it alone, defer it, or block on it.
 3. Name the stale links, evidence, examples, claims, handoffs, or controls.
 4. Link evidence for each choice.

--- a/skills/questioning-attitude/SKILL.md
+++ b/skills/questioning-attitude/SKILL.md
@@ -35,7 +35,7 @@ This is the front door. Before an agent builds, merges, or releases, find the re
 1. Restate the change as one clear question that evidence could prove right or wrong.
 2. List the assumptions that have to be true for the change to work.
 3. Sort what you know into facts, assumptions, unknowns, and "how good is this source?"
-4. Spot the uncertainty, the danger words, the warning signs, the steps where mistakes are likely, and any hidden reasons this should be treated as a standard change.
+4. Spot the uncertainty, the danger words, the warning signs, the steps where mistakes are likely, and any hidden reasons this should be treated as a standard change. Name the work type — greenfield, brownfield, defect-fix, or refactor-migration — because the type sets which questions matter: brownfield and migration force blast-radius and rollback-of-state questions; a defect forces a reproduction and a regression guard; greenfield forces interface and acceptance questions. Work type is orthogonal to the Quick/Standard/stronger mode, which grades rigor, not kind. See `docs/02-operating-system/work-type-lens.md`.
 5. Ask what evidence would change the decision. If nothing could change it, the question is not useful yet.
 6. Check the facts before you trust memory, confidence, or anything an agent generated.
 7. Name the conditions that should make you pause, hold, or escalate.
@@ -48,6 +48,7 @@ This is the front door. Before an agent builds, merges, or releases, find the re
 - What you know, what you don't, and any shaky sources.
 - The triggers for choosing a mode or escalating.
 - The evidence you need before you execute, verify, review, decide, or save the version.
+- The work type, and the questions that type forces.
 - The one fact that would change the decision.
 
 ## Verification

--- a/skills/questioning-attitude/SKILL.md
+++ b/skills/questioning-attitude/SKILL.md
@@ -35,7 +35,7 @@ This is the front door. Before an agent builds, merges, or releases, find the re
 1. Restate the change as one clear question that evidence could prove right or wrong.
 2. List the assumptions that have to be true for the change to work.
 3. Sort what you know into facts, assumptions, unknowns, and "how good is this source?"
-4. Spot the uncertainty, the danger words, the warning signs, the steps where mistakes are likely, and any hidden reasons this should be treated as a standard change. Name the work type — greenfield, brownfield, defect-fix, or refactor-migration — because the type sets which questions matter: brownfield and migration force blast-radius and rollback-of-state questions; a defect forces a reproduction and a regression guard; greenfield forces interface and acceptance questions. Work type is orthogonal to the Quick/Standard/stronger mode, which grades rigor, not kind. See `docs/02-operating-system/work-type-lens.md`.
+4. Spot the uncertainty, the danger words, the warning signs, the steps where mistakes are likely, and any hidden reasons this should be treated as a standard change. Name the work type — greenfield, brownfield, defect-fix, refactor-migration — and apply every type that fits, because more than one can (a production defect fix is brownfield and defect-fix; a live migration is brownfield and refactor-migration). Ask the questions every applicable type forces: brownfield and migration force blast-radius and rollback-of-state questions; a defect forces a reproduction and a regression guard; greenfield forces interface and acceptance questions. Work type is orthogonal to the Quick/Standard/Nuclear mode, which grades rigor, not kind. See `docs/02-operating-system/work-type-lens.md`.
 5. Ask what evidence would change the decision. If nothing could change it, the question is not useful yet.
 6. Check the facts before you trust memory, confidence, or anything an agent generated.
 7. Name the conditions that should make you pause, hold, or escalate.
@@ -48,7 +48,7 @@ This is the front door. Before an agent builds, merges, or releases, find the re
 - What you know, what you don't, and any shaky sources.
 - The triggers for choosing a mode or escalating.
 - The evidence you need before you execute, verify, review, decide, or save the version.
-- The work type, and the questions that type forces.
+- The work type(s), and the questions every applicable type forces.
 - The one fact that would change the decision.
 
 ## Verification

--- a/skills/rating-change-risk/SKILL.md
+++ b/skills/rating-change-risk/SKILL.md
@@ -7,7 +7,7 @@ description: Picks Quick, Standard, or a stronger human-reviewed mode based on c
 
 ## Overview
 
-Sort the change before you build it. That way the care you take matches the stakes and the evidence the change needs. The result is a mode choice, tied to the decision question, what the change must prove, and the triggers to escalate.
+Sort the change before you build it. That way the care you take matches the stakes and the evidence the change needs. The result is a mode choice, tied to the decision question, what the change must prove, and the triggers to escalate. Mode is about how much rigor; it is orthogonal to the work type (greenfield, brownfield, defect-fix, or refactor-migration), which is classified upstream in `questioning-attitude` and shapes which questions you ask. See `docs/02-operating-system/work-type-lens.md`.
 
 ## When to Use
 

--- a/templates/cm/change-impact.md
+++ b/templates/cm/change-impact.md
@@ -28,6 +28,7 @@
 | Skills/commands/templates | | update / no-op / defer / block | | | |
 | Dependencies/models/tools | | update / no-op / defer / block | | | |
 | Release/operate/support | | update / no-op / defer / block | | | |
+| Runtime/data blast radius (only if a running system or stored data is touched: schema/state, API consumers, backward-compat, rollback-of-state) | | update / no-op / defer / block | | | |
 
 ## Revalidation triggers
 

--- a/templates/golden-path/questioning-attitude.md
+++ b/templates/golden-path/questioning-attitude.md
@@ -23,6 +23,12 @@
 
 What decision must this change record make?
 
+## Work-type questions
+
+For each work type marked in the change context, answer the questions it forces; overlapping types stack, so cover the union (brownfield/migration → blast radius + rollback-of-state; defect-fix → reproduction + regression; greenfield → interfaces + acceptance). See `docs/02-operating-system/work-type-lens.md`.
+
+- Forced questions and answers (per marked type):
+
 ## Assumptions to validate
 
 | Assumption | Why it matters | Validation source | Status |
@@ -86,6 +92,7 @@ Danger words to challenge: probably, should, seems, obvious, just docs, safe, se
 ## Exit criteria
 
 - Assumptions are checked, marked as a gap, or assigned to someone.
+- For each work type marked, the questions it forces are answered or marked not applicable.
 - The triggers to escalate are not hidden.
 - The next artifact and the evidence it owes are named.
 

--- a/templates/golden-path/questioning-attitude.md
+++ b/templates/golden-path/questioning-attitude.md
@@ -16,6 +16,7 @@
 - Owner:
 - Date:
 - Request / issue / PR:
+- Work type: greenfield / brownfield / defect-fix / refactor-migration
 - Current golden-path phase: Question
 
 ## Decision question

--- a/templates/golden-path/questioning-attitude.md
+++ b/templates/golden-path/questioning-attitude.md
@@ -16,7 +16,7 @@
 - Owner:
 - Date:
 - Request / issue / PR:
-- Work type: greenfield / brownfield / defect-fix / refactor-migration
+- Work type (all that apply): greenfield / brownfield / defect-fix / refactor-migration
 - Current golden-path phase: Question
 
 ## Decision question

--- a/templates/standard/plan.md
+++ b/templates/standard/plan.md
@@ -43,11 +43,16 @@ requirement → task → code → evidence stays unbroken. Every requirement sho
 appear against at least one step; a step with no requirement is either scaffolding
 or scope creep — say which.
 
-| # | Task | Requirements covered |
-|---|---|---|
-| 1 | | REQ-001 |
-| 2 | | |
-| 3 | | |
+For work that will be handed to another agent or session, make each step a delegable
+slice: name its prerequisites, the proof that closes it, and the stop or done
+condition. This is a handoff contract, not a schedule — see `briefing-an-agent` and
+`handing-off-work`.
+
+| # | Task | Requirements covered | Prereqs / blocked-by | Proof for this step | Stop / done condition |
+|---|---|---|---|---|---|
+| 1 | | REQ-001 | | | |
+| 2 | | | | | |
+| 3 | | | | | |
 
 ## Two-speed work plan
 


### PR DESCRIPTION
## Context

An external review studied 21 agent repos to design a VS-Code Copilot planning agent and asked what — stripped of the VS-Code specifics — is worth folding into this repo. **This repo was one of the 21 reviewed**, cited as the exemplar for evidence-first operation, so most of the research only *validated* existing controls (`questioning-attitude`, `proving-claims`, `learning-from-experience`, staged `plan.md` gates, …). This PR folds in the few **genuine, generic gaps** as surgical in-place edits, and records on the ledger what was deliberately declined.

No new always-on skill, template, or command; `nuclear-grade.yaml` is unchanged. Depth lives in docs (loaded on demand), not in always-on context.

## What's adopted

- **Work-type lens** — `questioning-attitude` now classifies greenfield / brownfield / defect-fix / refactor-migration at the front door, because the *type* sets which questions matter. Explicitly **orthogonal** to the Quick/Standard/stronger rigor modes. Depth in new `docs/02-operating-system/work-type-lens.md`.
- **Runtime/data blast radius** — `checking-what-a-change-affects` + `templates/cm/change-impact.md` now screen schema/state migration, API consumers, backward-compat, and rollback-of-state, not just repo artifacts (one gated row + doc depth, respecting the template's overhead trap).
- **Delegable handoff slices** — `templates/standard/plan.md` build-sequence gains `Prereqs / blocked-by`, `Proof for this step`, and `Stop / done condition` columns (a handoff contract, not a schedule); `breaking-down-the-work` points WBS leaves at those slices.
- **Plan-phase vs build-phase authority** — `docs/04-adoption/agent-authority-model.md` names the read-only planning phase vs the write-enabled build phase (the generic kernel of the research's "read-only planner agent" idea; the boundary itself was already present).

## What's declined (recorded, not dropped)

- All VS-Code mechanics (custom agents, instructions/prompt files, hooks JSON, plugins, cloud agent) — this repo is tool-agnostic markdown.
- Parallel specialist-subagent fan-out — harness-specific; overlaps existing review skills.
- A standalone scored planning-eval harness — deferred; replaced by a light baseline-vs-skill note.

## How it's recorded

The change dogfoods the workflow: it ships as a Standard packet at `.nuclear/changes/incorporate-planning-lessons/` whose `basis.md` holds the full **adopt-vs-decline ledger**, and whose `ship.md` records a self-justification guard (the validator lints structure only; merit was gated by an adversarial review + plan approval + the out-of-band test suite).

## Process note

The plan was hardened by an adversarial review (a dozen-plus lenses) plus read-only fact checks that **shrank** the original design — e.g. dropping `references/` subfolders (tooling unbuilt) and a standalone execution-slices template (needless surface) in favor of in-place edits.

## Verification

- `python -m pytest` → **117 passed**
- `ruff check .` → clean
- `python tools/ng.py tokens .` → OK (token budget green; edited skill bodies under budget)
- `python tools/ng.py doctor .` → OK
- `python tools/ng.py validate .nuclear/changes/incorporate-planning-lessons` → OK

https://claude.ai/code/session_01RyqX9piwfR37ytffqCkJig

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyqX9piwfR37ytffqCkJig)_