### PR TITLE
Rename the PROVE fifth beat: Embed → Educate

### DIFF
--- a/.nuclear/changes/prove-educate-rename/proof.md
+++ b/.nuclear/changes/prove-educate-rename/proof.md
@@ -1,0 +1,56 @@
+# Quick Proof
+
+**Purpose:** Capture the smallest credible evidence record for this Quick change.
+
+---
+
+## Proof summary
+
+- Change slug: prove-educate-rename
+- Proof owner: FlyFission
+- Date/time: 2026-06-08
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: Renaming the PROVE fifth beat Embed → Educate is a label-only change. It keeps the full test suite, `doctor`, `tokens`, ruff, and every in-repo packet green; preserves the canonical eleven-beat path strings the public-doc tests assert byte-for-byte; leaves no stale "Embed" beat in any spellout or diagram; and is guarded going forward by a new `test_public_docs` invariant.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest -q`; `python -m ruff check .`; `python tools/ng.py doctor .`; `python tools/ng.py tokens .`; `python tools/ng.py validate .nuclear/changes/prove-educate-rename`.
+- Environment: Python at `/usr/local/bin/python`, pytest 9.0.3, ruff 0.15.16; repo working tree on `claude/pensive-cori-bWkzD`, fast-forwarded onto `main` at #28 (`343e811`).
+- Inputs/fixtures: the four changed docs (`README.md`, `WORKFLOWS.md`, `docs/02-operating-system/lifecycle.md`, `docs/diagrams.md`), the new test, and this packet.
+- Expected result: full suite green including the new PROVE-handle invariant and the existing `test_public_docs` path assertions; ruff clean; doctor OK; token budget OK; this packet validates.
+- Self-check used? yes; target = the canonical eleven-beat ASCII path strings in `README.md` and `lifecycle.md`, confirmed unchanged (only the PROVE acronym's fifth word changed).
+
+## Result
+
+- Status: pass
+- Actual result: `python -m pytest -q` → 118 passed (was 117; +1 for the new `test_prove_handle_uses_educate_and_stays_consistent`); `ruff check .` → All checks passed; `doctor .` → OK; `tokens .` → OK: token budget; `validate .nuclear/changes/prove-educate-rename` → passed. No "Embed" beat remains in `README.md`, `WORKFLOWS.md`, `lifecycle.md`, or `docs/diagrams.md`; the historical `prove-overlay` packet is intentionally left unchanged.
+- Evidence link or artifact path: the commands above; changed files listed in `risk.md` Scope.
+- If failed/gap: none. The classDef token `emb` in `docs/diagrams.md` is intentionally left unrenamed — it is a shared color class for the green Baseline·Operate·Learn nodes used by both the PRO billboard (labeled "Operate") and the PROVE map (labeled "Educate"); renaming it to `edu` would mislabel the PRO usage. The visible subgraph title is now "E — EDUCATE"; GitHub renders the Mermaid client-side.
+
+## Reviewer note
+
+- Reviewer: FlyFission
+- Review note: Label-only rename of the PROVE handle's fifth beat across the five live spellouts, plus a one-line diagram gloss clarifying that the seven control points are the everyday short form of the eleven beats and that the letter O is reused (Observe in PROVE, Operate in PRO). The eleven-beat path, its order, and the control points are unchanged. A new doc-invariant guards the handle against future mirror drift. Supersedes the `Embed` label from `prove-overlay` without rewriting that historical record.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: Rename the PROVE fifth beat Embed → Educate
+- Relevant changed files: `README.md`, `WORKFLOWS.md`, `docs/02-operating-system/lifecycle.md`, `docs/diagrams.md`, `tests/test_public_docs.py`
+- CI run / test output: `python -m pytest -q` (118 passed), `python -m ruff check .` (clean), `python tools/ng.py doctor .` (OK), `python tools/ng.py tokens .` (OK)
+- If AI-assisted: changes prepared by an AI agent under review; scope is a documentation label rename plus one guard test.
+
+## Exit criteria
+
+- Evidence directly matches the claim in `risk.md`.
+- Actual result is compared to the expected result named before proof.
+- Result status is explicit.
+- Any failure or gap has a next action or escalation.
+- Reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public software test-documentation and verification concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/prove-educate-rename/risk.md
+++ b/.nuclear/changes/prove-educate-rename/risk.md
@@ -1,0 +1,78 @@
+# Quick Risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** A label-only rename of the PROVE handle's fifth beat (Embed → Educate) across the docs that spell it, plus a one-line diagram clarity gloss and one doc-invariant test. No code path, validator logic, dependency, permission, release posture, or public assurance claim changes; the eleven-beat path, its order, and the control points are untouched.
+
+**Purpose:** Decide whether renaming the PROVE beat `Embed → Educate` can safely stay in Quick mode, and name the proof required.
+
+---
+
+## Change
+
+- Slug: prove-educate-rename
+- PR / issue: Rename the PROVE fifth beat Embed → Educate
+- Owner: FlyFission
+- Date: 2026-06-08
+- Summary: Rename the fifth PROVE beat from **Embed** to **Educate** so the handle reads Plan · Run · Observe · Verdict · Educate. "Educate" names the same Baseline · Operate · Learn beats by what they are for — turning real operation into the lesson the next loop is taught — and drops the borrowed machine-learning "embedding" vocabulary. The five live spellouts change in lockstep: `README.md`, `WORKFLOWS.md`, `docs/02-operating-system/lifecycle.md`, and `docs/diagrams.md` (the PROVE-diagram subgraph title and the zoom-crosswalk row). A one-line gloss is added in `docs/diagrams.md` clarifying that the seven control points are the everyday short form of the eleven beats, and that the letter **O** is reused (Observe in PROVE, Operate in PRO). A new `tests/test_public_docs.py` invariant guards the handle so the mirror cannot drift. This supersedes the `Embed` label introduced by the `prove-overlay` packet; that historical record is left unchanged.
+
+## Scope
+
+- Affected files/configs/docs: `README.md`, `WORKFLOWS.md`, `docs/02-operating-system/lifecycle.md`, `docs/diagrams.md`, `tests/test_public_docs.py`.
+- User-visible behavior changed? no (a documentation label plus a guard test).
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A diagram label or acronym reads poorly; reversible by edit. No runtime, evidence-gate, or trust-boundary effect. |
+| Reversibility | Fully reversible; a label rename plus a one-line gloss and one test. |
+| Detectability | High; the new `test_public_docs` invariant plus `pytest`, `doctor`, and `tokens` cover it, and the diagram renders visibly. |
+| Exposure | Public docs, but the change is a label swap within existing boundary wording. |
+| Uncertainty | Low; no logic change; the canonical eleven-beat path strings are untouched. |
+| Why Quick is enough | No new trust boundary, dependency, permission, or release effect; follows the `prove-overlay` Quick precedent for the same handle. |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest -q`; `python tools/ng.py doctor .`; `python tools/ng.py tokens .`; `python tools/ng.py validate .nuclear/changes/prove-educate-rename`.
+- Expected result: full suite green (including the new PROVE-handle invariant and the existing `test_public_docs` path assertions); doctor OK; token budget OK; this packet validates.
+- Evidence link/location: `proof.md`.
+
+## Critical-action self-check
+
+- Exact target: the five PROVE/PRO spellouts and the diagrams crosswalk and subgraph title; specifically NOT the canonical eleven-beat ASCII path strings in `README.md` and `docs/02-operating-system/lifecycle.md` that `test_public_docs` asserts byte-for-byte.
+- Expected result: only "Embed" → "Educate" (and the one diagram clarity gloss) changes; the eleven-beat sequence string and the `Decide -> Baseline -> Operate -> Learn` string stay byte-for-byte unchanged.
+- Stop condition: if any edit would alter a canonical path string or an existing `test_public_docs` assertion, stop and revert.
+
+## Escalation check
+
+Move up to Standard if any of these are true:
+
+- users, data, security, permissions, operations, or architecture are affected — no;
+- a trust decision about a dependency, model, or API changed — no;
+- a failure could be silent, delayed, costly, or hard to undo — no (a wrong label is visible and reverts cleanly);
+- the AI had the power to write, run commands, use the network, or approve actions beyond drafting — no (drafting docs plus a guard test under review);
+- the proof will not fit in one small `proof.md` — false.
+
+None apply. Quick stands.
+
+## Required links
+
+- Packet: `.nuclear/changes/prove-educate-rename/`
+- Related PR/issue: Rename the PROVE fifth beat Embed → Educate
+- Proof record: `proof.md`
+- Superseded label source: `.nuclear/changes/prove-overlay/` (left unchanged)
+- Relevant source-map/crosswalk if invoked: `docs/diagrams.md` (canonical diagrams)
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public graded-rigor and software-assurance concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ flowchart LR
     L -.feeds future basis.-> Q
 ```
 
-Zoomed out, those eleven beats are three moves — **PRO**: Plan · Run · Operate — or five with the gate named — **PROVE**: Plan · Run · Observe · Verdict · Embed. One label, two zoom levels:
+Zoomed out, those eleven beats are three moves — **PRO**: Plan · Run · Operate — or five with the gate named — **PROVE**: Plan · Run · Observe · Verdict · Educate. One label, two zoom levels:
 
 ```mermaid
 flowchart TB

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -30,7 +30,7 @@ The loop closes when operation feeds the next question.
 
 This is what "nuclear-grade" buys you over prompt-and-pray: every step has a job, an artifact, and a stop condition. A skipped step is not a shortcut — it is a known failure mode you chose to accept.
 
