### PR TITLE
Make using-nuclear-grade a directive dispatcher (advisory, no hooks)

### DIFF
--- a/.nuclear/changes/directive-dispatcher-skill/basis.md
+++ b/.nuclear/changes/directive-dispatcher-skill/basis.md
@@ -1,0 +1,96 @@
+# Standard Basis
+
+**Purpose:** State what must stay true for the directive router to be safe, honest, and reviewable.
+
+---
+
+## Change context
+
+- Slug: directive-dispatcher-skill
+- Related risk record: `risk.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Decision this basis supports: ship a directive, advisory `using-nuclear-grade` router.
+
+## Mission / need
+
+Skill auto-invocation is unreliable, and classification is the step most prone to motivated error under pressure. The router should force a spoken risk classification before acting and MUST-promote the cheap "it's only small" traps — as advisory guidance, ahead of (and to be tuned by) the A3 measurement.
+
+## Protected outcomes
+
+| Protected outcome | Why it matters | Evidence needed |
+|---|---|---|
+| The router instructs a mandatory classification before acting | The classification is the load-bearing control | Directive content present; guard test passes |
+| The MUST-promote trip-wire names the high-consequence traps | Stops "it's small" downgrades on auth/deps/etc. | Guard test asserts the traps |
+| The skill stays within contract + token budget | A broken skill fails CI / loads badly | `test_skill_contracts` + `test_tokens` pass |
+| No enforcement/assurance overclaim | It is advisory (rung 1), not a hard gate | Wording review; no "enforce" claim about itself |
+
+## Unacceptable outcomes
+
+| Unacceptable outcome | Consequence | Prevent / detect / mitigate |
+|---|---|---|
+| The classification step is silently removed later | The dispatcher reverts to a coin-flip | Guard test (`test_using_nuclear_grade_forces_classification_and_trip_wire`) |
+| The skill exceeds its token/contract budget | CI fails; the always-on cost balloons | `test_tokens` + `test_skill_contracts` |
+| The skill claims it "enforces" or that the lift is proven | Overclaim the repo condemns | Advisory wording; this packet defers the lift to A3 |
+
+## Assumptions, constraints, and invalidation triggers
+
+| Assumption / constraint | Fact / assumption / unknown | Basis or source | Invalidation trigger | Owner |
+|---|---|---|---|---|
+| Imperative "MUST" voice raises adherence | assumption | Anthropic skill guidance; plan Lens 5 R3 | A3 shows no lift over a gentler version | FlyFission |
+| The directive lift in classification rate is measurable | unknown | Needs a model-in-the-loop A3 run | A3 result | FlyFission |
+| The skill auto-loads via its description | fact | Claude Code skill mechanics | Skill loading mechanics change | FlyFission |
+
+## Grounding status
+
+| Statement | Fact / assumption / unknown / source claim / local proof / decision authority | Evidence or source | Decision impact |
+|---|---|---|---|
+| The router now instructs a mandatory classification + trip-wire | local proof | the SKILL.md text + guard test | Supports ship |
+| The wording measurably lifts classification behavior | unknown (deferred) | A3 measurement | Ship with residual risk; do not claim the lift |
+
+## Interfaces and trust boundaries
+
+- Internal interfaces affected: none (one skill's prose).
+- External services/APIs affected: none.
+- Data classes affected: none.
+- Human approval boundaries: maintainer reviews the always-on wording.
+- AI/model/tool authority boundaries: unchanged — advisory guidance, no hooks, no new authority.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Basis | Design feature or control | Evidence planned |
+|---|---|---|---|---|
+| REQ-001 | THE router SHALL instruct the agent to state the mode + the one fact before acting (classify first, as a declaration of intent) | classification is the control | "Classify first — out loud" step | guard test + read |
+| REQ-002 | WHEN a change touches a high-consequence trap THE router SHALL instruct a MUST-promote to Standard-plus | stop motivated downgrades | imperative trip-wire list | guard test |
+| REQ-003 | THE directive behavior SHALL be guarded against silent regression | mirrors the mirror-drift discipline | new contract test | the test runs in CI |
+| REQ-004 | THE edit SHALL stay within the skill contract and token budget | a broken skill fails / bloats | required sections; <=200 desc / <=3000 body | `test_skill_contracts` + `test_tokens` |
+
+## Design outline
+
+| Section | Covered? | Where it lives |
+|---|---|---|
+| Overview — what changes and why | yes | this basis + `risk.md` |
+| Architecture — shape and major parts | yes | one skill's Process / Overview / rationalizations |
+| Components and interfaces — boundaries above | yes | `Interfaces and trust boundaries` |
+| Data models — shapes, classes, ownership | n/a | no data models |
+| Error handling — failure paths and responses | yes | `Unacceptable outcomes` |
+| Testing strategy — how each claim is checked | yes | `verification.md` |
+
+## Required links
+
+- Risk record: `risk.md`
+- Verification record: `verification.md`
+- Ship record: `ship.md`
+- Product requirement / issue / ADR / design doc: the approved dispatcher design (revised core).
+- Source lineage, if cited: not cited.
+
+## Exit criteria
+
+- The builder and reviewer can answer "what must stay true?"
+- The protected outcomes and the outcomes to prevent are stated plainly.
+- Important assumptions each have a trigger that would prove them wrong.
+- The evidence needs flow into `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on human performance improvement and graded rigor, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/directive-dispatcher-skill/plan.md
+++ b/.nuclear/changes/directive-dispatcher-skill/plan.md
@@ -1,0 +1,122 @@
+# Standard Plan
+
+**Purpose:** Bound the dispatcher-skill edit, its review, and its rollback.
+
+---
+
+## Change context
+
+- Slug: directive-dispatcher-skill
+- Related risk record: `risk.md`
+- Related basis record: `basis.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Current lifecycle phase: Decide
+
+## Charter and anchor check
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes
+- Re-checked before Verify? yes
+- Charter articles in play: operational unambiguity (the classification is explicit); no-overclaim (advisory, not "enforce").
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | n/a | n/a | n/a |
+
+## Build sequence
+
+| # | Task | Requirements covered | Prereqs / blocked-by | Proof for this step | Stop / done condition |
+|---|---|---|---|---|---|
+| 1 | Read the skill contract + token budget | REQ-004 | none | `test_skill_contracts.py` + `tokens.py` reviewed | rules known |
+| 2 | Rewrite Overview + Process (classify-first + MUST trip-wire) in imperative voice | REQ-001, REQ-002 | step 1 | reads as directive; contract intact | sections updated |
+| 3 | Strengthen Common Rationalizations + Red Flags with the classification traps | REQ-001 | step 2 | present in the skill | sections updated |
+| 4 | Add the guard test | REQ-003 | steps 2-3 | `pytest` green | test passes |
+
+## Two-speed work plan
+
+| Work phase | Allowed actions | Acceptance gate |
+|---|---|---|
+| explore | review contract / budget | rules known |
+| candidate | edit the skill + add the test | reads directive |
+| audit | full suite + ruff + doctor + tokens + validate | all green |
+| accept | open PR; maintainer reviews wording + plans the A3 run | human review |
+
+## HPI task preview
+
+| Critical step | Likely error | Consequence | Control / contingency | Evidence |
+|---|---|---|---|---|
+| Editing an always-on skill | Over-budget body or broken contract → CI fails / bad load | Router degrades | `test_skill_contracts` + `test_tokens`; revert on failure | `verification.md` |
+| Directive wording | Sounds like enforcement | Overclaim | Keep advisory voice; defer the lift to A3 | `verification.md` |
+
+## Agent briefing
+
+- Role: builder (drafting under review).
+- Authority source: the approved plan; this packet.
+- Active procedure/template: Standard packet.
+- Last completed action if resumed: skill edited + guard test added + verified locally.
+- Handoff or turnover needed? no
+- Pause when unsure condition: pause if a step would add hooks, claim enforcement, or exceed budget.
+
+## Affected files and assets
+
+| File / asset | Change expected | Requirements covered | Why it matters | Owner |
+|---|---|---|---|---|
+| `skills/using-nuclear-grade/SKILL.md` | edit | REQ-001, REQ-002, REQ-004 | the always-on router | FlyFission |
+| `tests/test_skill_contracts.py` | edit | REQ-003 | guards the directive behavior | FlyFission |
+
+## Non-goals
+
+- No executable hooks, SessionStart, or PreToolUse behavior (a later, gated tier).
+- No edits to other skills, and no change to the eval prompts (the A3 corpus is its own work).
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Requirements approved | REQ-001..004 each a clear trigger→response, reviewed | pass |
+| Design approved | Five targeted edits + a guard test | pass |
+| Tasks approved | Build steps carry requirement IDs | pass |
+| Specification reviewed | Protected and unacceptable outcomes stated | pass |
+| Tests/evals defined | Each claim maps to evidence | pass |
+| Build complete | The skill + test match the plan | pass |
+| Verification complete | Evidence linked in `verification.md` | pass |
+| Release decision ready | Leftover risk + rollback recorded | pass |
+| Turnover complete if activated | Not activated | not applicable |
+
+## Rollback approach
+
+- Rollback method: revert `skills/using-nuclear-grade/SKILL.md` and the test edit (single revert).
+- State/data reversal notes: none.
+- Feature flag / kill switch: revert restores the prior advisory router.
+- Owner: FlyFission
+- Time to restore estimate: minutes.
+
+## Proof commands
+
+```bash
+python -m pytest -q
+python -m ruff check .
+python tools/ng.py doctor .
+python tools/ng.py tokens .
+python tools/ng.py validate .nuclear/changes/directive-dispatcher-skill
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Issue / PR / ADR / design doc: the approved dispatcher design.
+
+## Exit criteria
+
+- The work is bounded enough to keep scope from creeping.
+- The review checkpoints are named.
+- Rollback and restore are thought through before release.
+- The proof commands are ready for `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on human performance improvement and software lifecycle, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/directive-dispatcher-skill/risk.md
+++ b/.nuclear/changes/directive-dispatcher-skill/risk.md
@@ -1,0 +1,104 @@
+# Standard Risk
+
+**Purpose:** Sort the dispatcher-skill change by risk, justify Standard mode, and name the records turned on.
+
+---
+
+## Change identity
+
+- Slug: directive-dispatcher-skill
+- PR / issue: Make `using-nuclear-grade` a directive dispatcher (advisory, no hooks)
+- Owner: FlyFission
+- Date: 2026-06-08
+- Current lifecycle phase: Decide
+- Current work phase: accept
+- Summary: Rewrite the `using-nuclear-grade` router skill to be directive: a mandatory "classify first, out loud" step (a declaration of intent, not a request for permission), an imperative MUST-promote trip-wire on the high-consequence "it's only small" traps (auth, data/migration, dependencies, model ids, `.github/`, public wording), and the classification rationalizations — all in imperative voice. It stays an advisory **skill** — no executable hooks, no SessionStart/PreToolUse. Adds a guard test so the directive behavior cannot silently regress.
+
+## Mission anchor
+
+- Objective: make the always-first router force a spoken risk classification before acting, and MUST-promote the cheap traps, without shipping executable code or overclaiming.
+- Success criteria: the directive content is present and guarded by a test; the skill stays within its contract and token budget; the full suite is green.
+- Non-goals / forbidden directions: no executable hooks; no SessionStart/PreToolUse; no edits to other skills; no enforcement claim; no claim that the wording *measurably* lifts behavior (that is the deferred A3 measurement).
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: the approved plan (revised dispatcher = forced spoken classification as intent declaration; Lens 1 + Lens 5 convergence; R3 imperative voice).
+
+## Questioning-attitude summary
+
+- Decision question: can the router be made directive (force the classification) safely and advisorily, before the A3 measurement?
+- Evidence that would change the decision: A3 showing a directive preamble does not lift classification rate (then revisit directiveness or go to hooks), or the edit breaking the skill contract / token budget.
+- Assumptions that changed the mode: imperative "MUST" voice raises adherence (Anthropic guidance, plan Lens 5 R3), but the *magnitude* is unmeasured here.
+- Facts still needing validation: the behavioral lift itself — the A3 classification-rate measurement (needs a model-in-the-loop run; cannot run in this container).
+- Stop or hold conditions: stop if the edit would add executable hooks, claim enforcement, or exceed the skill body / description budget.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `skills/using-nuclear-grade/SKILL.md` | Always-on router skill (prompt) | Guides every session's classification | `skills/using-nuclear-grade/SKILL.md` |
+| `tests/test_skill_contracts.py` | Test | Guards the directive behavior + the contract | `tests/test_skill_contracts.py` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Edits an always-on router that ripples to every adopter/session; but advisory and reversible. |
+| Reversibility | high | Revert the SKILL.md and test edits; no state, no code. |
+| Detectability | high | Guard test + skill-contract test + token budget + `pytest` cover it. |
+| Exposure | medium | Public, agent-facing skill prose. |
+| Uncertainty | medium | The behavioral lift is unmeasured (the A3 go/no-go). |
+| Dependency trust | low | No new dependency. |
+| AI authority | low | Advisory guidance only; grants no new agent authority; no hooks. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine, repeated action where it is easy to stop paying attention | no | self-check / proof |
+| Known procedure where following the steps matters | yes | packet path / deviation note |
+| New or uncertain work where the assumptions may be wrong | yes | questioning attitude / research / review |
+| Work that was interrupted, resumed, or handed off | no | turnover / context pack |
+| A high-stakes critical action | no | self-check / peer-check / independent verification |
+
+## Selected mode
+
+- Mode: Standard
+- Why this mode: it changes the guidance an always-on router gives every session (an AI-behavior / prompt change) and ripples to every adopter.
+- Why lighter mode is not enough: Quick fits local reversible docs; this reshapes how the router classifies every change, which warrants a basis, a plan, a trace, and a release decision.
+- Why heavier mode is not yet required: advisory prose edit to one skill, reversible, no executable code/permission/data; matches the `incorporate-planning-lessons` precedent (Core-skill edits → Standard).
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline in this risk record. | FlyFission |
+| `basis.md` | yes | What must stay true about the directive router. | FlyFission |
+| `verification.md` | yes | Evidence for the directive content + the contract. | FlyFission |
+| `ship.md` | yes | Release decision; carries the deferred A3 residual. | FlyFission |
+| `turnover.md` | no | Same agent continues; no handoff. | FlyFission |
+| `self-check.md` | no | No irreversible critical action. | FlyFission |
+| `supplier-trust.md` | no | No external dependency/model/API trust decision. | FlyFission |
+| Nuclear subset record | no | Stakes below Nuclear. | FlyFission |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: the skill contract + token budget rules (so the edit stays valid).
+- Minimum evidence before merge/release: directive content present + guarded; `pytest`/`ruff`/`doctor`/`tokens`/`validate` green.
+- Independent review needed? yes; why: a maintainer should review the always-on wording, and run the A3 measurement to confirm the lift before going more forceful (hooks).
+
+## Required links
+
+- Packet: `.nuclear/changes/directive-dispatcher-skill/`
+- `basis.md`
+- `verification.md`
+- `ship.md`
+- Source-map/crosswalk references if source lineage is invoked: not invoked.
+
+## Exit criteria
+
+- The mode is justified.
+- The artifacts turned on are named.
+- Important risks, assumptions, and evidence due are recorded here, not hidden in chat or commit messages.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on human performance improvement, graded rigor, and configuration management, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/directive-dispatcher-skill/ship.md
+++ b/.nuclear/changes/directive-dispatcher-skill/ship.md
@@ -1,0 +1,103 @@
+# Standard Ship
+
+**Purpose:** State the release decision for the directive router skill.
+
+---
+
+## Release identity
+
+- Change slug: directive-dispatcher-skill
+- Version / release / baseline: `using-nuclear-grade` directive router (advisory)
+- PR / commit / artifact: this branch's PR
+- Owner: FlyFission
+- Date: 2026-06-08
+- Intended release window: with this PR merge
+
+## Scope and exclusions
+
+- Included: the directive rewrite of `skills/using-nuclear-grade/SKILL.md` + a guard test in `tests/test_skill_contracts.py`.
+- Excluded: executable hooks, SessionStart/PreToolUse, edits to other skills, eval-prompt/corpus changes.
+- Known non-goals: any enforcement behavior, and any claim that the wording provenly lifts behavior.
+
+## Evidence status summary
+
+| Evidence area | Status | Link | Notes |
+|---|---|---|---|
+| Risk classification | pass | `risk.md` | Standard justified |
+| Basis / requirements / claims | pass | `basis.md` | REQ-001..004 |
+| Questioning attitude | pass | `risk.md` | captured inline |
+| Verification | pass (lift deferred) | `verification.md` | A3 measures the lift |
+| Dependency / supply-chain evidence | not applicable | this packet | no dependency; no executable code |
+| AI-assisted work checks | pass | `verification.md` | design traces to the plan |
+| Review / approval | planned | the PR | maintainer review pending |
+
+## Residual risks and gaps
+
+| Risk / gap | Impact | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| Behavioral lift unmeasured | The directive wording may not measurably raise classification rate | defer | FlyFission | The A3 classification-rate measurement |
+| Over-triggering | A broader, directive router may fire on near-trivial work | accept | FlyFission | If adopters report noise, tighten the negative clause / split a lighter tier |
+
+## Rollback / restore plan
+
+- Rollback method: revert the SKILL.md + test edits (single revert).
+- Data migration reversal or restore notes: none.
+- Feature flag / kill switch: revert restores the prior advisory router.
+- Owner on call: FlyFission
+- Time to restore estimate: minutes.
+
+## Monitoring and post-release checks
+
+| Signal | Threshold / expected behavior | Owner | Where to inspect | Action if bad |
+|---|---|---|---|---|
+| A3 measurement result | A measurable classification lift at acceptable overhead | FlyFission | the A3 eval run | If no lift, revisit directiveness or move to the hooks tier |
+| Over-triggering reports | The router does not nag on throwaway work | FlyFission | GitHub issues | Tighten the negative clause |
+
+## Handoff
+
+- Operator/customer/support notes: the router now asks for a spoken mode call first; it is advisory.
+- Docs/runbook updated: the skill itself; no separate doc.
+- Communication needed: note the directive router in release notes when cut.
+- Turnover record if activated: not activated.
+- Follow-up date: when the A3 measurement is run.
+
+## Release decision
+
+- Decision: ship with residual risk
+- Decision maker: FlyFission
+- Rationale: the directive content is present, guarded, and within the contract/budget; the only unproven part (the behavioral lift) is the A3 measurement, which is a tuning input, not a blocker for shipping advisory guidance.
+- Decision question answered by evidence? yes for "the router instructs the classification"; the lift is the named deferred residual.
+- Conditions attached: maintainer runs the A3 measurement before going more forceful (hooks).
+- Decision posture: conservative enough.
+- Abort or rollback trigger: over-triggering complaints, or A3 showing the directive version is worse → revert.
+- OPEX or post-release learning trigger: the A3 result updates whether to add hooks.
+
+## Baseline trigger
+
+- Baseline required? yes
+- Baseline record: `using-nuclear-grade` becomes the controlled directive router.
+- Revalidation trigger: the A3 result, or a change to skill-loading mechanics.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `verification.md`
+- PR/commit/release artifact: this branch's PR.
+- Monitoring/dashboard/log query: the A3 measurement; GitHub issues.
+- Rollback/runbook: revert the SKILL.md + test edits.
+
+## Exit criteria
+
+- The release decision is stated plainly.
+- The slow audit step is done before any baseline or public claim is accepted.
+- The baseline trigger is named when the controlled state changes.
+- The evidence status and the gaps are visible.
+- The leftover uncertainty is bounded and owned, or it blocks or defers the decision.
+- A rollback/restore path exists, or its absence is accepted on purpose.
+- Monitoring and handoff cover the claims most likely to fail in operation.
+- Any accepted leftover risk has an owner and a recheck trigger.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on release readiness, human performance improvement, and learning from real operation, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/directive-dispatcher-skill/trace.md
+++ b/.nuclear/changes/directive-dispatcher-skill/trace.md
@@ -1,0 +1,60 @@
+# Standard Trace
+
+**Purpose:** Tie each claim to its basis, control, evidence, and ship stance.
+
+---
+
+## Change context
+
+- Slug: directive-dispatcher-skill
+- Related basis record: `basis.md`
+- Related verification record: `verification.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+
+## Trace summary
+
+| ID | Claim | Basis link | Task / code ref | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|---|
+| REQ-001 | Router instructs classify-first (declaration of intent) before acting | `basis.md` | `plan.md` step 2 / `skills/using-nuclear-grade/SKILL.md` | "Classify first — out loud" step | local proof | `verification.md` | ship | pass |
+| REQ-002 | MUST-promote trip-wire on the high-consequence traps | `basis.md` | `plan.md` step 2 / SKILL.md Process | imperative trap list | local proof | `verification.md` | ship | pass |
+| REQ-003 | Directive behavior guarded against regression | `basis.md` | `plan.md` step 4 / `tests/test_skill_contracts.py` | guard test | local proof | `verification.md` | ship | pass |
+| REQ-004 | Edit stays within skill contract + token budget | `basis.md` | `plan.md` step 1 / SKILL.md | required sections; budgets | local proof | `verification.md` | ship | pass |
+| (efficacy) | The wording measurably lifts classification rate | `basis.md` | A3 measurement | n/a (advisory) | unknown | deferred | ship with residual risk | deferred |
+
+## Evidence chain
+
+```text
+Need: force the risk classification the router currently leaves to chance
+  -> Basis: REQ-001..004 (classify-first, trip-wire, guarded, within budget)
+  -> Control: directive SKILL.md + guard test
+  -> Verification: guard test, skill-contract test, token budget, pytest, ruff, doctor, validate
+  -> Release: ship with residual risk (the behavioral-lift proof is the deferred A3 measurement)
+```
+
+## Open trace gaps
+
+| Gap | Why it matters | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| Behavioral lift not measured | We assert the router *instructs* the classification, not that it *lifts* the rate | defer | FlyFission | The A3 classification-rate measurement (model-in-the-loop run) |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+- Implementation / docs / tests / evals: `skills/using-nuclear-grade/SKILL.md`, `tests/test_skill_contracts.py`
+
+## Exit criteria
+
+- Each important claim has a status label.
+- Each important claim names its support type.
+- Every shipped claim has evidence or an accepted leftover risk.
+- Deferred or gap claims are not used as release evidence.
+- A reviewer can move quickly from claim to basis to evidence to release decision.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on requirements tracing and human performance improvement, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/directive-dispatcher-skill/verification.md
+++ b/.nuclear/changes/directive-dispatcher-skill/verification.md
@@ -1,0 +1,74 @@
+# Standard Verification
+
+**Purpose:** Show the directive-router claims have evidence that fits the change.
+
+---
+
+## Verification context
+
+- Slug: directive-dispatcher-skill
+- Related basis: `basis.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Verification scope: the directive content is present and guarded; the skill stays within its contract + token budget. Excludes the behavioral-lift measurement (the A3 go/no-go, which needs a model-in-the-loop run).
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
+
+## Claim-to-evidence table
+
+| Claim / requirement ID | Support type | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|---|
+| REQ-001 | local proof | deterministic test + peer review | guard test asserts the classify-first step; manual read | "Classify first" + "declaration of intent" present | pass | `tests/test_skill_contracts.py` | none |
+| REQ-002 | local proof | deterministic test | guard test asserts the MUST-promote trap list | >= 5 traps named; "MUST" + "Standard-plus" | pass | `tests/test_skill_contracts.py` | none |
+| REQ-003 | local proof | deterministic test | the guard test exists and runs in the suite | guard test present and passing | pass | `tests/test_skill_contracts.py` | none |
+| REQ-004 | local proof | deterministic test | skill-contract + token-budget tests | required sections; <=200 desc / <=3000 body | pass | `tests/test_skill_contracts.py`; `tests/test_tokens.py` | none |
+| efficacy (behavioral lift) | unknown | independent measurement | A3 classification-rate eval, preamble ON vs OFF | a measurable lift at acceptable overhead | deferred | A3 (maintainer model-run) | tracked in `ship.md` |
+
+## Commands, evals, and reviews
+
+| Method | Command / review / eval | Environment | Result | Evidence link |
+|---|---|---|---|---|
+| Full suite | `python -m pytest -q` | Python 3 | all pass (incl. the new guard test) | CI |
+| Lint | `python -m ruff check .` | ruff 0.15.16 | clean | CI |
+| Doctor | `python tools/ng.py doctor .` | repo | OK | CI |
+| Token budget | `python tools/ng.py tokens .` | repo | OK (skill body within budget) | CI |
+| Packet validate | `python tools/ng.py validate .nuclear/changes/directive-dispatcher-skill` | repo | OK | CI |
+
+## Negative / failure-mode checks
+
+| Failure mode | Check performed | Result | Evidence link |
+|---|---|---|---|
+| Classification step silently removed | guard test asserts it is present | pass (fails if removed) | `tests/test_skill_contracts.py` |
+| Skill body over budget | token-budget test | pass | `tests/test_tokens.py` |
+
+## AI-assisted work checks
+
+- AI scope: edited one skill's prose + added a guard test + drafted this packet under review.
+- Model/tool used: Claude Code agent.
+- Permissions/actions allowed: edit files; run tests; no executable hooks shipped.
+- Independent checks performed: full suite + lint + doctor + tokens + validate.
+- Self-check / turnover records: not activated.
+- Hallucination/slop screening: the directive design traces to the approved plan, not invented.
+- Human approval gates exercised: PR review + maintainer A3 run pending.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `ship.md`
+- CI run / eval report / test logs / review notes: GitHub Actions on the PR.
+- Implementation diff / PR: this branch's PR.
+
+## Exit criteria
+
+- Each important claim has a status.
+- Each important claim keeps the support type apart from the verification type.
+- Evidence is linked, not pasted in full.
+- Gaps are stated plainly and carried into `ship.md`.
+- The reviewer can tell whether the evidence backs the release decision.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on software verification and validation and AI risk, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: using-nuclear-grade
-description: Turns an AI-assisted change into a clear evidence path. Picks a mode, sets up the change record, and plans the proof, then points to the charter and the goal anchor. Use when you start using this workflow on a change, a repo, or a release call. Do not use for a throwaway experiment with nothing worth reviewing.
+description: The always-first router for AI-assisted work — before acting, state the mode (Quick or Standard-plus) and the one fact that sets it, then set up the matching change record and plan the proof. Use at the start of any change, repo adoption, or release call. Do not use for a throwaway experiment with nothing worth reviewing.
 ---
 
 # Using Nuclear-grade
 
 ## Overview
 
-Use Nuclear-grade to turn AI-assisted work into a clear evidence path. Start by asking the real question the change has to answer. Then judge how high the stakes are. Build the smallest change record that does the job. Write down what the change must do. Prove the claims that matter. Then say the release decision out loud.
+This is the always-first router for Nuclear-grade work. Before you act, classify the change by consequence and route to the matching rigor — move fast while ideas are throwaway, slow down the moment the work becomes a promise. Start by asking the real question the change must answer, then state the mode it earns and the one fact that sets it. Build the smallest change record that does the job, prove the claims that matter, and say the release decision out loud.
 
-The repo charter (`.nuclear/charter.md`) holds the lasting rules every change follows. Each change also gets a goal anchor. The anchor states what that one change is for, so the work does not drift off course.
+The repo charter (`.nuclear/charter.md`) holds the lasting rules every change follows. Each change also gets a goal anchor — what that one change is for — so the work does not drift off course.
 
 ## When to Use
 
@@ -33,16 +33,29 @@ The repo charter (`.nuclear/charter.md`) holds the lasting rules every change fo
 
 ## Process
 
-1. Start with a questioning attitude. Name the decision question, the assumptions, the fact that would change the decision, the gaps in evidence, and when to stop.
-2. Sort the change into Quick, Standard, or a stronger mode that a human reviews.
-   - If you are adopting Nuclear-grade for the first time, pick the Core 7 habits from `CORE.md` and invoke ancillary clusters by trigger rather than enabling everything at once.
-3. Create or find the change record under `.nuclear/changes/<slug>/`.
-4. Write down the least you need: what the change must do, what it must prove, the files it touches, and the claims it must not make.
-5. If the chosen workflow or template stops fitting the real situation, write down where you went off it and why.
-6. Keep the build work tied to the claims and the evidence.
-7. Move fast while ideas are easy to undo. Slow down before you accept a claim, write public wording, save an approved version, ship a release, or change what an agent may do.
-8. Run the checker on Quick or Standard records.
-9. Stop before release if the evidence status, the rollback plan, the monitoring, the decision, the trigger for saving a version, or the legal wording is unclear.
+**Classify first — out loud.** Before the first tool call, state the mode this change earns — **Quick**, or **Standard-plus** (Standard, or a stronger human-reviewed mode) — and the **one fact** that sets it. This is a declaration of intent, not a request for permission: you name the mode and act. Re-state it whenever the change grows.
+
+You MUST treat the change as **Standard-plus**, never Quick, when it touches any of these — the cheap "it's only small" traps:
+
+- authentication, permissions, or secrets;
+- behavior a user can see;
+- data handling, schema, or a migration;
+- a dependency or a dependency manifest;
+- a model id, a prompt, or what a tool or agent may do;
+- CI or `.github/`;
+- a release, a saved baseline, or public wording.
+
+When one is present, justify the mode in the record or escalate — do not let "it is a one-line change" downgrade it.
+
+Then:
+
+1. **Question first.** Name the decision question, the assumptions, the one fact that would change the decision, the evidence gaps, and the stop conditions.
+2. **Build the smallest record that fits the mode** under `.nuclear/changes/<slug>/`. Adopting for the first time? Take the Core 7 habits from `CORE.md` and switch on ancillary clusters by trigger, not all at once.
+3. **Write the least you need:** what the change must do, what it must prove, the files it touches, and the claims it must not make.
+4. **Keep build work tied to the claims and their evidence.** If the chosen path stops fitting, write down where you left it and why.
+5. **Slow down at the promise boundary** — before you accept a claim, write public wording, save an approved version, ship a release, or change what an agent may do.
+6. **Run the checker** on Quick or Standard records (`python tools/ng.py validate .nuclear/changes/<slug>`).
+7. **Stop before release** if the evidence status, the rollback, the monitoring, the decision, the baseline trigger, or the legal wording is unclear.
 
 ## Outputs
 
@@ -66,6 +79,8 @@ The repo charter (`.nuclear/charter.md`) holds the lasting rules every change fo
 
 ## Common Rationalizations
 
+- "It's a small change, so it's Quick." Size is not stakes. A one-line edit to auth, a dependency, a model id, a migration, or public wording is Standard-plus.
+- "I'll classify it later." The mode call is the cheapest control and the one most prone to motivated error under pressure. State it before the first tool call, not after the diff exists.
 - "The tests pass, so we don't need a record." Passing tests do not save the assumptions, the scope, the leftover risk, or the release decision.
 - "The agent remembers the context." Chat history is not a lasting review record.
 - "This is only documentation." Public docs can create claims about law, trust, and assurance.
@@ -73,6 +88,7 @@ The repo charter (`.nuclear/charter.md`) holds the lasting rules every change fo
 
 ## Red Flags
 
+- Work began before a mode was declared. The classification is the entry gate; skip it and everything after is on the honor system.
 - The record cannot name a single claim that matters.
 - The evidence is loose prose instead of commands, links, reviews, or named gaps.
 - The work says or hints at compliance, approval, safety, security, or formal verification and validation. None of those are provided here.

--- a/skills/using-nuclear-grade/SKILL.md
+++ b/skills/using-nuclear-grade/SKILL.md
@@ -54,7 +54,7 @@ Then:
 3. **Write the least you need:** what the change must do, what it must prove, the files it touches, and the claims it must not make.
 4. **Keep build work tied to the claims and their evidence.** If the chosen path stops fitting, write down where you left it and why.
 5. **Slow down at the promise boundary** — before you accept a claim, write public wording, save an approved version, ship a release, or change what an agent may do.
-6. **Run the checker** on Quick or Standard records (`python tools/ng.py validate .nuclear/changes/<slug>`).
+6. **Run the checker** on Quick or Standard-plus records (`python tools/ng.py validate .nuclear/changes/<slug>`).
 7. **Stop before release** if the evidence status, the rollback, the monitoring, the decision, the baseline trigger, or the legal wording is unclear.
 
 ## Outputs

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -125,3 +125,19 @@ def test_skill_evaluation_prompts_cover_every_skill():
         block = evaluation.split(heading, 1)[1].split("\n### `", 1)[0]
         assert block.count("Should trigger:") >= 3
         assert block.count("Should not trigger:") >= 2
