### PR TITLE
Rewrite README as an evidence-first landing page

### DIFF
--- a/.nuclear/changes/enterprise-landing-page/basis.md
+++ b/.nuclear/changes/enterprise-landing-page/basis.md
@@ -1,0 +1,93 @@
+# Basis — Enterprise Landing Page
+
+**Purpose:** State what must stay true for the new landing page to be clear, honest, and safe to publish.
+
+---
+
+## Change context
+
+- **Slug:** `enterprise-landing-page`
+- **Related risk record:** `risk.md`
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+- **Decision this basis supports:** Whether to replace the README with the new landing page and embed the new diagrams.
+
+## Mission / need
+
+The current README is honest and substantive but dense, and a first-time visitor cannot tell in ten seconds what the project is or why it matters. The need is a landing page a newcomer can follow that still keeps the brand, the proof, and every boundary the project depends on.
+
+## Protected outcomes
+
+| Protected outcome | Why it matters | Evidence needed |
+|---|---|---|
+| A newcomer understands what this is and can run a proof within the first screen. | First impression decides whether anyone adopts the work. | Self-check read of the rendered page; the proof commands run near the top. |
+| The page never overclaims. | Over-trust is the project's primary reputational hazard. | Boundary and disclaimer language present, uncollapsed, and in negative context. |
+| Diagrams degrade to readable text where Mermaid does not render. | The README is also the PyPI long description, where Mermaid is broken. | An adjacent text fallback under every embedded diagram. |
+| Counts and links stay honest as the corpus grows. | A stale hardcoded count silently becomes an overclaim. | Counts qualified with the version and pointed at the live source. |
+
+## Unacceptable outcomes
+
+| Unacceptable outcome | Consequence | Prevent / detect / mitigate |
+|---|---|---|
+| A hedge is upgraded into a hard claim. | The page promises assurance the project does not provide. | Keep the study, v0, and disclaimer wording near-verbatim; review the diff. |
+| The README breaks a CI doc invariant. | Public docs tests fail and the page loses a guaranteed property. | Preserve the lifecycle line, the HPI phrase, and negative-context boundary phrasing. |
+| A diagram carries meaning only in Mermaid. | PyPI and screen-reader users lose the content. | Text fallback under each diagram. |
+| A second diagram copy drifts from canon. | Two sources disagree over time. | New diagrams are canonical in `docs/diagrams.md` and embedded, not forked. |
+
+## Assumptions, constraints, and invalidation triggers
+
+| Assumption / constraint | Fact / assumption / unknown | Basis or source | Invalidation trigger | Owner |
+|---|---|---|---|---|
+| GitHub renders committed relative SVG and Mermaid in the README. | Fact | GitHub markdown rendering behavior. | The banner or diagrams fail to render on the branch. | Maintainer |
+| PyPI strips Mermaid and may strip SVG from the long description. | Assumption | Known PyPI long-description sanitizing. | PyPI renders the page with no fallback text. | Maintainer |
+| Component counts are 27 skills and 26 command prompts at v0.5.0. | Fact | `nuclear-grade.yaml`. | The catalog in `nuclear-grade.yaml` changes. | Maintainer |
+| No new runtime dependency is introduced. | Fact | The change is markdown plus one SVG. | A build step or package dependency is added. | Maintainer |
+
+## Interfaces and trust boundaries
+
+- **Internal interfaces affected:** Markdown links from `README.md` to other repo docs; embedded Mermaid mirrored from `docs/diagrams.md`.
+- **External services/APIs affected:** shields.io badge images only (decorative, not load-bearing).
+- **Data classes affected:** None; documentation-only change.
+- **Human approval boundaries:** Maintainer review and CI must pass before merge.
+- **AI/model/tool authority boundaries:** Unchanged; no agent authority is added or removed.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Basis | Design feature or control | Evidence planned |
+|---|---|---|---|---|
+| REQ-001 | THE README SHALL state what the project is, the one idea, and a runnable proof within the first screen. | A newcomer must orient in seconds. | Hero, "What this is", "The one idea", and "See it work in 30 seconds" sit at the top. | Self-check read of the rendered page. |
+| REQ-002 | WHERE a diagram is embedded THE README SHALL provide an adjacent text fallback. | The README is the PyPI long description, where Mermaid is broken. | An "In words" line or table under every Mermaid block. | Self-check that each block has a fallback. |
+| REQ-003 | THE README SHALL keep the boundary and disclaimer language present, uncollapsed, and in negative context. | Over-trust is the main hazard. | "What this is NOT", license/limits, and disclaimer links stay expanded. | `tests/test_public_docs.py` plus diff review. |
+| REQ-004 | THE new diagrams SHALL live canonically in `docs/diagrams.md` and be embedded, not duplicated as a separate source. | Two sources drift. | Sections 6 and 7 of `docs/diagrams.md` are the source; the README mirrors them. | Both diagrams present in both files; Mermaid validates. |
+| REQ-005 | WHERE a component count appears THE README SHALL qualify it with the version and point to the live source. | A stale count becomes an overclaim. | Counts marked "as of v0.5.0" with links to `nuclear-grade.yaml`, `SKILLS.md`, `COMMANDS.md`. | Counts match `nuclear-grade.yaml`. |
+| REQ-006 | THE README SHALL keep every relative link resolvable and preserve the CI doc invariants. | Broken links and lost invariants erode trust. | Verified link targets; lifecycle line and HPI phrase kept verbatim. | `tests/test_public_docs.py` plus link check. |
+
+## Design outline
+
+| Section | Covered? | Where it lives |
+|---|---|---|
+| Overview — what changes and why | yes | `Mission / need` above |
+| Architecture — shape and major parts | yes | `plan.md` build sequence |
+| Components and interfaces — boundaries above | yes | `Interfaces and trust boundaries` |
+| Data models — shapes, classes, ownership | n/a | Documentation-only change |
+| Error handling — failure paths and responses | yes | `Unacceptable outcomes` |
+| Testing strategy — how each claim is checked | yes | `verification.md` |
+
+## Required links
+
+- Risk record: `risk.md`
+- Verification record: `verification.md`
+- Ship record: `ship.md`
+- Canonical diagrams: `docs/diagrams.md`
+- Source lineage, if cited: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- The builder and reviewer can answer "what must stay true?" for the page.
+- The protected outcomes and the outcomes to prevent are stated plainly.
+- Each important assumption has a trigger that would prove it wrong.
+- The evidence needs flow into `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade basis record inspired by public ideas on design basis, configuration management, software assurance, and source-lineage discipline mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/enterprise-landing-page/plan.md
+++ b/.nuclear/changes/enterprise-landing-page/plan.md
@@ -1,0 +1,97 @@
+# Plan — Enterprise Landing Page
+
+**Purpose:** Bound the build, the review, and the rollback for the landing-page overhaul before scope grows.
+
+---
+
+## Change context
+
+- **Slug:** `enterprise-landing-page`
+- **Related risk record:** `risk.md`
+- **Related basis record:** `basis.md`
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+- **Current lifecycle phase:** Verify
+
+## Build sequence
+
+| # | Task | Requirements covered | Prereqs / blocked-by | Proof for this step | Stop / done condition |
+|---|---|---|---|---|---|
+| 1 | Add the role-sequence and configuration-management diagrams to `docs/diagrams.md` as canonical sections 6 and 7. | REQ-004 | None | Both diagrams validate as Mermaid. | Both sections present with text fallbacks. |
+| 2 | Create the typographic SVG hero banner with descriptive alt text and no compliance imagery. | REQ-001 | None | Banner renders on GitHub; alt text present. | `docs/assets/landing-banner.svg` committed. |
+| 3 | Rewrite `README.md`: hero, plain-language pitch, proof, embedded diagrams with fallbacks, qualified counts, governance links, and preserved invariants. | REQ-001, REQ-002, REQ-003, REQ-005, REQ-006 | Steps 1 and 2 | `tests/test_public_docs.py` passes. | Page reads top to bottom with no overclaim. |
+| 4 | Author this Standard packet so the change models the method. | REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006 | Steps 1 to 3 | `ng validate` reports OK. | All six records filled and valid. |
+
+## Two-speed work plan
+
+| Work phase | Allowed actions | Acceptance gate |
+|---|---|---|
+| explore | Draft wording, sketch diagrams, try layouts. | None; throwaway work. |
+| candidate | Write the README, diagrams, banner, and packet. | Diagrams validate; page reads cleanly. |
+| audit | Run the doc tests, validator, doctor, and token gate; re-read for overclaim. | All checks green; disclaimers intact. |
+| accept | Commit, push, open the draft PR. | CI green on the branch. |
+
+## Affected files and assets
+
+| File / asset | Change expected | Requirements covered | Why it matters | Owner |
+|---|---|---|---|---|
+| `README.md` | Full rewrite in place. | REQ-001, REQ-002, REQ-003, REQ-005, REQ-006 | The public landing page and PyPI description. | Maintainer |
+| `docs/diagrams.md` | Add canonical sections 6 and 7. | REQ-004 | Single source for the embedded diagrams. | Maintainer |
+| `docs/assets/landing-banner.svg` | New file. | REQ-001 | The hero banner. | Maintainer |
+| `.nuclear/changes/enterprise-landing-page/` | New Standard packet. | REQ-001 to REQ-006 | Makes the PR a worked example. | Maintainer |
+
+## Non-goals
+
+- No GitHub Pages site, HTML page, or build step.
+- No changes to skills, commands, templates, the CLI, or the charter.
+- No binary or generated image asset; the banner stays a hand-written, diffable SVG.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Requirements approved | Each REQ is one clear trigger to response statement, reviewed. | pass |
+| Design approved | The design outline in `basis.md` is complete for this change. | pass |
+| Tasks approved | Every build step carries the requirement IDs it delivers. | pass |
+| Specification reviewed | Protected outcomes and outcomes to prevent are stated plainly. | pass |
+| Tests/evals defined | Each claim maps to evidence in `verification.md`. | pass |
+| Build complete | The affected files match the plan. | pass |
+| Verification complete | Evidence is linked in `verification.md`. | pass |
+| Release decision ready | Residual risks and rollback are recorded in `ship.md`. | pass |
+
+## Rollback approach
+
+- **Rollback method:** Revert the landing-page commit; the previous README and `docs/diagrams.md` return unchanged.
+- **State/data reversal notes:** Not applicable; documentation-only change.
+- **Feature flag / kill switch:** Not applicable; the PR is the gate.
+- **Owner:** Maintainer.
+- **Time to restore estimate:** Under ten minutes via `git revert`.
+
+## Proof commands
+
+```bash
+python -m pytest tests/test_public_docs.py -v
+python tools/ng.py validate .nuclear/changes/enterprise-landing-page
+python tools/ng.py doctor .
+python tools/ng.py tokens .
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Canonical diagrams: `docs/diagrams.md`
+
+## Exit criteria
+
+- The work is bounded enough to keep scope from creeping.
+- The review checkpoints are named.
+- Rollback is thought through before release.
+- The proof commands are ready for `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade plan record inspired by public sources on software lifecycle, configuration management, release readiness, and software assurance mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/enterprise-landing-page/risk.md
+++ b/.nuclear/changes/enterprise-landing-page/risk.md
@@ -1,0 +1,82 @@
+# Risk — Enterprise Landing Page
+
+**Purpose:** Sort the README landing-page overhaul by risk, justify Standard mode, and name the evidence due before it ships.
+
+---
+
+## Change identity
+
+- **Slug:** `enterprise-landing-page`
+- **PR / issue:** `claude/enterprise-landing-page-uSnWo` branch / landing-page PR
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+- **Current lifecycle phase:** Verify
+- **Summary:** Rewrite `README.md` into a best-in-class, plain-language landing page; add two canonical diagrams (a role sequence and a configuration-management loop) to `docs/diagrams.md`; add a typographic SVG hero banner; and ship this Standard packet so the change models the method it documents.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| Public landing page | Documentation | First public trust surface and the PyPI long description. | `README.md` |
+| Canonical diagrams | Documentation | Single source for diagrams embedded across docs; drift risk if duplicated. | `docs/diagrams.md` |
+| Hero banner | Image asset | New typographic SVG shown at the top of the page. | `docs/assets/landing-banner.svg` |
+| README invariant tests | Tests | Gate the lifecycle string, the HPI phrase, and negative-context boundary phrasing. | `tests/test_public_docs.py` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | Medium | A public landing page sets first impressions and can over- or under-sell the work. |
+| Reversibility | High | Docs and one SVG revert cleanly; no data or runtime state changes. |
+| Detectability | Medium | Overclaim and broken-fallback issues need explicit reading and tests, not just CI green. |
+| Exposure | High | The README is the most-read public file and the packaged PyPI description. |
+| Uncertainty | Medium | Mermaid and SVG render differently across GitHub and PyPI; fallbacks must hold. |
+| Dependency trust | Low | No new runtime dependencies; badges use external shields.io images only. |
+| AI authority | Low | Documentation-only change; no tool, permission, or model authority is altered. |
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** The change touches the primary public trust surface and several controlled docs, and carries a real overclaim risk that needs a stated basis and verification.
+- **Why lighter mode is not enough:** A Quick packet would not capture the no-overclaim, diagram-fallback, and counts-honesty claims that make this change safe to publish.
+- **Why heavier mode is not yet required:** The change is documentation-only, reversible, and changes no code, permissions, data, or release behavior.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `basis.md` | yes | States the protected outcomes and the claims the page must keep true. | Maintainer |
+| `plan.md` | yes | Bounds the build sequence and the rollback. | Maintainer |
+| `trace.md` | yes | Links each landing-page claim to its evidence. | Maintainer |
+| `verification.md` | yes | Records the commands, tests, and reviews that back the claims. | Maintainer |
+| `ship.md` | yes | Records the release decision and residual risks. | Maintainer |
+| `questioning-attitude.md` | no | Adversarial review was captured during planning; no separate record needed. | Maintainer |
+| `turnover.md` | no | Single-session change; no handoff. | Maintainer |
+| Nuclear subset record | no | Stakes do not warrant a heavier mode. | Maintainer |
+
+## Immediate evidence obligations
+
+- README CI invariants are preserved: the eleven-beat lifecycle line, the `HPI for AI agents` phrase, and boundary phrases only in negative context.
+- Both new diagrams validate as Mermaid and appear in `docs/diagrams.md` and `README.md`.
+- Component counts match `nuclear-grade.yaml` and are qualified with the version.
+- All relative links resolve; `ng doctor` and `ng tokens` stay green.
+
+## Required links
+
+- Packet: `.nuclear/changes/enterprise-landing-page/`
+- `basis.md`
+- `plan.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Source-map / crosswalk references: `docs/00-standards-foundation/source-map.md`, `docs/01-field-guide/source-to-concept-crosswalk.md`
+
+## Exit criteria
+
+- The mode is justified.
+- The activated artifacts are named.
+- The overclaim, rendering, and link risks are visible and owned, not hidden in chat.
+
+## Source-lineage note
+
+Original Nuclear-grade risk record inspired by public graded-quality, configuration-management, lifecycle, verification, and source-lineage concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/enterprise-landing-page/ship.md
+++ b/.nuclear/changes/enterprise-landing-page/ship.md
@@ -1,0 +1,98 @@
+# Ship — Enterprise Landing Page
+
+**Purpose:** State the release decision for the landing-page overhaul plainly.
+
+---
+
+## Release identity
+
+- **Change slug:** `enterprise-landing-page`
+- **Version / release / baseline:** Landing-page README on `claude/enterprise-landing-page-uSnWo`
+- **PR / commit / artifact:** Landing-page draft PR
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+- **Intended release window:** After maintainer review and CI pass on the branch.
+
+## Scope and exclusions
+
+- **Included:** README rewrite, two canonical diagrams, the SVG hero banner, and this Standard packet.
+- **Excluded:** Any GitHub Pages site, HTML, build step, or changes to skills, commands, templates, the CLI, or the charter.
+- **Known non-goals:** Marketing claims, compliance language, or assurance the project does not provide.
+
+## Evidence status summary
+
+| Evidence area | Status | Link | Notes |
+|---|---|---|---|
+| Risk classification | pass | `risk.md` | Standard mode justified. |
+| Basis / requirements / claims | pass | `basis.md` | REQ-001 through REQ-006 defined. |
+| Trace | pass | `trace.md` | Claims mapped to evidence and release posture. |
+| Verification | pass | `verification.md` | Doc tests, validator, doctor, token gate, and Mermaid validation passed. |
+| Diagram fallbacks | pass | `README.md` | Each embedded diagram carries an "In words" fallback. |
+| Boundary / disclaimer wording | pass | `tests/test_public_docs.py` | Boundary phrases stay negative; disclaimers stay expanded. |
+| AI-assisted work checks | pass | `verification.md` | Independent deterministic checks performed locally. |
+
+## Residual risks and gaps
+
+| Risk / gap | Impact | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| PyPI may strip the SVG banner from the long description. | The hero image may not show on PyPI. | accept; the plain H1 title and text carry the page. | Maintainer | Next PyPI release renders without the banner. |
+| External shields.io badges depend on a third-party service. | A badge image could fail to load. | accept; badges are decorative, not load-bearing. | Maintainer | A badge image breaks. |
+| Component counts are a v0.5.0 snapshot. | A count could age as the catalog grows. | accept; counts are version-qualified and point to the live source. | Maintainer | `nuclear-grade.yaml` changes. |
+
+## Rollback / restore plan
+
+- **Rollback method:** `git revert` the landing-page commit; the previous README and `docs/diagrams.md` return unchanged.
+- **Data migration reversal or restore notes:** Not applicable; documentation-only change.
+- **Feature flag / kill switch:** Not applicable; the PR is the gate.
+- **Owner on call:** Maintainer.
+- **Time to restore estimate:** Under ten minutes.
+
+## Monitoring and post-release checks
+
+| Signal | Threshold / expected behavior | Owner | Where to inspect | Action if bad |
+|---|---|---|---|---|
+| CI status | Doc tests, validator, doctor, and token gate pass. | Maintainer | Branch CI checks. | Fix before merge. |
+| Reader confusion / overclaim risk | No issue suggesting the page implies compliance or assurance. | Maintainer | GitHub issues and reviews. | Narrow the wording. |
+| Rendering | Banner and diagrams render on GitHub; fallbacks read on PyPI. | Maintainer | Rendered README on the branch and the next PyPI page. | Adjust the asset or fallback. |
+
+## Handoff
+
+- **Operator/customer/support notes:** This is a public educational v0 under MIT, not a compliance, regulated-verification, or assurance product.
+- **Docs/runbook updated:** README, `docs/diagrams.md`, and the new banner asset.
+- **Communication needed:** The PR description explains the before/after, the new diagrams, the banner, and this packet.
+- **Follow-up date:** First post-merge issue triage.
+
+## Release decision
+
+- **Decision:** ship with named residual risk.
+- **Decision maker:** Maintainer.
+- **Rationale:** The change is documentation-only, reversible, and verified; the residual risks are bounded, owned, and have recheck triggers.
+- **Conditions attached:** Do not merge if CI or maintainer review fails.
+- **Abort or rollback trigger:** Any failing doc test, a broken fallback, or an overclaim found in review.
+
+## Baseline trigger
+
+- **Baseline required?** yes; the public landing page is a controlled item.
+- **Baseline record:** The merged commit on the default branch becomes the README baseline.
+- **Revalidation trigger:** A change to the component counts, the lifecycle, or the boundary wording.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `verification.md`
+- PR/commit/release artifact: landing-page draft PR
+- Monitoring: branch CI checks
+- Rollback: `git revert` of the landing-page commit
+
+## Exit criteria
+
+- The release decision is stated plainly.
+- The baseline trigger is named because a controlled item changed.
+- The evidence status and the gaps are visible.
+- A rollback path exists.
+- Any accepted residual risk has an owner and a recheck trigger.
+
+## Source-lineage note
+
+Original Nuclear-grade ship record inspired by public ideas on configuration management, release readiness, and software assurance mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/enterprise-landing-page/trace.md
+++ b/.nuclear/changes/enterprise-landing-page/trace.md
@@ -1,0 +1,61 @@
+# Trace — Enterprise Landing Page
+
+**Purpose:** Tie each landing-page claim to its basis, its control feature, its verification evidence, and its release stance.
+
+---
+
+## Change context
+
+- **Slug:** `enterprise-landing-page`
+- **Related basis record:** `basis.md`
+- **Related verification record:** `verification.md`
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+
+## Trace summary
+
+| ID | Claim | Basis link | Task / code ref | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|---|
+| REQ-001 | Project, one idea, and proof appear within the first screen. | `basis.md` | `plan.md` step 3 / `README.md` | Hero, "What this is", "The one idea", "See it work" at the top. | local proof | `verification.md` | ship | pass |
+| REQ-002 | Every embedded diagram has an adjacent text fallback. | `basis.md` | `plan.md` step 3 / `README.md` | "In words" line under each Mermaid block. | local proof | `verification.md` | ship | pass |
+| REQ-003 | Boundary and disclaimer language stays present, uncollapsed, and negative. | `basis.md` | `plan.md` step 3 / `README.md` | "What this is NOT" and license/limits kept expanded. | local proof | `verification.md` | ship | pass |
+| REQ-004 | New diagrams are canonical in `docs/diagrams.md` and embedded, not forked. | `basis.md` | `plan.md` step 1 / `docs/diagrams.md` | Sections 6 and 7 are the source; README mirrors them. | local proof | `verification.md` | ship | pass |
+| REQ-005 | Counts are qualified with the version and point to the live source. | `basis.md` | `plan.md` step 3 / `README.md` | "As of v0.5.0" with links to `nuclear-grade.yaml`. | fact | `verification.md` | ship | pass |
+| REQ-006 | Relative links resolve and CI doc invariants are preserved. | `basis.md` | `plan.md` step 3 / `tests/test_public_docs.py` | Lifecycle line and HPI phrase kept verbatim; links verified. | local proof | `verification.md` | ship | pass |
+
+## Evidence chain
+
+```text
+Risk / need: a dense README that newcomers cannot parse, with overclaim and rendering hazards
+  → Basis / requirement: REQ-001..006 (clarity, fallbacks, no overclaim, canonical diagrams, honest counts, intact invariants)
+  → Control / design feature: top-loaded pitch, per-diagram fallbacks, expanded disclaimers, single diagram source
+  → Verification evidence: doc tests, Mermaid validation, count cross-check, link check, packet validation
+  → Release decision: ship docs-only change; revert by git if a defect is found
+```
+
+## Open trace gaps
+
+| Gap | Why it matters | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| PyPI may strip the SVG banner from the long description. | The hero image may not show on PyPI. | accept; the plain H1 title and text carry the page. | Maintainer | Next PyPI release renders without the banner. |
+| External shields.io badges depend on a third-party service. | A badge image could fail to load. | accept; badges are decorative, not load-bearing. | Maintainer | A badge image breaks. |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+- Implementation: `README.md`, `docs/diagrams.md`, `docs/assets/landing-banner.svg`
+
+## Exit criteria
+
+- Each important claim has a status label.
+- Each important claim names its support type.
+- Every shipped claim has evidence or an accepted leftover risk.
+- A reviewer can move from claim to basis to evidence to decision quickly.
+
+## Source-lineage note
+
+Original Nuclear-grade trace record inspired by public sources on requirements tracing, verification, and configuration management mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/enterprise-landing-page/verification.md
+++ b/.nuclear/changes/enterprise-landing-page/verification.md
@@ -1,0 +1,76 @@
+# Verification — Enterprise Landing Page
+
+**Purpose:** Show that the landing-page claims have evidence that fits the size of the change.
+
+---
+
+## Verification context
+
+- **Slug:** `enterprise-landing-page`
+- **Related basis:** `basis.md`
+- **Owner:** Maintainer
+- **Date:** 2026-06-06
+- **Verification scope:** The README rewrite, the two canonical diagrams, the SVG banner, and this packet.
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
+
+## Claim-to-evidence table
+
+| Claim / requirement ID | Support type | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|---|
+| REQ-001 | local proof | peer review | Read the rendered README top to bottom. | Project, one idea, and a runnable proof are visible within the first screen. | pass | `README.md` | None. |
+| REQ-002 | local proof | self-check | Confirm an "In words" fallback under each Mermaid block. | Every embedded diagram has adjacent text. | pass | `README.md` | None. |
+| REQ-003 | local proof | deterministic test | `pytest tests/test_public_docs.py` plus diff review of disclaimers. | Boundary phrases stay negative; disclaimers stay expanded. | pass | `tests/test_public_docs.py` | None. |
+| REQ-004 | local proof | deterministic test | Mermaid validation of both new diagrams; confirm they exist in both files. | Both diagrams valid and present in `docs/diagrams.md` and `README.md`. | pass | `docs/diagrams.md` | None. |
+| REQ-005 | fact | self-check | Compare README counts to `nuclear-grade.yaml`. | Counts read 27 skills and 26 command prompts, qualified by version. | pass | `nuclear-grade.yaml` | None. |
+| REQ-006 | local proof | deterministic test | `pytest tests/test_public_docs.py` plus `ng validate` link check. | Invariants preserved; links resolve. | pass | `tests/test_public_docs.py` | None. |
+
+## Commands, evals, and reviews
+
+| Method | Command / review / eval | Environment | Result | Evidence link |
+|---|---|---|---|---|
+| Doc invariant tests | `python -m pytest tests/test_public_docs.py -v` | Local CI image | pass | `tests/test_public_docs.py` |
+| Packet validation | `python tools/ng.py validate .nuclear/changes/enterprise-landing-page` | Local | pass | `.nuclear/changes/enterprise-landing-page/` |
+| Repo health | `python tools/ng.py doctor .` | Local | pass | `tools/ng.py` |
+| Token budget | `python tools/ng.py tokens .` | Local | pass | `nuclear-grade.yaml` |
+| Mermaid validation | Render both new diagrams in a Mermaid validator | External validator | pass | `docs/diagrams.md` |
+
+## Negative / failure-mode checks
+
+| Failure mode | Check performed | Result | Evidence link |
+|---|---|---|---|
+| A boundary phrase used as a positive claim. | `test_boundary_phrases_are_only_used_in_negative_context`. | pass | `tests/test_public_docs.py` |
+| Lifecycle string or HPI phrase dropped. | Assertions in `test_public_docs.py`. | pass | `tests/test_public_docs.py` |
+| A diagram readable only in Mermaid. | Manual check for a text fallback under each block. | pass | `README.md` |
+| Internal residue leaking into a public doc. | `test_public_docs_contain_no_internal_residue`. | pass | `tests/test_public_docs.py` |
+
+## AI-assisted work checks
+
+- **AI scope:** An AI agent drafted the README, the diagrams, the banner, and this packet.
+- **Model/tool used:** Coding agent with repository file and shell access.
+- **Permissions/actions allowed:** Edit files in this repository and run local checks only.
+- **Independent checks performed:** Deterministic doc tests, the packet validator, doctor, and the token gate.
+- **Self-check / turnover records:** This packet; no separate turnover needed for a single-session change.
+- **Hallucination/slop screening:** Counts cross-checked against `nuclear-grade.yaml`; links verified to resolve.
+- **Human approval gates exercised:** Maintainer review and CI before merge.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `ship.md`
+- CI run / test logs: branch CI on `claude/enterprise-landing-page-uSnWo`
+- Implementation diff: `README.md`, `docs/diagrams.md`, `docs/assets/landing-banner.svg`
+
+## Exit criteria
+
+- Each important claim has a status.
+- Each important claim keeps the support type apart from the verification type.
+- Evidence is linked, not pasted in full.
+- Gaps are stated plainly and carried into `ship.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade verification record inspired by public sources on verification and validation, software assurance, and application-security checks mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,55 @@
-# Nuclear Grade Context Engineering
+<div align="center">
+
+<img src="docs/assets/landing-banner.svg" alt="Nuclear-grade Context Engineering — let AI do serious software work without losing control. Go fast while exploring; slow down when the work becomes a promise." width="820">
+
+<br/>
+
+**A simple, evidence-first way to let AI do serious software work — without losing control.**
 
 [![CI](https://github.com/FlyFission/nuclear-grade-context-engineering/actions/workflows/ci.yml/badge.svg)](https://github.com/FlyFission/nuclear-grade-context-engineering/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-2E7D45.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3A5BA8.svg)](pyproject.toml)
+[![No build step](https://img.shields.io/badge/setup-no%20build%20step-5B49A6.svg)](#quick-start)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-B07400.svg)](CONTRIBUTING.md)
 
-> A careful, evidence-first way to run AI on software work that matters.
+</div>
 
-AI agents no longer just suggest code. They edit files, change prompts, call tools, swap dependencies, write the evidence, and help ship releases. That is a lot of power with very little ceremony.
+# Nuclear Grade Context Engineering
 
-Nuclear-grade gives that work a clear path. Before an agent builds, you ask hard questions. You find the facts. You write down what the change must do. The agent works only inside the limits you set. Then you check the claims against real evidence, decide on purpose, save the approved version, and learn from what happens next.
+AI agents no longer just suggest code. They edit files, change prompts, call tools, swap dependencies, write the evidence, and help ship releases. That is a lot of power with very little ceremony. Nuclear-grade gives that work a clear, safe path — so you can move fast and still trust what ships.
 
-The discipline is borrowed from how high-consequence engineering is run: question your assumptions, prove your claims, and never let standards slip one small step at a time. The name is the standard, not the vocabulary.
+You do not need to read the whole repo to start. Run the two commands in [See it work in 30 seconds](#see-it-work-in-30-seconds), then copy one folder.
+
+## Contents
+
+- [What this is](#what-this-is)
+- [The one idea](#the-one-idea)
+- [See it work in 30 seconds](#see-it-work-in-30-seconds)
+- [How one change flows](#how-one-change-flows)
+- [Who does what](#who-does-what)
+- [Keeping the approved version under control](#keeping-the-approved-version-under-control)
+- [The common way vs. the nuclear-grade way](#the-common-way-vs-the-nuclear-grade-way)
+- [What you get](#what-you-get)
+- [Pick how much you want](#pick-how-much-you-want)
+- [Which change record do I need?](#which-change-record-do-i-need)
+- [Who this is for](#who-this-is-for)
+- [Quick start](#quick-start)
+- [Works across your tools](#works-across-your-tools)
+- [Project and community](#project-and-community)
+- [Map of the repo](#map-of-the-repo)
+- [What this is NOT](#what-this-is-not)
+- [License and limits](#license-and-limits)
+- [Where the ideas come from](#where-the-ideas-come-from)
+
+## What this is
+
+Before an agent builds, you ask hard questions and find the facts. You write down what the change must do. The agent works only inside the limits you set. Then you check the claims against real evidence, decide on purpose, save the approved version, and learn from what happens next.
+
+The discipline is borrowed from how high-consequence engineering is run: question your assumptions, prove your claims, and never let standards slip one small step at a time. The name is the standard of care, not the vocabulary — keep the discipline and rename the local copy if "nuclear-grade" would mis-calibrate your team (see [`DISCLAIMER.md`](DISCLAIMER.md)).
 
 ## The one idea
 
-Go fast while you are exploring. Slow down the moment the work becomes a promise.
+**Go fast while you are exploring. Slow down the moment the work becomes a promise.**
 
 An agent can try ideas and throw them away cheaply, so let it. But the rules tighten as soon as the work turns into a claim, a file you have to keep under control, a public statement, an approved version, a release call, or a change to what the agent is allowed to do.
 
@@ -28,7 +65,9 @@ question -> specify -> execute -> verify -> decide -> save approved version -> o
 
 This first release (v0) is a working toolkit you can use today: skills an agent can follow, command prompts you can paste, templates for small and large changes, a small command-line tool, a checker, a public list of sources, one fully worked example, and one hands-on comparison study.
 
-## Watch an AI agent prove it stayed in its workspace
+## See it work in 30 seconds
+
+Watch an AI agent prove it stayed inside its workspace, then read the change record that backs the result:
 
 ```bash
 python -m pytest docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py -v