-These seven are the everyday form of the loop. For standard and high-consequence work the same loop fans out into eleven beats — `Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn` — splitting Question into Question/Discover, Specify into Specify/Plan, Decide into Review/Decide, and Operate into Operate/Learn. Same control points, more beats. Those eleven beats also carry a memory handle — **PROVE** (Plan · Run · Observe · Verdict · Embed), or just **PRO** (Plan · Run · Operate) zoomed out; see [`docs/diagrams.md`](docs/diagrams.md).
+These seven are the everyday form of the loop. For standard and high-consequence work the same loop fans out into eleven beats — `Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn` — splitting Question into Question/Discover, Specify into Specify/Plan, Decide into Review/Decide, and Operate into Operate/Learn. Same control points, more beats. Those eleven beats also carry a memory handle — **PROVE** (Plan · Run · Observe · Verdict · Educate), or just **PRO** (Plan · Run · Operate) zoomed out; see [`docs/diagrams.md`](docs/diagrams.md).
 
 ## Two speeds, one loop
 

--- a/docs/02-operating-system/lifecycle.md
+++ b/docs/02-operating-system/lifecycle.md
@@ -10,7 +10,7 @@
 Question -> Discover -> Specify -> Plan -> Execute -> Verify -> Review -> Decide -> Baseline -> Operate -> Learn
 ```
 
-That spine carries a handle: **PROVE** — Plan · Run · Observe · Verdict · Embed — or **PRO** (Plan · Run · Operate) zoomed out. See [`../diagrams.md`](../diagrams.md).
+That spine carries a handle: **PROVE** — Plan · Run · Observe · Verdict · Educate — or **PRO** (Plan · Run · Operate) zoomed out. See [`../diagrams.md`](../diagrams.md).
 
 This is a way of working, not a compliance program. You sort the risk inside `risk.md`. That file holds the chosen mode, the triggers that force you to escalate, what the change must prove, and the conditions that make you hold.
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -79,7 +79,7 @@ flowchart TB
   subgraph LV["V — VERDICT"]
     DEC{"Decide"}
   end
-  subgraph LE["E — EMBED"]
+  subgraph LE["E — EDUCATE"]
     direction LR
     B(["Baseline"]) --> OP(["Operate"]) --> L(["Learn"])
   end
@@ -103,9 +103,9 @@ flowchart TB
 | Execute | **R** — Run | **R** — Run |
 | Verify · Review | **O** — Observe | ↳ inside Run |
 | Decide | **V** — Verdict | ↳ inside Run |
-| Baseline · Operate · Learn | **E** — Embed | **O** — Operate |
+| Baseline · Operate · Learn | **E** — Educate | **O** — Operate |
 
-PROVE and PRO are memory handles for the full eleven-beat path; the [seven control points](../WORKFLOWS.md) are its everyday short form, and the [Core 7](../CORE.md) are always-on habits, not path stages. "PROVE" names the prove-your-claims habit — evidence behind every claim — not formal proof or verification.
+PROVE and PRO are memory handles for the same eleven-beat path; the [seven control points](../WORKFLOWS.md) are the everyday short form of those eleven beats, and the [Core 7](../CORE.md) are always-on habits, not path stages. One letter is reused across the two zoom levels — **O** is *Observe* (Verify · Review) in PROVE but *Operate* (run it in the world) in PRO — so when they differ, read the crosswalk above, not the letter. "PROVE" names the prove-your-claims habit — evidence behind every claim — not formal proof or verification.
 
 ---
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -32,6 +32,7 @@ The same eleven beats, grouped into a handle you can remember. Zoom out to **PRO
 flowchart TB
   classDef plan fill:#DCE6FA,stroke:#3A5BA8,color:#12203F;
   classDef run fill:#E4DEF7,stroke:#5B49A6,color:#1E1640;
+  %% 'emb': green style for the Baseline/Operate/Learn nodes; the class name is kept from before the Embed -> Educate rename (it is shared by both the PRO and PROVE diagrams).
   classDef emb fill:#DCEFDE,stroke:#2E7D45,color:#102810;
   classDef gate fill:#FFD24D,stroke:#B07400,color:#3A2600,stroke-width:2px;
   subgraph LP["P — PLAN"]
@@ -63,6 +64,7 @@ flowchart TB
   classDef plan fill:#DCE6FA,stroke:#3A5BA8,color:#12203F;
   classDef run fill:#E4DEF7,stroke:#5B49A6,color:#1E1640;
   classDef obs fill:#D2EBE6,stroke:#248A7E,color:#0E2A26;
+  %% 'emb': green style for the Baseline/Operate/Learn nodes; the class name is kept from before the Embed -> Educate rename (it is shared by both the PRO and PROVE diagrams).
   classDef emb fill:#DCEFDE,stroke:#2E7D45,color:#102810;
   classDef gate fill:#FFD24D,stroke:#B07400,color:#3A2600,stroke-width:2px;
   subgraph LP["P — PLAN"]

--- a/tests/test_public_docs.py
+++ b/tests/test_public_docs.py
@@ -186,3 +186,31 @@ def test_skill_workflow_comparison_scores_both_paths_for_each_trial():
         ]
         assert simple_rows, f"missing simple-prompt score row for {trial_id}"
         assert nuclear_rows, f"missing Nuclear-grade score row for {trial_id}"
+
+
+def test_prove_handle_uses_educate_and_stays_consistent():
+    """PROVE/PRO are memory handles mirrored across several docs. The fifth beat
+    is 'Educate' (renamed from 'Embed'); guard the mirror so the rename can't
+    drift and a stale 'Embed' beat cannot survive. See
+    .nuclear/changes/prove-educate-rename/."""
+    prove = "Plan · Run · Observe · Verdict · Educate"
+    pro = "Plan · Run · Operate"
+    spellout_docs = (
+        "README.md",
+        "WORKFLOWS.md",
+        "docs/02-operating-system/lifecycle.md",
+    )
+    for rel in spellout_docs:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert prove in text, f"{rel} missing PROVE spellout '{prove}'"
+        assert pro in text, f"{rel} missing PRO spellout '{pro}'"
+
+    diagrams = (ROOT / "docs" / "diagrams.md").read_text(encoding="utf-8")
+    assert "**E** — Educate" in diagrams, "diagrams.md crosswalk must name 'E — Educate'"
+    assert 'subgraph LE["E — EDUCATE"]' in diagrams, "diagrams.md PROVE diagram must label 'E — EDUCATE'"
+
+    stale = ("Verdict · Embed", "**E** — Embed", "E — EMBED")
+    for rel in (*spellout_docs, "docs/diagrams.md"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for token in stale:
+            assert token not in text, f"{rel} still contains stale PROVE beat '{token}'"


### PR DESCRIPTION
## What & why

Renames the fifth **PROVE** beat from **Embed** to **Educate**, so the handle reads **Plan · Run · Observe · Verdict · Educate**. "Educate" names the same *Baseline · Operate · Learn* beats by what they are *for* — turning real operation into the lesson the next loop is taught — and drops the borrowed machine-learning "embedding" vocabulary that read as jargon here.

This is the first, deliberately small and independent increment of a larger approved plan (a PROVE subagent pipeline + plugin packaging). It lands on its own because the rename is pure, reversible documentation.

## What's in this PR

- **Rename the five live spellouts in lockstep:** `README.md`, `WORKFLOWS.md`, `docs/02-operating-system/lifecycle.md`, and `docs/diagrams.md` (the PROVE-diagram subgraph title **and** the zoom-crosswalk row).
- **One-line diagram clarity gloss** in `docs/diagrams.md`: the seven control points are the everyday short form of the eleven beats, and the letter **O** is reused — *Observe* in PROVE, *Operate* in PRO — so read the crosswalk when they differ.
- **A new `test_public_docs` invariant** guarding the PROVE/PRO handle across every doc that mirrors it, so the acronym can't silently drift and a stale "Embed" can't survive.
- **A Quick change packet** (`.nuclear/changes/prove-educate-rename/`) recording the decision — and **superseding the `Embed` label from the historical `prove-overlay` packet without rewriting that record** (per the repo's own CM doctrine).

The canonical eleven-beat path strings the public-doc tests assert are left byte-for-byte unchanged.

## Verification

- `python -m pytest -q` → **118 passed** (117 + the new invariant)
- `python -m ruff check .` → clean
- `python tools/ng.py doctor .` → OK
- `python tools/ng.py tokens .` → OK (token budget)
- `python tools/ng.py validate` over all 19 packets → OK

Branch is fast-forwarded onto `main` at #28.

https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck)_