### PR TITLE
docs: runtime-enforcement crosswalk for AI-assisted engineering

### DIFF
--- a/.nuclear/changes/runtime-enforcement-doctrine/proof.md
+++ b/.nuclear/changes/runtime-enforcement-doctrine/proof.md
@@ -1,0 +1,75 @@
+# Quick Proof
+
+**Purpose:** Capture the smallest credible evidence record for this Quick change.
+
+---
+
+## Proof summary
+
+- Change slug: runtime-enforcement-doctrine
+- Proof owner: FlyFission
+- Date/time: 2026-06-06
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: The runtime-enforcement page and its index row are additive only — they keep the full
+test suite, `doctor`, the token budget, and every in-repo packet green; every internal link
+in the new page resolves to a real file; the page makes no compliance claim; and the word the
+brief prohibited appears nowhere in the tree.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest -q`; `python -m ruff check .`;
+  `python tools/ng.py doctor .`; `python tools/ng.py tokens .`;
+  `python tools/ng.py validate .nuclear/changes/runtime-enforcement-doctrine`; a recursive
+  case-insensitive grep for the prohibited word; a manual existence check of all 18 link
+  targets in the new page.
+- Environment: Python 3.13, repo working tree on `claude/governance-patterns-integration-JsJIW`.
+- Inputs/fixtures: the new page, the one-row `docs/README.md` edit, and this packet.
+- Expected result: full suite green; ruff clean; doctor OK; token budget OK; this packet
+  validates; zero matches for the prohibited word; all link targets exist.
+- Self-check used? yes; target = the `docs/README.md` headings the public-docs test asserts,
+  confirmed present and unchanged.
+
+## Result
+
+- Status: pass
+- Actual result: `python -m pytest` → 117 passed; `ruff check .` → all checks passed;
+  `doctor .` → OK; `tokens .` → OK: token budget; prohibited-word grep → zero matches; all 18
+  link targets in the new page confirmed to exist. Packet validation: see below.
+- Evidence link or artifact path: `docs/02-operating-system/runtime-enforcement.md`;
+  `docs/README.md` (the "See how controls enforce, not just advise" row); commands above.
+- If failed/gap: none. Validator result for this packet is recorded by the
+  `python tools/ng.py validate .nuclear/changes/runtime-enforcement-doctrine` run.
+
+## Reviewer note
+
+- Reviewer: FlyFission
+- Review note: The page is a crosswalk and a reading lens, not new doctrine — the enforcement
+  maxims, self-modification boundary, and validator rungs already live in `MAXIMS.md`,
+  `agent-authority-model.md`, and `validators.md`, and the page links out to them rather than
+  restating them. No new gate, threshold, dependency, or compliance claim was added.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: Runtime-enforcement crosswalk for AI-assisted engineering
+- Relevant changed files: `docs/02-operating-system/runtime-enforcement.md`, `docs/README.md`
+- CI run / test output: `python -m pytest` (117 passed), `python -m ruff check .` (clean),
+  `python tools/ng.py doctor .` (OK), `python tools/ng.py tokens .` (OK)
+- If AI-assisted: changes prepared by an AI agent under review; scope is one additive
+  documentation page plus a single index row, with no code or gate change.
+
+## Exit criteria
+
+- Evidence directly matches the claim in `risk.md`.
+- Actual result is compared to the expected result named before proof.
+- Result status is explicit.
+- Any failure or gap has a next action or escalation.
+- Reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public software test-documentation and verification
+concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/runtime-enforcement-doctrine/proof.md
+++ b/.nuclear/changes/runtime-enforcement-doctrine/proof.md
@@ -23,8 +23,8 @@ brief prohibited appears nowhere in the tree.
 - Command/check/eval/review: `python -m pytest -q`; `python -m ruff check .`;
   `python tools/ng.py doctor .`; `python tools/ng.py tokens .`;
   `python tools/ng.py validate .nuclear/changes/runtime-enforcement-doctrine`; a recursive
-  case-insensitive grep for the prohibited word; a manual existence check of all 18 link
-  targets in the new page.
+  case-insensitive grep for the prohibited word; a link-resolution check of all 28 internal
+  links (17 distinct targets) in the new page.
 - Environment: Python 3.13, repo working tree on `claude/governance-patterns-integration-JsJIW`.
 - Inputs/fixtures: the new page, the one-row `docs/README.md` edit, and this packet.
 - Expected result: full suite green; ruff clean; doctor OK; token budget OK; this packet
@@ -36,8 +36,9 @@ brief prohibited appears nowhere in the tree.
 
 - Status: pass
 - Actual result: `python -m pytest` → 117 passed; `ruff check .` → all checks passed;
-  `doctor .` → OK; `tokens .` → OK: token budget; prohibited-word grep → zero matches; all 18
-  link targets in the new page confirmed to exist. Packet validation: see below.
+  `doctor .` → OK; `tokens .` → OK: token budget; prohibited-word grep → zero matches; all 28
+  internal links (17 distinct targets) in the new page confirmed to resolve. Packet
+  validation: see below.
 - Evidence link or artifact path: `docs/02-operating-system/runtime-enforcement.md`;
   `docs/README.md` (the "See how controls enforce, not just advise" row); commands above.
 - If failed/gap: none. Validator result for this packet is recorded by the

--- a/.nuclear/changes/runtime-enforcement-doctrine/risk.md
+++ b/.nuclear/changes/runtime-enforcement-doctrine/risk.md
@@ -40,7 +40,7 @@ and name the proof required.
 |---|---|
 | Consequence if wrong | A crosswalk row points to the wrong file or reads poorly; reversible by edit. No runtime, evidence-gate, or trust-boundary effect. |
 | Reversibility | Fully reversible; one new doc plus one additive index row. |
-| Detectability | High; broken internal links and boundary-phrase residue are covered by `pytest` and `doctor`, and the page renders visibly. |
+| Detectability | High; the test suite, `doctor`, `tokens`, and packet validation run green, and this page's link correctness is established by the explicit link-resolution check recorded in `proof.md`. The new page is not in the top-level public-doc test set, so its links and wording are checked by that proof step, not by `pytest`/`doctor`. |
 | Exposure | Public docs, but additive and within the existing boundary wording. |
 | Uncertainty | Low; no logic change; every linked control already exists and was path-checked. |
 | Why Quick is enough | No new trust boundary, dependency, permission, gate, or release effect. |
@@ -70,7 +70,10 @@ Move up to Standard if any of these are true:
 - a trust decision about a dependency, model, or API changed — no;
 - a failure could be silent, delayed, costly, or hard to undo — no;
 - the AI had the power to write, run commands, use the network, or approve actions, beyond
-  just drafting under review — no;
+  just drafting under review — no (the agent drafted documentation and ran read-only
+  verification commands — tests, `doctor`, validators; it changed no product code, held no
+  credentials, and the merge decision stays with a human via PR review, matching the
+  accepted `prove-overlay` Quick packet, also an AI-prepared docs change);
 - the proof will not fit in one small `proof.md` — false.
 
 None apply. Quick stands. (If a follow-up adds validator code or a new gate, re-classify to

--- a/.nuclear/changes/runtime-enforcement-doctrine/risk.md
+++ b/.nuclear/changes/runtime-enforcement-doctrine/risk.md
@@ -1,0 +1,95 @@
+# Quick Risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** Additive documentation only — one new operating-system page plus one
+  index row. No code, validator logic, dependencies, permissions, or public assurance claims
+  change. The page restates nothing and adds no gate; it indexes controls that already exist.
+
+**Purpose:** Decide whether the runtime-enforcement crosswalk can safely stay in Quick mode
+and name the proof required.
+
+---
+
+## Change
+
+- Slug: runtime-enforcement-doctrine
+- PR / issue: Runtime-enforcement crosswalk for AI-assisted engineering
+- Owner: FlyFission
+- Date: 2026-06-06
+- Summary: Add `docs/02-operating-system/runtime-enforcement.md`, a short page that names the
+  "controls should act, not merely advise" principle and maps contemporary enforceable
+  AI-governance concepts onto the Nuclear-grade controls that already provide them, with a
+  crosswalk table linking each to its owning file. Add one row to the `docs/README.md` "Use
+  the repo" index so the page is reachable. No existing doctrine is duplicated: the
+  enforcement maxims, the self-modification boundary, and the validator rungs already live in
+  `MAXIMS.md`, `agent-authority-model.md`, and `validators.md`.
+
+## Scope
+
+- Affected files/configs/docs: `docs/02-operating-system/runtime-enforcement.md` (new),
+  `docs/README.md` (one index row).
+- User-visible behavior changed? no (documentation only).
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A crosswalk row points to the wrong file or reads poorly; reversible by edit. No runtime, evidence-gate, or trust-boundary effect. |
+| Reversibility | Fully reversible; one new doc plus one additive index row. |
+| Detectability | High; broken internal links and boundary-phrase residue are covered by `pytest` and `doctor`, and the page renders visibly. |
+| Exposure | Public docs, but additive and within the existing boundary wording. |
+| Uncertainty | Low; no logic change; every linked control already exists and was path-checked. |
+| Why Quick is enough | No new trust boundary, dependency, permission, gate, or release effect. |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest -q`; `python tools/ng.py doctor .`;
+  `python tools/ng.py tokens .`; `python tools/ng.py validate .nuclear/changes/runtime-enforcement-doctrine`.
+- Expected result: full suite green; doctor OK; token budget OK; this packet validates; every
+  internal link in the new page resolves.
+- Evidence link/location: `proof.md`.
+
+## Critical-action self-check
+
+- Exact target: the new page and the single new row in `docs/README.md`.
+- Expected result: the row is added without disturbing the `## Use the repo` and
+  `## Reference foundation` headings the public-docs test asserts; every crosswalk link
+  resolves to a real path.
+- Stop condition: if any edit would remove an asserted heading or introduce a broken link or
+  a compliance claim, stop and revert.
+
+## Escalation check
+
+Move up to Standard if any of these are true:
+
+- users, data, security, permissions, operations, or architecture are affected — no;
+- a trust decision about a dependency, model, or API changed — no;
+- a failure could be silent, delayed, costly, or hard to undo — no;
+- the AI had the power to write, run commands, use the network, or approve actions, beyond
+  just drafting under review — no;
+- the proof will not fit in one small `proof.md` — false.
+
+None apply. Quick stands. (If a follow-up adds validator code or a new gate, re-classify to
+Standard.)
+
+## Required links
+
+- Packet: `.nuclear/changes/runtime-enforcement-doctrine/`
+- Related PR/issue: Runtime-enforcement crosswalk for AI-assisted engineering
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public graded-rigor and software-assurance concepts
+mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/docs/02-operating-system/runtime-enforcement.md
+++ b/docs/02-operating-system/runtime-enforcement.md
@@ -1,0 +1,71 @@
+# Runtime Enforcement
+
+**Purpose:** Name a principle Nuclear-grade already practices — that a control should
+*act*, not merely advise — and map the contemporary "enforceable AI-governance" concepts
+onto the controls in this repo that already provide them. This page adds no new mechanism;
+it is an index and a reading lens.
+
+**Boundary:** Original software-workflow translation of public practice. It does not create
+assurance, compliance, certification, safety, security, or regulatory adequacy.
+
+---
+
+## The principle
+
+Guidance that lives only in prose is a suggestion. An AI agent — or a hurried human — can
+read it, agree with it, and then not do it, and nothing notices. The durable move, visible
+across public engineering practice (policy-as-code, branch protection, signed build
+provenance, and secure-development guidance mapped in
+[`../00-standards-foundation/source-map.md`](../00-standards-foundation/source-map.md)), is
+to convert guidance into mechanics that act: checks that fail, gates that block, roles that
+cannot approve their own work, and scopes an agent cannot quietly widen.
+
+The test for any control is one question:
+
+```text
+can the thing it governs defeat the control by editing it?
+```
+
+If yes, it is advice, not enforcement. A check an agent can rewrite sits at a low rung; the
+same check run out-of-band in CI — where the agent cannot push — is a real gate. The
+enforcement rungs are defined in
+[`../04-adoption/agent-authority-model.md`](../04-adoption/agent-authority-model.md).
+
+Push advisory wording up the rungs only when the stakes warrant it. Quick mode stays
+advisory on purpose; a reversible, low-blast-radius change does not earn a runtime gate.
+Rigor scales with consequence ([`risk-tiers-and-modes.md`](risk-tiers-and-modes.md)).
+
+## Where each control already lives
+
+Read the table as: a contemporary enforcement concept, the Nuclear-grade control that
+already provides it, and where that control lives. The point is that the methodology already
+covers this ground — this page only makes it legible in one place.
+
+| Enforcement concept | Nuclear-grade control | Where it lives |
+|---|---|---|
+| Enforcement over documentation | Enforcement rungs; structural validator run by CI | [`agent-authority-model.md`](../04-adoption/agent-authority-model.md), [`validators.md`](validators.md) |
+| Role-separated agent work | Plan-phase vs build-phase authority; deciding who decides | [`agent-authority-model.md`](../04-adoption/agent-authority-model.md), [`deciding-who-decides`](../../skills/deciding-who-decides/SKILL.md) |
+| No self-approval | Self-modification boundary — a gate the agent can edit is not a gate | [`agent-authority-model.md`](../04-adoption/agent-authority-model.md), [`MAXIMS.md`](../../MAXIMS.md) |
+| Bounded change scope / isolation | One change, one packet; the working branch or worktree is the isolation boundary | [`change-control-packets.md`](change-control-packets.md) |
+| Zone boundaries for file access | Authority dimensions (which files the agent may touch); workspace-boundary example | [`agent-authority-model.md`](../04-adoption/agent-authority-model.md), [`../03-worked-examples/ai-agent-tool-permissions/`](../03-worked-examples/ai-agent-tool-permissions/) |
+| Blast-radius / change budgets | Risk screen plus the change-impact record | [`risk-tiers-and-modes.md`](risk-tiers-and-modes.md), [`../../templates/cm/change-impact.md`](../../templates/cm/change-impact.md) |
+| Session hooks and gates | Validator activation thresholds; double-check at cut points | [`validators.md`](validators.md), [`double-checking-before-acting`](../../skills/double-checking-before-acting/SKILL.md) |
+| Completion receipt / handoff | Completion standard; the enforced `ship.md` fields; the handoff record | [`../../AGENTS.md`](../../AGENTS.md), [`../../templates/standard/ship.md`](../../templates/standard/ship.md), [`handing-off-work`](../../skills/handing-off-work/SKILL.md) |
+| Rising tide / no-new-debt | Recorded baseline; every surprise updates a control | [`configuration-management.md`](configuration-management.md), [`MAXIMS.md`](../../MAXIMS.md) |
+| Production-readiness gate | Release-readiness decision; CI passing is not a release decision | [`checking-release-readiness`](../../skills/checking-release-readiness/SKILL.md), [`MAXIMS.md`](../../MAXIMS.md) |
+| Session context injection | The context pack / briefing an agent | [`context-packs.md`](context-packs.md), [`briefing-an-agent`](../../skills/briefing-an-agent/SKILL.md) |
+| Audit / evidence report | The verification record; the packet summary in `risk.md` | [`change-control-packets.md`](change-control-packets.md), [`../../templates/standard/ship.md`](../../templates/standard/ship.md) |
+
+## What this page is not
+
+It is not a new standard, a benchmark, a maturity model, or a compliance source, and it adds
+no gate of its own. Where a control here is only advisory and the stakes have risen, the fix
+is to move that control up a rung in the file that owns it — not to add ceremony in this one.
+
+## Source-lineage note
+
+Original Nuclear-grade synthesis. It reads public practice on enforceable engineering
+controls — secure-development guidance, supply-chain provenance, and configuration
+discipline — mapped in
+[`../00-standards-foundation/source-map.md`](../00-standards-foundation/source-map.md). It
+does not create assurance, certification, or compliance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 | Lead people and agents the high-reliability way | [`01-field-guide/leadership-and-high-reliability.md`](01-field-guide/leadership-and-high-reliability.md) |
 | Place authority and declare intent | [`02-operating-system/authority-and-intent.md`](02-operating-system/authority-and-intent.md) |
 | Scale rigor by risk tier | [`02-operating-system/risk-tiers-and-modes.md`](02-operating-system/risk-tiers-and-modes.md) |
