### PR TITLE
Add advisory, opt-in dispatcher hooks (SessionStart + UserPromptSubmit)

### DIFF
--- a/.nuclear/changes/dispatcher-hooks/basis.md
+++ b/.nuclear/changes/dispatcher-hooks/basis.md
@@ -1,0 +1,99 @@
+# Standard Basis
+
+**Purpose:** State what must stay true for the advisory dispatcher hooks to be safe, honest, and reviewable.
+
+---
+
+## Change context
+
+- Slug: dispatcher-hooks
+- Related risk record: `risk.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Decision this basis supports: ship two advisory, opt-in session hooks.
+
+## Mission / need
+
+The directive dispatcher exists as a skill (advisory, auto-loaded). Adopters who want it *always-on* — injected every session and on every prompt — need hooks. Hooks are executable code, so they must add no exfiltration surface, must not auto-activate, and must not overclaim.
+
+## Protected outcomes
+
+| Protected outcome | Why it matters | Evidence needed |
+|---|---|---|
+| The hooks reach no network and run no subprocess | An in-session hook is your own process and could exfiltrate | network-ban test over hook sources |
+| The injected text is static and never the prompt | Prevents instruction-laundering through the hook | no-prompt-echo test |
+| The hooks are opt-in, not auto-activated | Keeps the no-hooks install the default (F2) | no `hooks/hooks.json` shipped; HOOKS.md enable step |
+| No enforcement/assurance overclaim | The hooks are advisory (rung 1) | honesty note in the preamble + HOOKS.md |
+
+## Unacceptable outcomes
+
+| Unacceptable outcome | Consequence | Prevent / detect / mitigate |
+|---|---|---|
+| A hook phones home | Secret/SSH/env exfiltration | network-ban test (`socket`/`urllib`/`requests`/`http`/`subprocess`/...) |
+| A hook echoes the user's prompt | Injected text laundered into context | no-prompt-echo test |
+| Hooks auto-activate on plugin install | No-hooks default broken (F2) | ship no `hooks/hooks.json`; document manual enable |
+| The preamble drifts from CORE.md | The router teaches a stale matrix | CORE.md cluster-sync test |
+| Injection markers in the preamble | The preamble itself becomes an attack | injection-firewall test (F4) |
+
+## Assumptions, constraints, and invalidation triggers
+
+| Assumption / constraint | Fact / assumption / unknown | Basis or source | Invalidation trigger | Owner |
+|---|---|---|---|---|
+| `SessionStart`/`UserPromptSubmit` inject via `hookSpecificOutput.additionalContext` | fact | official Claude Code hooks docs | hook I/O schema change | FlyFission |
+| Plugin `hooks/hooks.json` auto-activates; omitting it keeps hooks opt-in | fact | official docs | plugin hook-discovery change | FlyFission |
+| A live Claude Code session is not exercised here | fact | no Claude Code runtime in CI | n/a | FlyFission |
+
+## Grounding status
+
+| Statement | Fact / assumption / unknown / source claim / local proof / decision authority | Evidence or source | Decision impact |
+|---|---|---|---|
+| The hooks emit valid, static, zero-network output | local proof | hook smoke-run + tests | Supports ship |
+| The hooks inject as intended in a live session | unknown (deferred) | needs a live Claude Code session | Ship with residual risk; maintainer smoke-test |
+
+## Interfaces and trust boundaries
+
+- Internal interfaces affected: none (standalone scripts).
+- External services/APIs affected: none — the hooks make no network calls.
+- Data classes affected: none.
+- Human approval boundaries: maintainer reviews executable code + runs a live session.
+- AI/model/tool authority boundaries: unchanged — advisory injection, no blocking, no new authority.
+
+## Derived requirements or claims
+
+| ID | Requirement / claim | Basis | Design feature or control | Evidence planned |
+|---|---|---|---|---|
+| REQ-001 | THE SessionStart hook SHALL inject a static routing preamble (classify-first + two-speed + clusters + honesty) | always-on dispatcher | `session_start.py` PREAMBLE constant | smoke-run + test |
+| REQ-002 | THE UserPromptSubmit hook SHALL inject a static line and SHALL NOT echo the prompt | no instruction-laundering | static CLASSIFY_LINE; drains stdin unused | no-echo test |
+| REQ-003 | THE hooks SHALL be pure standard library with no network or subprocess use | no exfiltration surface | imports limited to `json`, `sys` | network-ban test |
+| REQ-004 | THE hooks SHALL be opt-in (no auto-activation) | preserve no-hooks default (F2) | ship no `hooks/hooks.json` | absence check + HOOKS.md |
+| REQ-005 | THE preamble SHALL stay in sync with CORE.md and within budget | no stale matrix / no bloat | cluster-sync + length tests | tests |
+
+## Design outline
+
+| Section | Covered? | Where it lives |
+|---|---|---|
+| Overview — what changes and why | yes | this basis + `risk.md` |
+| Architecture — shape and major parts | yes | two stdin→JSON scripts + HOOKS.md |
+| Components and interfaces — boundaries above | yes | `Interfaces and trust boundaries` |
+| Data models — shapes, classes, ownership | n/a | no data models |
+| Error handling — failure paths and responses | yes | `Unacceptable outcomes`; stdin drain is exception-guarded |
+| Testing strategy — how each claim is checked | yes | `verification.md` |
+
+## Required links
+
+- Risk record: `risk.md`
+- Verification record: `verification.md`
+- Ship record: `ship.md`
+- Product requirement / issue / ADR / design doc: the approved revised dispatcher design + F2/F4.
+- Source lineage, if cited: not cited.
+
+## Exit criteria
+
+- The builder and reviewer can answer "what must stay true?"
+- The protected outcomes and the outcomes to prevent are stated plainly.
+- Important assumptions each have a trigger that would prove them wrong.
+- The evidence needs flow into `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on human performance improvement and secure software supply chains, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/dispatcher-hooks/plan.md
+++ b/.nuclear/changes/dispatcher-hooks/plan.md
@@ -1,0 +1,127 @@
+# Standard Plan
+
+**Purpose:** Bound the dispatcher-hooks work, its review, and its rollback.
+
+---
+
+## Change context
+
+- Slug: dispatcher-hooks
+- Related risk record: `risk.md`
+- Related basis record: `basis.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Current lifecycle phase: Decide
+
+## Charter and anchor check
+
+- Mission anchor confirmed (objective, success criteria, non-goals) before Plan? yes
+- Re-checked before Verify? yes
+- Charter articles in play: graded rigor (advisory, opt-in for the in-session tier); honest reporting (the advisory honesty note).
+
+| What is crossed | Why it is necessary | Why no simpler path | Owner decision |
+|---|---|---|---|
+| none | n/a | n/a | n/a |
+
+## Build sequence
+
+| # | Task | Requirements covered | Prereqs / blocked-by | Proof for this step | Stop / done condition |
+|---|---|---|---|---|---|
+| 1 | Confirm the hook I/O contract + F2/F4 hardening | REQ-001..004 | none | doc fetch with citations | contract known |
+| 2 | Write the two static, zero-network hook scripts | REQ-001, REQ-002, REQ-003 | step 1 | smoke-run emits valid JSON | scripts work |
+| 3 | Write HOOKS.md (declare + enable + honesty) | REQ-004 | step 2 | enable snippet present | doc complete |
+| 4 | Add `tests/test_hooks.py` (ban, no-echo, firewall, sync, budget) | REQ-002..005 | step 2 | `pytest` green | tests pass |
+
+## Two-speed work plan
+
+| Work phase | Allowed actions | Acceptance gate |
+|---|---|---|
+| explore | confirm the hook I/O contract | contract known |
+| candidate | write scripts + HOOKS.md + tests | smoke-run + tests green |
+| audit | full suite + ruff + doctor + tokens + validate | all green |
+| accept | open PR; maintainer reviews the code + runs a live session | human review |
+
+## HPI task preview
+
+| Critical step | Likely error | Consequence | Control / contingency | Evidence |
+|---|---|---|---|---|
+| Writing executable hooks | A network call or a prompt echo slips in | Exfiltration / injection-laundering | network-ban + no-echo tests; revert on failure | `verification.md` |
+| Shipping the hooks | Auto-activation by accident | No-hooks default broken | Ship no `hooks/hooks.json`; absence is the control | `verification.md` |
+
+## Agent briefing
+
+- Role: builder (drafting under review).
+- Authority source: the approved plan; this packet.
+- Active procedure/template: Standard packet.
+- Last completed action if resumed: scripts + HOOKS.md + tests written and verified locally.
+- Handoff or turnover needed? no
+- Pause when unsure condition: pause if a hook would need the network, echo input, auto-activate, or block tools.
+
+## Affected files and assets
+
+| File / asset | Change expected | Requirements covered | Why it matters | Owner |
+|---|---|---|---|---|
+| `hooks/session_start.py` | new | REQ-001, REQ-003 | the SessionStart injection | FlyFission |
+| `hooks/user_prompt_submit.py` | new | REQ-002, REQ-003 | the per-prompt reminder | FlyFission |
+| `HOOKS.md` | new | REQ-004 | declares + enables the hooks | FlyFission |
+| `tests/test_hooks.py` | new | REQ-002..005 | guards the properties | FlyFission |
+
+## Non-goals
+
+- No `hooks/hooks.json` (would auto-activate; we keep hooks opt-in).
+- No PreToolUse blocking gate or enforcement dial (a separate, higher-risk tier).
+- No live Claude Code session run from this container.
+
+## Review checkpoints
+
+| Checkpoint | Required before moving on | Status |
+|---|---|---|
+| Requirements approved | REQ-001..005 each a clear trigger→response, reviewed | pass |
+| Design approved | two static scripts + HOOKS.md + tests | pass |
+| Tasks approved | Build steps carry requirement IDs | pass |
+| Specification reviewed | Protected and unacceptable outcomes stated | pass |
+| Tests/evals defined | Each claim maps to evidence | pass |
+| Build complete | The scripts + doc + tests match the plan | pass |
+| Verification complete | Evidence linked in `verification.md` | pass |
+| Release decision ready | Leftover risk + rollback recorded | pass |
+| Turnover complete if activated | Not activated | not applicable |
+
+## Rollback approach
+
+- Rollback method: delete `hooks/`, `HOOKS.md`, and the test (single revert); adopters remove the settings.json entry.
+- State/data reversal notes: none.
+- Feature flag / kill switch: the hooks are inert unless wired into settings.json.
+- Owner: FlyFission
+- Time to restore estimate: minutes.
+
+## Proof commands
+
+```bash
+echo '{"source":"startup"}' | python hooks/session_start.py
+python -m pytest -q tests/test_hooks.py
+python -m pytest -q
+python -m ruff check .
+python tools/ng.py doctor .
+python tools/ng.py tokens .
+python tools/ng.py validate .nuclear/changes/dispatcher-hooks
+```
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `trace.md`
+- `verification.md`
+- `ship.md`
+- Issue / PR / ADR / design doc: the approved revised dispatcher design + F2/F4.
+
+## Exit criteria
+
+- The work is bounded enough to keep scope from creeping.
+- The review checkpoints are named.
+- Rollback and restore are thought through before release.
+- The proof commands are ready for `verification.md`.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on human performance improvement and secure software supply chains, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/dispatcher-hooks/risk.md
+++ b/.nuclear/changes/dispatcher-hooks/risk.md
@@ -1,0 +1,106 @@
+# Standard Risk
+
+**Purpose:** Sort the dispatcher-hooks change by risk, justify Standard mode, and name the records turned on.
+
+---
+
+## Change identity
+
+- Slug: dispatcher-hooks
+- PR / issue: Add advisory, opt-in SessionStart + UserPromptSubmit dispatcher hooks
+- Owner: FlyFission
+- Date: 2026-06-08
+- Current lifecycle phase: Decide
+- Current work phase: accept
+- Summary: Add two **advisory, opt-in** session hooks that make the directive dispatcher always-on: `hooks/session_start.py` injects a static routing preamble (classify-first + two-speed + the cluster map + an honesty note), and `hooks/user_prompt_submit.py` injects one static classification reminder. Both are **pure standard library, zero network, static output**. They are **not auto-activated** — this repo ships no `hooks/hooks.json`, so installing the plugin does not turn them on; the no-hooks install stays the default (security finding F2). `HOOKS.md` declares behavior, the security guarantee, and the manual enable step. `tests/test_hooks.py` guards the network ban, the no-prompt-echo property, the injection firewall, the budget, and CORE.md cluster-sync. The blocking PreToolUse gate is a deliberately-deferred separate tier.
+
+## Mission anchor
+
+- Objective: make the dispatcher always-on as opt-in hooks, with zero exfiltration surface and no overclaim.
+- Success criteria: the hooks inject the static guidance, never echo the prompt, are pure-stdlib/zero-network, are opt-in, and are guarded by tests; the suite is green.
+- Non-goals / forbidden directions: no auto-activation; no network/subprocess in hooks; no PreToolUse blocking gate (separate tier); no enforcement claim.
+- Drift check: re-anchor / escalate / stop when an action stops serving the objective.
+- Traces to: the approved plan (revised dispatcher; F2 no-hooks-default; F4 static-injection).
+
+## Questioning-attitude summary
+
+- Decision question: can the always-on dispatcher ship as hooks without adding an exfiltration surface or auto-activating?
+- Evidence that would change the decision: a hook reaching the network, echoing the prompt, or auto-activating on plugin install.
+- Assumptions that changed the mode: even advisory, opt-in hooks are executable code that runs in adopter sessions — a security-relevant surface — so Standard.
+- Facts still needing validation: the live injection behavior on a real Claude Code session (verified here by the documented hook I/O contract + structure, not a live session).
+- Stop or hold conditions: stop if a hook would need the network, echo untrusted input, auto-activate, or block tools.
+
+## Affected configuration items
+
+| Item | Type | Why it matters | Link |
+|---|---|---|---|
+| `hooks/session_start.py` | Hook (executable) | Injects the routing preamble | `hooks/session_start.py` |
+| `hooks/user_prompt_submit.py` | Hook (executable) | Injects the classification reminder | `hooks/user_prompt_submit.py` |
+| `HOOKS.md` | Doc | Declares behavior, security, enable steps | `HOOKS.md` |
+| `tests/test_hooks.py` | Test | Guards the security + behavior properties | `tests/test_hooks.py` |
+
+## Threshold screen
+
+| Dimension | Low / medium / high | Notes |
+|---|---|---|
+| Consequence | medium | Executable code that runs in adopter sessions; but advisory, opt-in, and static-output. |
+| Reversibility | high | Delete the hooks + HOOKS.md + test; adopters disable by removing the settings.json entry. |
+| Detectability | high | Network-ban, no-echo, firewall, sync, and budget tests; visible injected text. |
+| Exposure | medium | Public; the hooks run on machines of adopters who opt in. |
+| Uncertainty | low | Deterministic; the only unproven step is a live Claude Code session. |
+| Dependency trust | low | Pure standard library; zero network; no new dependency. |
+| AI authority | low | Advisory injection; the hooks cannot block or grant authority. |
+
+## HPI work-mode screen
+
+| Work mode / precursor | Present? | Control |
+|---|---|---|
+| Routine, repeated action where it is easy to stop paying attention | no | self-check / proof |
+| Known procedure where following the steps matters | yes | packet path / deviation note |
+| New or uncertain work where the assumptions may be wrong | yes | questioning attitude / research / review |
+| Work that was interrupted, resumed, or handed off | no | turnover / context pack |
+| A high-stakes critical action | no | self-check / peer-check / independent verification |
+
+## Selected mode
+
+- Mode: Standard
+- Why this mode: it ships executable code that runs in adopter sessions — a security-relevant surface the review treated as critical — even though it is advisory and opt-in.
+- Why lighter mode is not enough: Quick fits local reversible docs; executable hooks on adopter machines warrant a basis, plan, trace, and release decision.
+- Why heavier mode is not yet required: advisory, opt-in, pure-stdlib, zero-network, static-output, reversible; the higher-risk blocking gate is deferred.
+
+## Activated artifacts
+
+| Artifact | Activated? | Reason | Owner |
+|---|---|---|---|
+| `questioning-attitude.md` | no | Captured inline in this risk record. | FlyFission |
+| `basis.md` | yes | The security + behavior properties that must hold. | FlyFission |
+| `verification.md` | yes | Evidence for the hook behavior + the guarantees. | FlyFission |
+| `ship.md` | yes | Release decision for executable code. | FlyFission |
+| `turnover.md` | no | Same agent continues; no handoff. | FlyFission |
+| `self-check.md` | no | No irreversible critical action. | FlyFission |
+| `supplier-trust.md` | no | No external dependency/model/API trust decision. | FlyFission |
+| Nuclear subset record | no | Stakes below Nuclear. | FlyFission |
+
+## Immediate evidence obligations
+
+- Minimum evidence before build: the hook I/O contract (SessionStart/UserPromptSubmit) and F2/F4 hardening.
+- Minimum evidence before merge/release: zero-network + no-echo + injection-firewall + sync + budget tests green; `pytest`/`ruff`/`doctor`/`tokens`/`validate` green.
+- Independent review needed? yes; why: a maintainer should review executable code shipped to adopters and run a live session once.
+
+## Required links
+
+- Packet: `.nuclear/changes/dispatcher-hooks/`
+- `basis.md`
+- `verification.md`
+- `ship.md`
+- Source-map/crosswalk references if source lineage is invoked: not invoked.
+
+## Exit criteria
+
+- The mode is justified.
+- The artifacts turned on are named.
+- Important risks, assumptions, and evidence due are recorded here, not hidden in chat or commit messages.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on human performance improvement, secure software supply chains, and graded rigor, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/dispatcher-hooks/ship.md
+++ b/.nuclear/changes/dispatcher-hooks/ship.md
@@ -1,0 +1,104 @@
+# Standard Ship
+
+**Purpose:** State the release decision for the advisory dispatcher hooks.
+
+---
+
+## Release identity
+
+- Change slug: dispatcher-hooks
+- Version / release / baseline: advisory SessionStart + UserPromptSubmit hooks (opt-in)
+- PR / commit / artifact: this branch's PR
+- Owner: FlyFission
+- Date: 2026-06-08
+- Intended release window: with this PR merge
+
+## Scope and exclusions
+
+- Included: `hooks/session_start.py`, `hooks/user_prompt_submit.py`, `HOOKS.md`, `tests/test_hooks.py`.
+- Excluded: any `hooks/hooks.json` (auto-activation), the PreToolUse blocking gate, the enforcement dial.
+- Known non-goals: enforcement; auto-activation; any network access.
+
+## Evidence status summary
+
+| Evidence area | Status | Link | Notes |
+|---|---|---|---|
+| Risk classification | pass | `risk.md` | Standard justified |
+| Basis / requirements / claims | pass | `basis.md` | REQ-001..005 |
+| Questioning attitude | pass | `risk.md` | captured inline |
+| Verification | pass (live deferred) | `verification.md` | live session deferred |
+| Dependency / supply-chain evidence | pass | `verification.md` | pure stdlib, zero network (test-enforced) |
+| AI-assisted work checks | pass | `verification.md` | I/O traces to official docs |
+| Review / approval | planned | the PR | maintainer review pending |
+
+## Residual risks and gaps
+
+| Risk / gap | Impact | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| No live Claude Code session run | Injection unproven end-to-end | defer | FlyFission | Maintainer enables hooks and starts a session |
+| In-session hooks are rungs 1–3 (defeatable) | They are advisory, not a control | accept | FlyFission | The real gate is the rung-4 CI (`ng scaffold-ci`) |
+| Manual enable (settings.json) | Friction vs auto-on | accept | FlyFission | A future `ng scaffold-hooks` could automate the opt-in |
+
+## Rollback / restore plan
+
+- Rollback method: delete `hooks/`, `HOOKS.md`, and the test; adopters remove the settings.json entry.
+- Data migration reversal or restore notes: none.
+- Feature flag / kill switch: the hooks are inert unless wired into settings.json.
+- Owner on call: FlyFission
+- Time to restore estimate: minutes.
+
+## Monitoring and post-release checks
+
+| Signal | Threshold / expected behavior | Owner | Where to inspect | Action if bad |
+|---|---|---|---|---|
+| First live session with hooks enabled | preamble + reminder appear; no errors | FlyFission | a Claude Code session | fix the hook; patch |
+| Over-injection / noise reports | the preamble helps, does not nag | FlyFission | GitHub issues | trim the preamble |
+
+## Handoff
+
+- Operator/customer/support notes: enable per `HOOKS.md`; the hooks are advisory and opt-in.
+- Docs/runbook updated: `HOOKS.md`.
+- Communication needed: note the opt-in hooks in release notes when cut.
+- Turnover record if activated: not activated.
+- Follow-up date: when a maintainer runs a live session with hooks enabled.
+
+## Release decision
+
+- Decision: ship with residual risk
+- Decision maker: FlyFission
+- Rationale: the hooks are advisory, opt-in, pure-stdlib, zero-network, and static-output, all test-enforced; the only unproven step (a live session) is low-risk and reversible.
+- Decision question answered by evidence? yes for the static/zero-network/opt-in properties; the live injection is the named residual.
+- Conditions attached: maintainer reviews the executable code and runs one live session before announcing.
+- Decision posture: conservative enough.
+- Abort or rollback trigger: a hook reaching the network or echoing input (would fail CI), or live-session breakage → revert.
+- OPEX or post-release learning trigger: any hook issue updates HOOKS.md / the scripts.
+
+## Baseline trigger
+
+- Baseline required? yes
+- Baseline record: the two hooks + HOOKS.md become controlled items; the preamble is tied to CORE.md by test.
+- Revalidation trigger: a hook I/O schema change, or a CORE.md matrix change.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `verification.md`
+- PR/commit/release artifact: this branch's PR.
+- Monitoring/dashboard/log query: GitHub issues; live-session observation.
+- Rollback/runbook: delete `hooks/` + `HOOKS.md`; remove the settings.json entry.
+
+## Exit criteria
+
+- The release decision is stated plainly.
+- The slow audit step is done before any baseline or public claim is accepted.
+- The baseline trigger is named when the controlled state changes.
+- The evidence status and the gaps are visible.
+- The leftover uncertainty is bounded and owned, or it blocks or defers the decision.
+- A rollback/restore path exists, or its absence is accepted on purpose.
+- Monitoring and handoff cover the claims most likely to fail in operation.
+- Any accepted leftover risk has an owner and a recheck trigger.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on secure software supply chains, human performance improvement, and release readiness, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/dispatcher-hooks/trace.md
+++ b/.nuclear/changes/dispatcher-hooks/trace.md
@@ -1,0 +1,62 @@
+# Standard Trace
+
+**Purpose:** Tie each claim to its basis, control, evidence, and ship stance.
+
+---
+
+## Change context
+
+- Slug: dispatcher-hooks
+- Related basis record: `basis.md`
+- Related verification record: `verification.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+
+## Trace summary
+
+| ID | Claim | Basis link | Task / code ref | Control / design feature | Support type | Verification evidence | Ship posture | Status |
+|---|---|---|---|---|---|---|---|---|
+| REQ-001 | SessionStart injects a static routing preamble | `basis.md` | `plan.md` step 2 / `hooks/session_start.py` | PREAMBLE constant | local proof | `verification.md` | ship | pass |
+| REQ-002 | UserPromptSubmit injects a static line, never the prompt | `basis.md` | `plan.md` step 2 / `hooks/user_prompt_submit.py` | static CLASSIFY_LINE | local proof | `verification.md` | ship | pass |
+| REQ-003 | Hooks are pure stdlib, zero network | `basis.md` | `plan.md` step 2 / `hooks/*.py` | imports limited to json, sys | local proof | `verification.md` | ship | pass |
+| REQ-004 | Hooks are opt-in (no auto-activation) | `basis.md` | `plan.md` step 3 / no `hooks/hooks.json` | absence + HOOKS.md enable step | local proof | `verification.md` | ship | pass |
+| REQ-005 | Preamble in sync with CORE.md + within budget | `basis.md` | `plan.md` step 4 / `tests/test_hooks.py` | sync + length tests | local proof | `verification.md` | ship | pass |
+| (live) | The hooks inject correctly in a live Claude Code session | `basis.md` | a live session | n/a | unknown | deferred | ship with residual risk | deferred |
+
+## Evidence chain
+
+```text
+Need: the dispatcher always-on, without an exfiltration surface or auto-activation
+  -> Basis: REQ-001..005 (static injection, no-echo, zero-network, opt-in, in-sync)
+  -> Control: two static stdlib hooks + HOOKS.md + the security/behavior tests
+  -> Verification: smoke-run, network-ban, no-echo, firewall, sync, budget, pytest, ruff, doctor
+  -> Release: ship with residual risk (a live Claude Code session run is deferred)
+```
+
+## Open trace gaps
+
+| Gap | Why it matters | Disposition | Owner | Recheck trigger |
+|---|---|---|---|---|
+| No live Claude Code session run | Injection behavior unproven end-to-end | defer | FlyFission | Maintainer enables the hooks and starts a session |
+| Enabling is manual (settings.json) | More friction than auto-on | accept | FlyFission | A future `ng scaffold-hooks` could automate the opt-in |
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `plan.md`
+- `verification.md`
+- `ship.md`
+- Implementation / docs / tests / evals: `hooks/session_start.py`, `hooks/user_prompt_submit.py`, `HOOKS.md`, `tests/test_hooks.py`
+
+## Exit criteria
+
+- Each important claim has a status label.
+- Each important claim names its support type.
+- Every shipped claim has evidence or an accepted leftover risk.
+- Deferred or gap claims are not used as release evidence.
+- A reviewer can move quickly from claim to basis to evidence to release decision.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on requirements tracing and secure software supply chains, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/dispatcher-hooks/verification.md
+++ b/.nuclear/changes/dispatcher-hooks/verification.md
@@ -1,0 +1,79 @@
+# Standard Verification
+
+**Purpose:** Show the dispatcher-hooks claims have evidence that fits the change.
+
+---
+
+## Verification context
+
+- Slug: dispatcher-hooks
+- Related basis: `basis.md`
+- Owner: FlyFission
+- Date: 2026-06-08
+- Verification scope: the hooks emit valid, static, zero-network output; they are opt-in; the preamble stays in sync and within budget. Excludes a live Claude Code session (no runtime in this container).
+
+## Evidence status legend
+
+Use: `pass`, `fail`, `gap`, `deferred`, `not applicable`, `planned`.
+
+## Claim-to-evidence table
+
+| Claim / requirement ID | Support type | Verification type | Verification method | Acceptance criteria | Result status | Evidence link | Gap / follow-up |
+|---|---|---|---|---|---|---|---|
+| REQ-001 | local proof | deterministic test | run `session_start.py`; inspect output | valid JSON; `additionalContext` has classify-first + honesty | pass | `tests/test_hooks.py` | live session deferred |
+| REQ-002 | local proof | deterministic test | feed a seeded prompt; assert it is not echoed | seeded prompt absent from output | pass | `tests/test_hooks.py` | none |
+| REQ-003 | local proof | deterministic test | scan hook sources for banned imports | no `socket`/`urllib`/`requests`/`http`/`subprocess`/... | pass | `tests/test_hooks.py` | none |
+| REQ-004 | local proof | inspection | confirm no `hooks/hooks.json`; HOOKS.md enable step | hooks inert until wired in settings.json | pass | `HOOKS.md` | none |
+| REQ-005 | local proof | deterministic test | cluster-sync vs CORE.md; preamble length | clusters present in both; preamble < budget | pass | `tests/test_hooks.py` | none |
+| live injection | unknown | independent verification | enable hooks; start a Claude Code session | preamble + reminder appear in context | deferred | maintainer run | tracked in `ship.md` |
+
+## Commands, evals, and reviews
+
+| Method | Command / review / eval | Environment | Result | Evidence link |
+|---|---|---|---|---|
+| Hook smoke-run | `echo '{...}' | python hooks/session_start.py` | Python 3, container | valid JSON; 1898-char preamble | this packet |
+| No-echo smoke | `echo '{"user_prompt":"SECRET"}' | python hooks/user_prompt_submit.py` | Python 3 | SECRET absent | this packet |
+| Full suite | `python -m pytest -q` | Python 3 | 123 passed | CI |
+| Lint | `python -m ruff check .` | ruff 0.15.16 | clean | CI |
+| Doctor | `python tools/ng.py doctor .` | repo | OK | CI |
+| Token budget | `python tools/ng.py tokens .` | repo | OK | CI |
+| Packet validate | `python tools/ng.py validate .nuclear/changes/dispatcher-hooks` | repo | OK | CI |
+
+## Negative / failure-mode checks
+
+| Failure mode | Check performed | Result | Evidence link |
+|---|---|---|---|
+| Hook reaches the network / shells out | banned-import scan over hook sources | pass | `tests/test_hooks.py` |
+| Hook echoes the user's prompt | seeded-prompt no-echo test | pass | `tests/test_hooks.py` |
+| Injection markers in the preamble | injection-firewall test | pass | `tests/test_hooks.py` |
+| Preamble drifts from CORE.md | cluster-sync test | pass | `tests/test_hooks.py` |
+
+## AI-assisted work checks
+
+- AI scope: wrote two hook scripts + HOOKS.md + tests + this packet under review.
+- Model/tool used: Claude Code agent.
+- Permissions/actions allowed: edit files; run tests; the shipped hooks make no network calls.
+- Independent checks performed: full suite + lint + doctor + tokens + validate; hook smoke-runs.
+- Self-check / turnover records: not activated.
+- Hallucination/slop screening: hook I/O traces to cited official docs; the preamble mirrors CORE.md.
+- Human approval gates exercised: PR review + a maintainer live-session run pending.
+
+## Required links
+
+- `risk.md`
+- `basis.md`
+- `ship.md`
+- CI run / eval report / test logs / review notes: GitHub Actions on the PR.
+- Implementation diff / PR: this branch's PR.
+
+## Exit criteria
+
+- Each important claim has a status.
+- Each important claim keeps the support type apart from the verification type.
+- Evidence is linked, not pasted in full.
+- Gaps are stated plainly and carried into `ship.md`.
+- The reviewer can tell whether the evidence backs the release decision.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public sources on software verification and validation and secure software supply chains, mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -37,14 +37,17 @@ Copy the two scripts into your repo (for example `.claude/hooks/`) and register 
 {
   "hooks": {
     "SessionStart": [
-      { "matcher": "startup|resume|clear|compact", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/session_start.py" } ] }
+      { "matcher": "startup|resume|clear|compact", "hooks": [ { "type": "command", "command": "python3", "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/session_start.py"] } ] }
     ],
     "UserPromptSubmit": [
-      { "matcher": "*", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/user_prompt_submit.py" } ] }
+      { "matcher": "*", "hooks": [ { "type": "command", "command": "python3", "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/user_prompt_submit.py"] } ] }
     ]
   }
 }
 ```
+
+The commands use **exec form** (`command` + `args`) so a project path containing spaces or shell
+metacharacters is passed as a single argument and the hook starts correctly.
 
 The preamble mirrors the decision matrix in [`CORE.md`](CORE.md); a test asserts the cluster names
 stay in sync.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,54 @@
+# Hooks (advisory, opt-in)
+
+Nuclear-grade ships two **advisory** session hooks that make the dispatcher always-on. They are
+**opt-in**: this repo ships **no** `hooks/hooks.json`, so installing the plugin does **not**
+auto-activate them. The no-hooks install stays the default — a deliberate security posture (the
+in-session hooks are rungs 1–3 and defeatable; the real gate is the out-of-band CI from
+`ng scaffold-ci`). Enable them yourself when you want the always-on routing.
+
+## What they do
+
+| Hook | Event | Reads | Returns | Effect |
+|---|---|---|---|---|
+| `hooks/session_start.py` | SessionStart | stdin session metadata (drained, unused) | a static routing preamble as `additionalContext` | injects the classify-first rule + two-speed + the cluster map at session start |
+| `hooks/user_prompt_submit.py` | UserPromptSubmit | stdin (the prompt is drained, **never echoed**) | one static classification line as `additionalContext` | reminds the agent to state the mode before acting |
+
+## Security properties (enforced by `tests/test_hooks.py`)
+
+- **Pure standard library, zero network** — the scripts import only `json` and `sys`. A test fails
+  the build if `socket`, `urllib`, `requests`, `http`, `subprocess`, `ftplib`, or `smtplib` appears
+  in a hook source.
+- **Static output** — the injected text is a fixed constant. The UserPromptSubmit hook never
+  reflects the user's prompt (a seeded prompt is asserted absent from the output), so it cannot be
+  used to launder injected instructions.
+- **No file reads, no side effects** — the hooks read stdin and print JSON; nothing else.
+- **Advisory only (rung 1)** — these hooks inject *text*; they do not block anything. The blocking
+  `PreToolUse` gate is a separate, deliberately-deferred tier (it must decide on structured facts
+  only, fail closed, and never auto-allow).
+
+## Enable them
+
+Copy the two scripts into your repo (for example `.claude/hooks/`) and register them in
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "startup|resume", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/session_start.py" } ] }
+    ],
+    "UserPromptSubmit": [
+      { "matcher": "*", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/user_prompt_submit.py" } ] }
+    ]
+  }
+}
+```
+
+The preamble mirrors the decision matrix in [`CORE.md`](CORE.md); a test asserts the cluster names
+stay in sync.
+
+## Honesty
+
+This guidance is advisory — an agent can ignore it. It is **not** enforcement and **not** a
+compliance claim. Trust-bearing work still needs the out-of-band CI gate (`ng scaffold-ci`) and
+human review.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -15,13 +15,15 @@ in-session hooks are rungs 1–3 and defeatable; the real gate is the out-of-ban
 
 ## Security properties (enforced by `tests/test_hooks.py`)
 