+
+
+def test_using_nuclear_grade_forces_classification_and_trip_wire():
+    """The router must force a spoken risk classification (a declaration of intent)
+    and MUST-promote the cheap 'it's only small' traps; guard that directive
+    behavior against silent regression. See
+    .nuclear/changes/directive-dispatcher-skill/."""
+    text = (SKILLS_DIR / "using-nuclear-grade" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "Classify first" in text, "router must lead with a mandatory classification"
+    assert "declaration of intent" in text, "classification is a declaration, not a permission request"
+    assert "Standard-plus" in text and "MUST" in text, "router must MUST-promote, not merely suggest"
+
+    traps = ("authentication", "dependency manifest", "model id", ".github/", "public wording", "migration")
+    present = sum(trap in text for trap in traps)
+    assert present >= 5, f"dispatcher trip-wire must name the high-consequence traps (found {present})"

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -132,12 +132,14 @@ def test_using_nuclear_grade_forces_classification_and_trip_wire():
     and MUST-promote the cheap 'it's only small' traps; guard that directive
     behavior against silent regression. See
     .nuclear/changes/directive-dispatcher-skill/."""
-    text = (SKILLS_DIR / "using-nuclear-grade" / "SKILL.md").read_text(encoding="utf-8")
+    # Case-insensitive so a capitalization tweak does not fail the contract,
+    # while the classify-first move and the trip-wire must stay present.
+    text = (SKILLS_DIR / "using-nuclear-grade" / "SKILL.md").read_text(encoding="utf-8").lower()
 
-    assert "Classify first" in text, "router must lead with a mandatory classification"
+    assert "classify first" in text, "router must lead with a mandatory classification"
     assert "declaration of intent" in text, "classification is a declaration, not a permission request"
-    assert "Standard-plus" in text and "MUST" in text, "router must MUST-promote, not merely suggest"
+    assert "standard-plus" in text and "must" in text, "router must MUST-promote, not merely suggest"
 
     traps = ("authentication", "dependency manifest", "model id", ".github/", "public wording", "migration")
-    present = sum(trap in text for trap in traps)
-    assert present >= 5, f"dispatcher trip-wire must name the high-consequence traps (found {present})"
+    missing = [trap for trap in traps if trap not in text]
+    assert len(traps) - len(missing) >= 5, f"dispatcher trip-wire missing traps: {missing}"


### PR DESCRIPTION
## What & why

Makes the always-first router skill `using-nuclear-grade` **directive**, so it forces the risk classification it currently leaves to chance. This is increment 3 of the approved plan — the dispatcher's core value, shipped as an **advisory skill** (no executable hooks), which sidesteps both the security/hooks tier and the gated A3 measurement.

The mechanism is the convergence the plan's three review lenses reached independently: a **spoken risk-classification as a declaration of intent** (not a permission request), plus a deterministic **trip-wire** on the cheap "it's only small" traps.

## What's in this PR

- **`skills/using-nuclear-grade/SKILL.md`** — rewritten directive:
  - **Classify first, out loud** — state the mode (Quick or Standard-plus) and the one fact that sets it, *before* the first tool call.
  - An imperative **MUST-promote** trip-wire: auth · data/migrations · dependencies · model ids · `.github/` · public wording → never Quick.
  - The classification rationalizations ("it's small", "I'll classify later") and a no-classification red flag.
- **`tests/test_skill_contracts.py`** — a guard test so the directive behavior (classify-first + the trip-wire traps) can't silently regress. Stays within the skill contract + token budget.
- **Standard change packet** (`.nuclear/changes/directive-dispatcher-skill/`).

## Honest scope

It stays **advisory (rung 1)** — the agent is *guided* by the skill, not *blocked* by a hook; the PR claims nothing about enforcement. And it claims the router now **instructs** the classification — **not** that the wording **measurably lifts** classification rate. That lift is exactly the **A3 measurement**, which needs a model-in-the-loop run and is recorded as **deferred to you** (`verification.md`/`ship.md`). The result tells us whether to go more forceful (the hooks tier) later.

## Verification

- `python -m pytest -q` → **118 passed** (incl. the new guard test)
- `python -m ruff check .` → clean
- `python tools/ng.py doctor .` → OK · `tokens .` → OK (router body within budget)
- `python tools/ng.py validate` over all packets → OK

Branch is off `main`; independent of #29 (rename) and #30 (plugin vehicle).

https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck)_