@@ -37,53 +76,15 @@ python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.n
 # OK — the change record exposes the evidence behind that result.
 ```
 
-That packet is your template, not a curiosity. See [`CORE.md`](CORE.md) for the seven habits behind it and the decision matrix that picks up the rest by trigger; copy [`docs/03-worked-examples/ai-agent-tool-permissions/`](docs/03-worked-examples/ai-agent-tool-permissions/) to start your own.
+That packet is your template, not a curiosity. Copy [`docs/03-worked-examples/ai-agent-tool-permissions/`](docs/03-worked-examples/ai-agent-tool-permissions/) to start your own, and see [`CORE.md`](CORE.md) for the seven habits behind it. The longer guided tour lives in [`QUICKSTART.md`](QUICKSTART.md). If your shell only has `python3`, use `python3`.
 
-The longer guided tour — including the safety-check learning device — lives in [`QUICKSTART.md`](QUICKSTART.md). If your shell only has `python3`, use `python3`.
+## How one change flows
 
-> *A note on tone.* "Nuclear-grade" names the *standard of care*, not a compliance claim (see [`DISCLAIMER.md`](DISCLAIMER.md)). When you adopt this, you do not have to adopt the vocabulary — if the name would mis-calibrate your team or sound like an assurance claim you cannot back, rename the local copy. Keep the discipline; drop the branding.
-
-## What you get
-
-| Part | What it does | Start here |
-|---|---|---|
-| Workflows | Step-by-step paths for small changes, big changes, and the careful checks in between | [`WORKFLOWS.md`](WORKFLOWS.md) |
-| Skills | Instructions an agent can follow, each with inputs, outputs, how to verify, when to stop, and warning signs | [`SKILLS.md`](SKILLS.md) |
-| Command prompts | Ready-to-paste prompt cards for questioning, sorting risk, checking impact, saving an approved version, reviewing evidence, release checks, and more | [`COMMANDS.md`](COMMANDS.md) |
-| Templates | Fill-in records for small changes, standard changes, and high-consequence ones | [`templates/`](templates/) |
-| Command-line tool | `init`, `new`, `validate`, `doctor`, `list`, `status`, `migrate` | [`docs/05-reference/cli-reference.md`](docs/05-reference/cli-reference.md) |
-| Checker | A no-dependencies check for small and standard change records | [`tools/ng_validate.py`](tools/ng_validate.py) |
-| Worked example | A real change record proving an AI agent stayed inside its workspace | [`EXAMPLES.md`](EXAMPLES.md) |
-| Sources | The public ideas this borrows from, and how to talk about them safely | [`docs/00-standards-foundation/source-map.md`](docs/00-standards-foundation/source-map.md) |
-
-## How it is different
-
-| The common way | The nuclear-grade way |
-|---|---|
-| Ask an agent, look at the diff, run the tests. | Question the assumptions, name what must stay under control, write down the intent, check the evidence, decide, and save the approved version. |
-| The pull request text tries to talk reviewers into a yes. | A change record links intent, what must not break, what is under control, the evidence, the gaps, and the decision. |
-| Agents get broad access and vague instructions. | Agents get a role, a list of what they may do, what they may not do, what they must prove, where the work stands, and when to stop. |
-| Green tests become the reason to ship. | The release record states the evidence, the leftover risk, the rollback plan, what to watch, the decision, and what to save. |
-| Lessons disappear into the chat history. | Lessons from real operation feed back into future plans, tests, monitors, and controls. |
-
-The shift, in one view:
-
-```text
-review the diff           -> review the whole approved setup
-trust the prompt history  -> keep a controlled record of the change
-hand the agent free rein  -> hand it focused context and a duty to prove
-treat green tests as a yes -> make an explicit release decision and save the result
-```
-
-This is practical, not decorative. Instructions should be hard to misuse. Small actions should still serve the goal. And "I'm confident" should never be confused with "here is the proof."
-
-## The full path
+Every change walks the same path. Each step is a control point: it stops one specific failure and produces one artifact you can point at. A skipped step is not a shortcut — it is a named failure mode you chose to accept.
 
 ```text
 Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn
 ```
-
-Each step is a control point: it stops one specific failure mode and produces one artifact you can point at. A skipped step is not a shortcut — it is a named failure mode you chose to accept. The control-point detail — stops / produces / abort-if — is tabled for the everyday seven-step form of this loop in [`WORKFLOWS.md`](WORKFLOWS.md), and the same control points apply when the loop fans out into all eleven beats.
 
 ```mermaid
 flowchart LR