-- **Pure standard library, zero network** — the scripts import only `json` and `sys`. A test fails
-  the build if `socket`, `urllib`, `requests`, `http`, `subprocess`, `ftplib`, or `smtplib` appears
-  in a hook source.
+- **Pure standard library, zero network** — the scripts import only `json` and `sys`. A test
+  AST-parses each hook and fails the build if anything beyond `json`/`sys` is imported (a
+  banned-substring scan also rejects `socket`, `urllib`, `requests`, `http`, `subprocess`, etc.).
 - **Static output** — the injected text is a fixed constant. The UserPromptSubmit hook never
   reflects the user's prompt (a seeded prompt is asserted absent from the output), so it cannot be
   used to launder injected instructions.
-- **No file reads, no side effects** — the hooks read stdin and print JSON; nothing else.
+- **No file reads, no side effects** — the hooks read stdin and print JSON; a test fails the build if
+  a hook calls `open`, `exec`, `eval`, or `compile`. The matcher includes `clear` and `compact` so the
+  preamble is re-injected after `/clear` or context compaction, not only at startup/resume.
 - **Advisory only (rung 1)** — these hooks inject *text*; they do not block anything. The blocking
   `PreToolUse` gate is a separate, deliberately-deferred tier (it must decide on structured facts
   only, fail closed, and never auto-allow).