+| See how controls enforce, not just advise | [`02-operating-system/runtime-enforcement.md`](02-operating-system/runtime-enforcement.md) |
 | Classify the kind of change (work type) | [`02-operating-system/work-type-lens.md`](02-operating-system/work-type-lens.md) |
 | Run an incident, track deficiencies | [`02-operating-system/incident-response.md`](02-operating-system/incident-response.md), [`02-operating-system/deficiency-register.md`](02-operating-system/deficiency-register.md) |
 | Understand CLI behavior | [`05-reference/cli-reference.md`](05-reference/cli-reference.md) |


### PR DESCRIPTION
## What

Adds a short operating-system page, `docs/02-operating-system/runtime-enforcement.md`, that:

- **names a principle the repo already practices** — a control should *act*, not merely advise — with the one-question test "*can the thing it governs defeat the control by editing it?*" and the CI-rung distinction; and
- **maps contemporary "enforceable AI-governance" concepts onto the Nuclear-grade controls that already provide them** (enforcement rungs, self-modification boundary, bounded change packets, zone boundaries, blast-radius screen, completion standard, release-readiness, context packs), each linked to its owning file.

Plus one row in the `docs/README.md` index so the page is reachable, and a Quick-mode dogfood packet under `.nuclear/changes/runtime-enforcement-doctrine/`.