@@ -95,7 +96,7 @@ flowchart LR
     L -.feeds future basis.-> Q
 ```
 
-Zoomed out, those eleven beats are three moves — **PRO**: Plan · Run · Operate — or five with the gate named — **PROVE**: Plan · Run · Observe · Verdict · Embed. One label, two zoom levels (full crosswalk in [`docs/diagrams.md`](docs/diagrams.md)):
+Zoomed out, those eleven beats are three moves — **PRO**: Plan · Run · Operate — or five with the gate named — **PROVE**: Plan · Run · Observe · Verdict · Embed. One label, two zoom levels:
 
 ```mermaid
 flowchart TB
@@ -125,28 +126,116 @@ flowchart TB
   class C1,C2,C3 emb
 ```
 
-More diagrams (mode decision tree, skill graph, packet artifact graph) are in [`docs/diagrams.md`](docs/diagrams.md).
+*If the diagrams above do not render (for example on PyPI), the eleven-beat line just above is the same path in text.* The control-point detail — what each step stops and produces — is in [`WORKFLOWS.md`](WORKFLOWS.md), and every diagram here is canonical in [`docs/diagrams.md`](docs/diagrams.md).
 
-A "baseline" is just the version you have agreed is correct and want to protect. Small and standard change records are the Git-native way to walk a change through this path. You sort the risk early so the simple path stays easy to teach. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them.
+Underneath the path sit a few habits borrowed from high-reliability work — what we call **HPI for AI agents** (Human Performance Improvement). Use them when they change the outcome: brief the work before a risky step, double-check critical actions, hand off cleanly, get a second set of eyes when trust is on the line, and capture the lesson after a near miss.
 
-Underneath the path sit a few habits borrowed from high-reliability work, what we call HPI for AI agents (Human Performance Improvement). Use them when they change the outcome: brief the work before a risky step, double-check critical actions, hand off cleanly, get a second set of eyes when trust is on the line, and capture the lesson after a near miss.
+## Who does what
 
-## Leadership and high reliability: top-down and bottom-up
+Four roles share the work: **you**, the **AI agent**, the **change record**, and the **reviewer**. The agent moves fast — but only inside limits you approve first. The record carries each claim and its evidence. The reviewer decides on the evidence, not the pitch.
 
-The submarine world it borrows from is not only about procedure. It is about how authority moves. Nuclear-grade applies that in two directions at once.
+```mermaid
+sequenceDiagram
+    actor You
+    participant Agent as AI agent
+    participant Record as Change record
+    actor Reviewer
+    You->>Agent: Ask the hard question, set the goal
+    Agent->>Record: Draft the risk and what "good" means
+    Record-->>You: You read the draft
+    You->>Agent: Approve the limits (may / may not do)
+    Agent->>Agent: Build only inside the limits
+    Agent->>Record: Write each claim with its evidence
+    Record-->>Reviewer: Show evidence, gaps, decision
+    Reviewer->>Record: Decide on purpose (ship / defer / block)
+    Record->>Record: Save the approved version (baseline)
+    Note over You,Reviewer: Lessons from real use feed the next change
+```
 
-- **Top-down:** supervisors supply *clarity* (the mission, the constraints, what good looks like) and grow *competence* (evidence, evals, a track record) so that authority can move to where the information already is. The leader's job shifts from approving every move to verifying clarity and competence.
-- **Bottom-up:** the person or agent closest to the work *declares intent and reasoning* before a critical action — "I intend to do X because the checks show Y" — surfaces what they see, and *escalates at trust boundaries*. Anyone may halt unclear work, and bad news is protected, never punished.
+**In words:** you ask and set the goal → the agent drafts the risk and what "good" means → you approve the limits → the agent builds only inside them → the agent writes each claim with its evidence → the reviewer checks the evidence and decides (ship / defer / block) → the approved version is saved as the baseline → lessons from real use feed the next change. Canonical copy in [`docs/diagrams.md`](docs/diagrams.md).
 
-The point is to push authority to the information, not to remove a human gate. The gradient raises rigor where it matters: reversible, well-evidenced work is decided at the edge; anything irreversible, trust-bearing, or thinly evidenced escalates. And because AI amplifies an organization's existing strengths and weaknesses, this discipline matters more with agents, not less — treat AI output as a hypothesis to prove, not as authority. See [`docs/01-field-guide/leadership-and-high-reliability.md`](docs/01-field-guide/leadership-and-high-reliability.md).
+## Keeping the approved version under control
 
-## Change records: small vs. standard
+A **baseline** is just the version everyone agreed is correct and wants to protect. Changes never edit the baseline directly — they go through evidence and a decision first, and only an accepted change becomes the new baseline. That is configuration management, in one loop:
 
-This first release checks two kinds of change records.
+```mermaid
+flowchart LR
+    classDef item fill:#DCE6FA,stroke:#3A5BA8,color:#12203F;
+    classDef gate fill:#FFD24D,stroke:#B07400,color:#3A2600,stroke-width:2px;
+    classDef base fill:#DCEFDE,stroke:#2E7D45,color:#102810;
+    CI["Controlled items<br/>code, prompts, models,<br/>deps, docs, releases"]:::item --> CH["A change"]
+    CH --> EV["Evidence<br/>pass or gap, named"]
+    EV --> DEC{"Decide<br/>on purpose"}:::gate
+    DEC -->|"ship / defer"| BL["Saved baseline<br/>the approved version"]:::base
+    DEC -.->|"block"| CH
+    BL --> OP["Operate"]
+    OP --> LE["Lessons learned"]
+    LE -.->|"feed the next change"| CI
+```
+
+**In words:** controlled items (code, prompts, models, dependencies, docs, releases) → a change → named evidence (pass or gap) → a deliberate decision → if ship or defer, save the new baseline; if block, back to the change → operate the baseline → lessons feed the next change. You only add the heavier records — what is under control, ripple effects, the saved baseline, drift, and operating lessons — when the stakes are high enough to earn them. Canonical copy in [`docs/diagrams.md`](docs/diagrams.md).
+
+## The common way vs. the nuclear-grade way
+
+| The common way | The nuclear-grade way |
+|---|---|
+| Ask an agent, look at the diff, run the tests. | Question the assumptions, name what must stay under control, write down the intent, check the evidence, decide, and save the approved version. |
+| The pull request text tries to talk reviewers into a yes. | A change record links intent, what must not break, what is under control, the evidence, the gaps, and the decision. |
+| Agents get broad access and vague instructions. | Agents get a role, a list of what they may do, what they may not do, what they must prove, where the work stands, and when to stop. |
+| Green tests become the reason to ship. | The release record states the evidence, the leftover risk, the rollback plan, what to watch, the decision, and what to save. |
+| Lessons disappear into the chat history. | Lessons from real operation feed back into future plans, tests, monitors, and controls. |
+
+The shift, in one view:
 
 ```text