@@ -35,7 +37,7 @@ Copy the two scripts into your repo (for example `.claude/hooks/`) and register 
 {
   "hooks": {
     "SessionStart": [
-      { "matcher": "startup|resume", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/session_start.py" } ] }
+      { "matcher": "startup|resume|clear|compact", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/session_start.py" } ] }
     ],
     "UserPromptSubmit": [
       { "matcher": "*", "hooks": [ { "type": "command", "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/user_prompt_submit.py" } ] }

--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Nuclear-grade SessionStart hook (advisory, opt-in).
+
+Injects a static routing preamble at session start. Pure standard library,
+zero network, static output: it reads stdin only to drain it, never reads
+project files, and never echoes any untrusted text. Advisory only (rung 1) --
+it injects guidance and cannot block anything. See HOOKS.md.
+"""
+
+import json
+import sys
+
+PREAMBLE = """\
+Nuclear-grade is active. Route every change by consequence.
+
+BEFORE your first action, state the mode and the one fact that sets it. This is a declaration of intent -- you name the mode and act, you do not ask permission.
+- Quick: local, reversible, obvious proof, no new trust boundary.
+- Standard+ (Standard, or a stronger human-reviewed mode): anything touching authentication, permissions, or secrets; user-visible behavior; data, schema, or a migration; a dependency; a model id, a prompt, or what a tool or agent may do; CI or .github/; a release or saved baseline; or public wording. When unsure, choose Standard.
+
+Two speeds: move fast while the work is throwaway; slow down the moment it becomes a promise -- a claim, a controlled file, public wording, a baseline, a release, or a change to what an agent may do.
+
+Invoke a cluster only when its trigger fires (the default is the Core habits -- question, rate risk, prove claims, double-check cut-points, stay on mission, check release readiness, learn from misses):
+- Agent authority: the agent can write, run, use the network, or approve actions in its working set.
+- Configuration management: you produce controlled artifacts -- packets, baselines, pinned configs.
+- Claims discipline: public claims about safety, security, compliance, licensing, or provenance.
+- Incident & deficiency: a production failure, data loss, or agent-caused harm.
+- Hygiene: a repo-layout decision, or code-quality drift in a diff.
+
+Do not talk yourself down a tier: "it's a small change" (size is not stakes), "it's only docs" (public wording makes claims), "I'll classify later" (the mode call is the cheapest control -- say it first).
+
+Honesty: this guidance is advisory -- it can be ignored, and it is not enforcement. Trust-bearing work still needs the out-of-band CI gate and human review. "Nuclear-grade" is a standard of care, not a compliance claim.
+"""
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)  # drain stdin; the content is not used
+    except (json.JSONDecodeError, ValueError):
+        pass
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": PREAMBLE,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/user_prompt_submit.py
+++ b/hooks/user_prompt_submit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Nuclear-grade UserPromptSubmit hook (advisory, opt-in).
+
+Appends ONE static line reminding the agent to classify the change before
+acting. Pure standard library, zero network. The injected text is a fixed
+constant: the user's prompt is read from stdin only to drain it and is never
+reflected back, so this hook cannot be used to launder injected instructions.
+Advisory only -- it injects a reminder and cannot block anything. See HOOKS.md.
+"""
+
+import json
+import sys
+
+CLASSIFY_LINE = (
+    "Nuclear-grade reminder: before acting, state the mode (Quick or Standard+) "
+    "and the one fact that sets it. Treat authentication, data or migrations, "
+    "dependencies, model ids, CI or .github/, releases, or public wording as "
+    "Standard+ -- size is not stakes."
+)
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)  # drain stdin; the prompt is intentionally not used
+    except (json.JSONDecodeError, ValueError):
+        pass
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": CLASSIFY_LINE,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,76 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "hooks"
+HOOK_SCRIPTS = sorted(HOOKS.glob("*.py"))
+
+# F2: in-session hooks must be pure standard library with no network or subprocess use.
+BANNED = ("socket", "urllib", "requests", "http", "subprocess", "ftplib", "smtplib", "telnetlib")
+
+# Lens 2 / A8: the SessionStart preamble mirrors CORE.md's decision matrix; guard the mirror.
+CLUSTERS = (
+    "Agent authority",
+    "Configuration management",
+    "Claims discipline",
+    "Incident & deficiency",
+    "Hygiene",
+)
+
+
+def _run_hook(script: Path, stdin_obj: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(stdin_obj),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_hook_scripts_exist():
+    assert HOOK_SCRIPTS, "expected hook scripts under hooks/"
+
+
+def test_hooks_are_pure_stdlib_and_zero_network():
+    for script in HOOK_SCRIPTS:
+        src = script.read_text(encoding="utf-8")
+        for banned in BANNED:
+            assert banned not in src, f"{script.name} must not reference {banned!r} (zero-network, pure-stdlib)"
+
+
+def test_session_start_injects_a_static_preamble():
+    out = _run_hook(HOOKS / "session_start.py", {"hook_event_name": "SessionStart", "source": "startup"})
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert "state the mode" in ctx
+    assert "advisory" in ctx.lower()  # the honesty note must be present
+    assert len(ctx) < 2200, "preamble must stay within its ~300-token budget"
+
+
+def test_user_prompt_submit_never_echoes_the_prompt():
+    secret = "ZZZ-do-not-echo-this-prompt-ZZZ"
+    out = _run_hook(
+        HOOKS / "user_prompt_submit.py",
+        {"hook_event_name": "UserPromptSubmit", "user_prompt": secret},
+    )
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert secret not in ctx, "the injected line must be static, never the user's prompt"
+    assert "state the mode" in ctx
+
+
+def test_preamble_has_no_injection_markers():
+    src = (HOOKS / "session_start.py").read_text(encoding="utf-8").lower()
+    for marker in ("ignore previous", "disregard", "override the", "auto-approve", "exfiltrate", "system:"):
+        assert marker not in src, f"preamble contains an injection marker: {marker!r}"
+
+
+def test_preamble_clusters_stay_in_sync_with_core():
+    core = (ROOT / "CORE.md").read_text(encoding="utf-8")
+    preamble = (HOOKS / "session_start.py").read_text(encoding="utf-8")
+    for cluster in CLUSTERS:
+        assert cluster in core, f"cluster missing from CORE.md: {cluster}"
+        assert cluster in preamble, f"preamble drifted from CORE.md (missing cluster): {cluster}"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import subprocess
 import sys
@@ -74,3 +75,30 @@ def test_preamble_clusters_stay_in_sync_with_core():
     for cluster in CLUSTERS:
         assert cluster in core, f"cluster missing from CORE.md: {cluster}"
         assert cluster in preamble, f"preamble drifted from CORE.md (missing cluster): {cluster}"
+
+
+def test_hooks_import_only_json_and_sys():
+    """Robust form of the 'pure standard library' guarantee: AST-parse each hook
+    and assert it imports nothing beyond json/sys (a banned-substring scan would
+    miss os/pathlib/importlib)."""
+    allowed = {"json", "sys"}
+    for script in HOOK_SCRIPTS:
+        tree = ast.parse(script.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        assert imported <= allowed, f"{script.name} imports beyond json/sys: {sorted(imported - allowed)}"
+
+
+def test_hooks_do_no_file_io_or_dynamic_exec():
+    """The 'no file reads, no side effects' guarantee: ban open/exec/eval/compile
+    calls (open() is a builtin, so the import allowlist alone would miss it)."""
+    banned_calls = {"open", "exec", "eval", "compile", "__import__"}
+    for script in HOOK_SCRIPTS:
+        tree = ast.parse(script.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls, f"{script.name} calls {node.func.id}()"


### PR DESCRIPTION
## What & why

Makes the directive dispatcher **always-on** for adopters who opt in, via two session hooks:
- **SessionStart** → injects a static routing preamble (classify-first rule, two-speed, the 5-cluster map, an honesty note), mirrored from `CORE.md`.
- **UserPromptSubmit** → injects one static classification reminder.

This is the in-session side of Phase 2, built to the security review's bar.

## The security posture (this is the point)

- **Opt-in, not auto-on.** This repo ships **no `hooks/hooks.json`**, so installing the plugin does **not** activate these hooks — the no-hooks install stays the default (**F2**). `HOOKS.md` has the explicit `settings.json` enable step.
- **Pure stdlib, zero network.** The scripts import only `json`/`sys`; a test fails the build if `socket`/`urllib`/`requests`/`http`/`subprocess`/… appears in a hook source.
- **Static output, no laundering.** The injected text is constant; the UserPromptSubmit hook **never echoes the prompt** (a seeded prompt is asserted absent — **F4**).
- **Advisory only (rung 1).** The hooks inject *text*; they block nothing. The blocking **PreToolUse gate is a deliberately-deferred separate tier**.

## What's in this PR

- `hooks/session_start.py`, `hooks/user_prompt_submit.py` — the two hooks.
- `HOOKS.md` — behavior table, the test-enforced security guarantees, the enable snippet, the honesty note.
- `tests/test_hooks.py` — network-ban, no-prompt-echo, injection-firewall, `CORE.md` cluster-sync, and budget guards.
- **Standard change packet** (`.nuclear/changes/dispatcher-hooks/`).

## Honest residual

No live Claude Code session was run here (no runtime in this container) — the hook I/O contract + the structured tests verify behavior; the live injection is **deferred to a maintainer** smoke-test (`ship.md`).

## Verification

`python -m pytest -q` → **123 passed** · ruff clean · `ng doctor`/`tokens` OK · all packets validate. Smoke-runs confirm valid JSON, an 1898-char preamble (within budget), and that a seeded prompt is not echoed.

Off `main`; independent of #29–#32.

https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY8kAChAdrFbPovLKpwbck)_