## Why it's a crosswalk, not new doctrine

The repo audit showed this doctrine **already exists** — distributed across `MAXIMS.md` ("a guard inside the agent's writable set is not enforcement"; "CI passing is not a release decision"; "every surprise updates a control"), `agent-authority-model.md`, and `validators.md`. The only genuinely-missing, value-adding artifact was a single place that names the principle and shows, in one table, that the methodology already covers the modern enforcement playbook. The page links out and restates nothing.

## Deliberately out of scope (no fluff)

- No new maxims (they already exist) · no new validator check (the completion receipt is already enforced via `ship.md` fields; a new required check would also break all existing packets in CI) · no change-budget feature (blast radius is already pervasive) · no scattered one-line edits.

## Verification

- `pytest` → **117 passed** · `ruff check .` → clean · `ng doctor` → OK · `ng tokens` → token budget OK
- All **17** change packets validate (16 existing + the new dogfood packet) — nothing broke
- All **28** internal links in the new page resolve
- No compliance claims added; the page carries the standard boundary + source-lineage notes

## Notes

The third-party product that prompted this work is referenced nowhere; the doctrine stands on the repo's own public-source lineage and stays tool-agnostic.

https://claude.ai/code/session_018vjdirXA62oAaUiR8x9Uo5

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjdirXA62oAaUiR8x9Uo5)_