-.nuclear/changes/<name>/
+review the diff           -> review the whole approved setup
+trust the prompt history  -> keep a controlled record of the change
+hand the agent free rein  -> hand it focused context and a duty to prove
+treat green tests as a yes -> make an explicit release decision and save the result
 ```
+
+This is practical, not decorative. Instructions should be hard to misuse. Small actions should still serve the goal. And "I'm confident" should never be confused with "here is the proof."
+
+## What you get
+
+| Part | What it does | Start here |
+|---|---|---|
+| Workflows | Step-by-step paths for small changes, big changes, and the careful checks in between | [`WORKFLOWS.md`](WORKFLOWS.md) |
+| Skills | Instructions an agent can follow, each with inputs, outputs, how to verify, when to stop, and warning signs | [`SKILLS.md`](SKILLS.md) |
+| Command prompts | Ready-to-paste prompt cards for questioning, sorting risk, checking impact, saving an approved version, reviewing evidence, release checks, and more | [`COMMANDS.md`](COMMANDS.md) |
+| Templates | Fill-in records for small changes, standard changes, and high-consequence ones | [`templates/`](templates/) |
+| Command-line tool | `init`, `new`, `validate`, `doctor`, `list`, `status`, `migrate`, `tokens` | [`docs/05-reference/cli-reference.md`](docs/05-reference/cli-reference.md) |
+| Checker | A no-dependencies check for small and standard change records | [`tools/ng_validate.py`](tools/ng_validate.py) |
+| Worked example | A real change record proving an AI agent stayed inside its workspace | [`EXAMPLES.md`](EXAMPLES.md) |
+| Sources | The public ideas this borrows from, and how to talk about them safely | [`docs/00-standards-foundation/source-map.md`](docs/00-standards-foundation/source-map.md) |
+
+As of v0.5.0 that is **27 skills** and **26 command prompts**. The live list is the source of truth — see [`nuclear-grade.yaml`](nuclear-grade.yaml), [`SKILLS.md`](SKILLS.md), and [`COMMANDS.md`](COMMANDS.md) — so treat any count here as a snapshot, not a promise.
+
+## Pick how much you want
+
+You do not adopt the whole system on day one. It scales with the stakes:
+
+- **Start with the Core 7** — seven always-on habits that fit any change. See [`CORE.md`](CORE.md).
+- **Add clusters by consequence** — bring in the heavier skills, templates, and records only when a change touches users, data, dependencies, permissions, AI authority, or a release.
+- **Grow into the full system** — the complete skill set, command prompts, and modes once your team has tested the lighter path.
+
+Ready-made bundles live in [`starter-kit/`](starter-kit/), and [`CORE.md`](CORE.md) has a decision matrix that picks the right kit for your project by trigger.
+
+## Which change record do I need?
+
+Rigor scales with consequence, not effort. This release checks two kinds of change records, both kept under `.nuclear/changes/<name>/`:
+
+```mermaid
+flowchart TD
+    Start([Change request]) --> Q1{Local, reversible,<br/>obvious proof,<br/>no new trust boundary?}
+    Q1 -->|yes| Quick[Quick packet<br/>risk.md + proof.md]
+    Q1 -->|no| Q2{User / data / dep /<br/>permission / AI authority /<br/>release consequence?}
+    Q2 -->|yes| Standard[Standard packet<br/>6 files]
+    Q2 -->|severe, silent,<br/>irreversible, external trust| Strong[Human-reviewed<br/>stronger mode]
+    Q2 -->|already went wrong| Incident[Incident pattern]
+```
+
+**In words / which files:**
 
 | Kind | Use it when | Files |
 |---|---|---|
@@ -165,7 +254,52 @@ Use Nuclear-grade if you are:
 - leading a team that wants speed without losing the plot on risk and releases;
 - building internal workflows where people and agents both need focused context and a duty to prove their claims.
 
-## What this is not
+## Quick start
+
+1. **Get the tool.** Clone the repo and install it (no third-party dependencies). See [`INSTALL.md`](INSTALL.md).
+2. **Check your setup.** Run `python tools/ng.py doctor .` to confirm things are wired up, and `python tools/ng.py list` to see what is available.
+3. **Make your first record.** Run `python tools/ng.py new <slug> --mode quick`, fill in the two files, then prove it with `python tools/ng.py validate .nuclear/changes/<slug>`.
+
+If your shell only has `python3`, use `python3`. The full guided tour is in [`QUICKSTART.md`](QUICKSTART.md). **Using an AI agent? Point it at [`AGENTS.md`](AGENTS.md)** — it is the shared brief agents read first.
+
+## Works across your tools
+
+Cursor, Claude Code, Aider, Codex, and Copilot each read slightly different files for their reasoning and rules. `.nuclear/`, [`AGENTS.md`](AGENTS.md), and the `SKILL.md` contract are a **shared, tool-agnostic shape** that all of them can import as plain markdown: a portable surface for agent authority, change records, and evidence. No matter which IDE ships reasoning steps natively, the packets and habits travel with the repository.
+
+## Project and community
+
+| Topic | Where |
+|---|---|
+| How to contribute | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| How decisions are made | [`GOVERNANCE.md`](GOVERNANCE.md) |
+| Reporting a vulnerability | [`SECURITY.md`](SECURITY.md) |
+| Community expectations | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
+| Getting help | [`SUPPORT.md`](SUPPORT.md) |
+| Where this is going | [`ROADMAP.md`](ROADMAP.md) |
+| What changed | [`CHANGELOG.md`](CHANGELOG.md) |
+| The principles in short form | [`MAXIMS.md`](MAXIMS.md) |
+| Citing this work | [`CITATION.cff`](CITATION.cff) |
+
+## Map of the repo
+
+```text
+skills/                         skills an agent can follow
+commands/                       paste-ready command prompts
+templates/                      fill-in records for small, standard, and high-consequence changes
+starter-kit/                    ready-made bundles to drop into a project
+tools/                          the command-line tool and the checker
+tests/                          tests for the checker, the tool, the contracts, and the public docs
+docs/00-standards-foundation/   sources, safe citation, compliance boundaries
+docs/01-field-guide/            how each source idea maps to a plain concept, incl. the leadership and high-reliability guide
+docs/02-operating-system/       the path, the habits, the modes, the records, the checks, authority and intent, incidents, deficiencies
+docs/03-worked-examples/        the flagship worked example and the comparison study
+docs/04-adoption/               rollout, agent permissions, reviewer playbook
+docs/05-reference/              the skill, command, and tool contracts
+docs/diagrams.md                visual maps of the path, modes, skills, and records
+docs/glossary.md                plain-language decoding of terms and idioms
+```
+
+## What this is NOT
 
 Nuclear-grade is not a compliance program, a certification, a regulated quality-assurance system, a safety analysis, a production sandbox, a regulatory submission, legal advice, or a substitute for qualified engineering, legal, security, safety, or compliance review.
 
@@ -177,53 +311,7 @@ Read these before you use it:
 - [`docs/00-standards-foundation/compliance-boundaries.md`](docs/00-standards-foundation/compliance-boundaries.md)
 - [`docs/00-standards-foundation/do-not-cite-directly.md`](docs/00-standards-foundation/do-not-cite-directly.md)
 
-## Map of the repo
-
-```text
-skills/                         skills an agent can follow
-commands/                       paste-ready command prompts
-templates/                      fill-in records for small, standard, and high-consequence changes
-tools/                          the command-line tool and the checker
-tests/                          tests for the checker, the tool, the contracts, and the public docs
-docs/00-standards-foundation/   sources, safe citation, compliance boundaries
-docs/01-field-guide/            how each source idea maps to a plain concept, incl. the leadership and high-reliability guide
-docs/02-operating-system/       the path, the habits, the modes, the records, the checks, authority and intent, incidents, deficiencies
-docs/03-worked-examples/        the flagship worked example
-docs/04-adoption/               rollout, agent permissions, reviewer playbook
-docs/05-reference/              the skill, command, and tool contracts
-docs/diagrams.md                visual maps of the path, modes, skills, and records
-docs/glossary.md                plain-language decoding of terms and idioms
-```
-
-## What is in v0
-
-Included now:
-
-- a get-started-fast onboarding and a map of the repo;
-- templates for small and standard changes;
-- heavier templates for what is under control, ripple effects, saved baselines, drift, and operating lessons;
-- "golden path" templates for questioning, writing a spec, handing off, self-checking, and recording a decision;
-- a local command-line tool and a no-dependencies checker;
-- skills an agent can follow and command prompts you can paste;
-- a public list of sources and honest labels for how settled each one is;
-- a worked example proving an AI agent only wrote inside its workspace (checked by tests);
-- a hands-on comparison across twelve real use cases (see `docs/03-worked-examples/skill-workflow-comparison/`);
-- tests for the checker, the tool, the skill and command contracts, the public docs, and the example code.
-
-The comparison is honest about its limits: it is author-judged across twelve scenarios, design evidence not proof of effectiveness. See [`docs/03-worked-examples/skill-workflow-comparison/methodology.md`](docs/03-worked-examples/skill-workflow-comparison/methodology.md) for what the trials measure and what they do not.
-
-Not included yet:
-
-- a packaged plug-in for one specific agent platform;
-- full worked examples for external API controls and human approval steps;
-- deep automated checking for the heavier change patterns;
-- a production sandbox, a compliance package, or any regulated-use assurance workflow.
-
-## Across tools
-
-Cursor, Claude Code, Aider, Codex, and Copilot each read slightly different files for their reasoning and rules. `.nuclear/`, `AGENTS.md`, and the `SKILL.md` contract are a **shared, tool-agnostic shape** that all of them can import as plain markdown: a portable surface for agent authority, change records, and evidence. No matter which IDE ships reasoning steps natively, the packets and habits travel with the repository.
-
-See [`MAXIMS.md`](MAXIMS.md) for the principles in short form, and [`CORE.md`](CORE.md) for the decision matrix that picks the right kit for your project.
+The comparison study is honest about its limits: it is author-judged across twelve scenarios, design evidence not proof of effectiveness. See [`docs/03-worked-examples/skill-workflow-comparison/methodology.md`](docs/03-worked-examples/skill-workflow-comparison/methodology.md) for what the trials measure and what they do not.
 
 ## License and limits
 

--- a/docs/assets/landing-banner.svg
+++ b/docs/assets/landing-banner.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 320" width="1200" height="320" role="img" aria-labelledby="title desc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title id="title">Nuclear-grade Context Engineering</title>
+  <desc id="desc">An evidence-first way to let AI do serious software work without losing control. Go fast while exploring; slow down when the work becomes a promise.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0E1A30"/>
+      <stop offset="1" stop-color="#16263F"/>
+    </linearGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#3A5BA8"/>
+      <stop offset="0.5" stop-color="#5BC8B3"/>
+      <stop offset="1" stop-color="#FFD24D"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="320" rx="20" fill="url(#bg)"/>
+  <rect x="1" y="1" width="1198" height="318" rx="19" fill="none" stroke="#283C5C" stroke-width="2"/>
+
+  <text x="600" y="118" text-anchor="middle" fill="#F4F7FC" font-size="76" font-weight="800" letter-spacing="2">NUCLEAR-GRADE</text>
+  <text x="600" y="170" text-anchor="middle" fill="#9DB6E0" font-size="34" font-weight="600" letter-spacing="14">CONTEXT ENGINEERING</text>
+
+  <rect x="360" y="196" width="480" height="3" rx="1.5" fill="url(#rule)"/>
+
+  <text x="600" y="240" text-anchor="middle" fill="#D7E0EE" font-size="25" font-weight="500">Let AI do serious software work &#8212; without losing control.</text>
+  <text x="600" y="278" text-anchor="middle" fill="#7FA0C9" font-size="20" font-style="italic">Go fast while exploring. Slow down when it becomes a promise.</text>
+</svg>

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -186,6 +186,55 @@ flowchart TD
 
 ---
 
+## 6. Who does what in one change
+
+How four roles hand off authority over a single change: **you**, the **AI agent**, the **change record**, and the **reviewer**. The agent moves fast inside limits you approved first; the record carries the claims and their evidence; the reviewer decides on the evidence, not the pitch. Read top to bottom.
+
+```mermaid
+sequenceDiagram
+    actor You
+    participant Agent as AI agent
+    participant Record as Change record
+    actor Reviewer
+    You->>Agent: Ask the hard question, set the goal
+    Agent->>Record: Draft the risk and what "good" means
+    Record-->>You: You read the draft
+    You->>Agent: Approve the limits (may / may not do)
+    Agent->>Agent: Build only inside the limits
+    Agent->>Record: Write each claim with its evidence
+    Record-->>Reviewer: Show evidence, gaps, decision
+    Reviewer->>Record: Decide on purpose (ship / defer / block)
+    Record->>Record: Save the approved version (baseline)
+    Note over You,Reviewer: Lessons from real use feed the next change
+```
+
+**In words (text fallback):** you ask + set the goal → agent drafts the risk and the definition of "good" → you approve the limits → agent builds only inside them → agent writes each claim with its evidence → reviewer checks the evidence and decides (ship / defer / block) → the approved version is saved as the baseline → lessons from real use feed the next change.
+
+---
+
+## 7. Keeping the approved version under control
+
+The configuration-management loop in one picture. A **baseline** is the version everyone agreed is correct and wants to protect. Changes do not edit the baseline directly — they go through evidence and a decision first, and only an accepted change becomes the new baseline.
+
+```mermaid
+flowchart LR
+    classDef item fill:#DCE6FA,stroke:#3A5BA8,color:#12203F;
+    classDef gate fill:#FFD24D,stroke:#B07400,color:#3A2600,stroke-width:2px;
+    classDef base fill:#DCEFDE,stroke:#2E7D45,color:#102810;
+    CI["Controlled items<br/>code, prompts, models,<br/>deps, docs, releases"]:::item --> CH["A change"]
+    CH --> EV["Evidence<br/>pass or gap, named"]
+    EV --> DEC{"Decide<br/>on purpose"}:::gate
+    DEC -->|"ship / defer"| BL["Saved baseline<br/>the approved version"]:::base
+    DEC -.->|"block"| CH
+    BL --> OP["Operate"]
+    OP --> LE["Lessons learned"]
+    LE -.->|"feed the next change"| CI
+```
+
+**In words (text fallback):** controlled items (code, prompts, models, dependencies, docs, releases) → a change → named evidence (pass or gap) → a deliberate decision → if ship/defer, save the new baseline; if block, back to the change → operate the baseline → lessons learned feed the next change to the controlled items.
+
+---
+
 ## Source-lineage note
 
 These diagrams are an original visual restatement of the Nuclear-grade workflow, influenced by public lifecycle, configuration-management, and software-assurance sources mapped in [`00-standards-foundation/source-map.md`](00-standards-foundation/source-map.md). They do not create formal V&V, compliance, certification, safety, security, or regulatory adequacy.


### PR DESCRIPTION
## What and why

The old `README.md` was honest and substantive but dense, and a first-time visitor couldn't tell in ten seconds what the project is or why it matters. This rewrites it into a best-in-class, plain-language landing page a newcomer can follow — while keeping the brand, the runnable proof, and **every** boundary the project depends on.

The change deliberately **models the method it documents**: it ships with its own Standard change packet.

## Before → after

- **Before:** 238 lines, expert/nautical vocabulary, the two strongest assets (configuration-management and orchestration) buried in prose.
- **After:** top-loaded pitch + a runnable proof in the first screen, the same ideas *shown* as diagrams, a Table of Contents, and a surfaced project/community section. Substance, proof commands, comparison-study caveats, and disclaimers are preserved near-verbatim.

## What's in this PR

- **SVG hero banner** (`docs/assets/landing-banner.svg`) — hand-written, diffable, typographic. No radiation or compliance imagery (nothing that implies an assurance claim); self-contained panel so it reads in light and dark themes; descriptive `alt` text, and a plain `#` H1 remains so the page degrades gracefully where SVG is stripped (e.g. PyPI).
- **Two new canonical diagrams in `docs/diagrams.md`**, embedded in the README:
  - a **role sequence** — *you → AI agent → change record → reviewer* over one change;
  - a **configuration-management / baseline loop** — controlled items → change → evidence → decision → saved baseline → lessons.
- **Per-diagram text fallbacks** — every embedded Mermaid block has an adjacent "In words" line, so the page stays usable on PyPI (where the README is the long description and Mermaid is broken) and for screen readers.
- **Honest counts** — component counts are qualified as a v0.5.0 snapshot and point to the live source (`nuclear-grade.yaml`, `SKILLS.md`, `COMMANDS.md`) so they can't silently overclaim as the corpus grows.
- **Surfaced trust signals** — links to CONTRIBUTING, GOVERNANCE, SECURITY, CODE_OF_CONDUCT, SUPPORT, ROADMAP, CHANGELOG, MAXIMS, CITATION, plus an `AGENTS.md` pointer for agent readers.
- **Boundaries kept visible** — "What this is NOT", license/limits, and disclaimer links stay expanded (never collapsed) and in negative context.
- **Standard change packet** (`.nuclear/changes/enterprise-landing-page/`) — risk, basis, plan, trace, verification, ship.

## Why no diagram drift / no overclaim

The new diagrams live **once** in `docs/diagrams.md` and are mirrored into the README, so there's a single source. No hedge was upgraded into a hard claim: the comparison-study "author-judged, design evidence not proof" wording, the v0 caveats, and all disclaimer language are preserved.

## Verification

- `pytest tests/test_public_docs.py` and the **full suite (117 tests)** pass — the CI doc invariants (eleven-beat lifecycle line, the "HPI for AI agents" phrase, negative-context boundary phrasing) are intact.
- Both new diagrams validate as Mermaid.
- `ng validate .nuclear/changes/enterprise-landing-page` → **OK**; `ng doctor` and `ng tokens` green.
- All README and `docs/diagrams.md` relative links resolve.

https://claude.ai/code/session_019B9tViBgc3KrUETfYBup4v

---
_Generated by [Claude Code](https://claude.ai/code/session_019B9tViBgc3KrUETfYBup4v)_