### PR TITLE
Add context-window-discipline doctrine extracted from verified context-engineering research

### DIFF
--- a/.nuclear/changes/context-window-discipline/proof.md
+++ b/.nuclear/changes/context-window-discipline/proof.md
@@ -46,9 +46,12 @@ the triggering external report was carried into the repo.
   internal links checked across the five touched docs, all resolve. Web verification
   confirmed each Tier 9 source: Anthropic context-engineering post; LangChain
   context-engineering docs; Neo4j practical guide; Breunig failure-mode post; Chroma
-  context-rot report; arXiv 2307.03172 (Lost in the Middle, TACL 2023); arXiv 2510.04618
+  context-rot report; arXiv 2307.03172 (Lost in the Middle; the arXiv abstract page itself
+  records TACL acceptance); arXiv 2510.04618
   (ACE); microsoft/LLMLingua (arXiv 2310.05736 / 2310.06839 / 2403.12968); arXiv 2506.15655
-  (cAST, EMNLP 2025 Findings); arXiv 2510.00446 (LongCodeZip, ASE 2025). Packet validation:
+  (cAST; venue EMNLP 2025 Findings verified against the ACL Anthology record,
+  https://aclanthology.org/2025.findings-emnlp.430/); arXiv 2510.00446 (LongCodeZip; no
+  independently verified venue, so none is claimed). Packet validation:
   recorded by the `python tools/ng.py validate .nuclear/changes/context-window-discipline`
   run after this file was added; the only prior finding was the then-missing `proof.md`.
 - Evidence link or artifact path: `docs/02-operating-system/context-window-discipline.md`;

--- a/.nuclear/changes/context-window-discipline/proof.md
+++ b/.nuclear/changes/context-window-discipline/proof.md
@@ -1,0 +1,98 @@
+# Quick Proof
+
+**Purpose:** Capture the smallest credible evidence record for this Quick change.
+
+---
+
+## Proof summary
+
+- Change slug: context-window-discipline
+- Proof owner: FlyFission
+- Date/time: 2026-06-10
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: The context-window-discipline page and its supporting edits are additive only — they
+keep the full test suite, ruff, `doctor`, the token budget, and this packet green; every
+internal link in the touched docs resolves; every external source cited in the new Tier 9 of
+`source-map.md` is public and was independently re-verified; and no unverifiable claim from
+the triggering external report was carried into the repo.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest`; `python -m ruff check .`;
+  `python tools/ng.py doctor .`; `python tools/ng.py tokens .`;
+  `python tools/ng.py validate .nuclear/changes/context-window-discipline`; a link-resolution
+  script over all internal links in the five touched docs; web verification of each Tier 9
+  source URL on 2026-06-10.
+- Environment: Python 3.13, repo working tree on `claude/context-engineering-agents-492oi0`.
+- Inputs/fixtures: the new page, the Tier 9 source-map section, the one-row `docs/README.md`
+  edit, one grounding sentence each in `context-packs.md` and `token-burn-control.md`, seven
+  glossary rows, and this packet.
+- Expected result: full suite green; ruff clean; doctor OK; token budget OK; this packet
+  validates; all internal link targets exist; every Tier 9 URL confirmed public.
+- Self-check used? yes; target = the `docs/README.md` headings the public-docs test asserts
+  (`## Use the repo`, `## Reference foundation`), confirmed present and unchanged, and the
+  exclusion list from `risk.md` (no per-tool "context waste" percentages, no
+  "Forward-Deployed Context Engineer" framing, no unverified efficiency numbers), confirmed
+  absent from the tree.
+
+## Result
+
+- Status: pass
+- Actual result: `python -m pytest` → 142 passed; `python -m ruff check .` → all checks
+  passed; `doctor .` → OK; `tokens .` → OK: token budget; link-resolution script → 33
+  internal links checked across the five touched docs, all resolve. Web verification
+  confirmed each Tier 9 source: Anthropic context-engineering post; LangChain
+  context-engineering docs; Neo4j practical guide; Breunig failure-mode post; Chroma
+  context-rot report; arXiv 2307.03172 (Lost in the Middle, TACL 2023); arXiv 2510.04618
+  (ACE); microsoft/LLMLingua (arXiv 2310.05736 / 2310.06839 / 2403.12968); arXiv 2506.15655
+  (cAST, EMNLP 2025 Findings); arXiv 2510.00446 (LongCodeZip, ASE 2025). Packet validation:
+  recorded by the `python tools/ng.py validate .nuclear/changes/context-window-discipline`
+  run after this file was added; the only prior finding was the then-missing `proof.md`.
+- Evidence link or artifact path: `docs/02-operating-system/context-window-discipline.md`;
+  `docs/00-standards-foundation/source-map.md` (Tier 9); `docs/README.md` (the "Budget and
+  order an agent's context window" row); commands above.
+- If failed/gap: none blocking. Two recorded limits: (1) external URLs can rot — Tier 9
+  links were verified on 2026-06-10 only, an existing repo-wide concern; (2) the Anthropic,
+  Chroma, and arXiv pages returned HTTP 403 to this environment's direct fetcher, so
+  verification was via web-search confirmation of title, venue, and content rather than a
+  byte-level fetch.
+
+## Reviewer note
+
+- Reviewer: FlyFission
+- Review note: The page is grounding and a failure-mode index, not a new gate — context
+  packs, token budgets, lessons-learned deltas, and turnover already exist; the page links
+  out to them and explains why they work. The triggering external report's unverifiable
+  numbers and marketing framing were excluded by name in `risk.md` and confirmed absent.
+  Benchmark figures are attributed to their papers with an explicit "their benchmarks, not
+  promises" hedge in both the page header and the Tier 9 intro.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: Extract verified context-engineering mechanics from external research report
+- Relevant changed files: `docs/02-operating-system/context-window-discipline.md`,
+  `docs/00-standards-foundation/source-map.md`, `docs/README.md`,
+  `docs/02-operating-system/context-packs.md`,
+  `docs/02-operating-system/token-burn-control.md`, `docs/glossary.md`
+- CI run / test output: `python -m pytest` (142 passed), `python -m ruff check .` (clean),
+  `python tools/ng.py doctor .` (OK), `python tools/ng.py tokens .` (OK)
+- If AI-assisted: changes prepared by an AI agent under review; scope is one additive
+  documentation page, one additive source-map tier, and five small additive edits, with no
+  code or gate change; web access was used only to re-verify public citations.
+
+## Exit criteria
+
+- Evidence directly matches the claim in `risk.md`.
+- Actual result is compared to the expected result named before proof.
+- Result status is explicit.
+- Any failure or gap has a next action or escalation.
+- Reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public software test-documentation and verification
+concepts mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/context-window-discipline/risk.md
+++ b/.nuclear/changes/context-window-discipline/risk.md
@@ -1,0 +1,115 @@
+# Quick Risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** Additive documentation only — one new operating-system page, one new
+  source-map tier, three one-line cross-links, and seven glossary rows. No code, validator
+  logic, dependencies, permissions, or public assurance claims change. The page indexes and
+  grounds controls that already exist (context packs, token-burn control, lessons learned);
+  it adds no gate.
+
+**Purpose:** Decide whether extracting the verified content of an external
+"context engineering blueprint" research report into repo doctrine can safely stay in Quick
+mode, and name the proof required.
+
+---
+
+## Change
+
+- Slug: context-window-discipline
+- PR / issue: Extract verified context-engineering mechanics from external research report
+- Owner: FlyFission
+- Date: 2026-06-10
+- Summary: Add `docs/02-operating-system/context-window-discipline.md`, the mechanics behind
+  the existing context-pack and token-burn doctrine: why small ordered context outperforms
+  big context (attention budget, context rot, lost-in-the-middle), the named context failure
+  modes (poisoning, distraction, confusion, clash, rot, collapse, brevity bias) each mapped
+  to an existing Nuclear-grade control, placement/ordering rules, compression caveats,
+  structure-aware code retrieval, and multi-agent state hygiene. Add a Tier 9
+  (Context-Engineering Mechanics Sources) section to `source-map.md` with ten verified
+  public sources. Add one index row to `docs/README.md`, one grounding link each to
+  `context-packs.md` and `token-burn-control.md`, and seven plain-language glossary rows.
+- Provenance discipline: the triggering report cited only two distinct public pages and
+  carried several unverifiable numbers. Every source in the new Tier 9 was independently
+  re-verified against its public URL before citation. Deliberately **not** adopted from the
+  report: per-tool "context waste" percentages (no traceable public source), the
+  "Forward-Deployed Context Engineer" framing (marketing, not engineering), garbled formula
+  fragments, and vendor-specific middleware patterns.
+
+## Scope
+
+- Affected files/configs/docs: `docs/02-operating-system/context-window-discipline.md` (new),
+  `docs/00-standards-foundation/source-map.md` (one additive tier),
+  `docs/README.md` (one index row), `docs/02-operating-system/context-packs.md` (one
+  sentence), `docs/02-operating-system/token-burn-control.md` (one sentence),
+  `docs/glossary.md` (seven additive rows).
+- User-visible behavior changed? no (documentation only).
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A citation or benchmark caveat reads poorly or a link rots; reversible by edit. No runtime, evidence-gate, or trust-boundary effect. |
+| Reversibility | Fully reversible; all edits are additive. |
+| Detectability | High; the test suite, `doctor`, `tokens`, and packet validation run green, and link resolution for the new page is recorded in `proof.md`. |
+| Exposure | Public docs, but additive, hedged ("their benchmarks, not promises"), and within the existing boundary wording. |
+| Uncertainty | Low; every cited source was re-verified public before inclusion; doctrine maps onto existing controls rather than inventing new ones. |
+| Why Quick is enough | No new trust boundary, dependency, permission, gate, or release effect. |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest -q`; `python tools/ng.py doctor .`;
+  `python tools/ng.py tokens .`;
+  `python tools/ng.py validate .nuclear/changes/context-window-discipline`;
+  explicit resolution check of every internal link in the new page.
+- Expected result: full suite green; doctor OK; token budget OK; this packet validates;
+  every internal link resolves.
+- Evidence link/location: `proof.md`.
+
+## Critical-action self-check
+
+- Exact target: the new page, the new source-map tier, and the five small additive edits.
+- Expected result: no existing heading asserted by `tests/test_public_docs.py` is disturbed;
+  every new internal link resolves; every external source row carries a real, re-verified
+  public URL; no benchmark number is stated as a promise.
+- Stop condition: if any edit would remove an asserted heading, introduce a broken link, an
+  unverified citation, or a compliance claim, stop and revert.
+
+## Escalation check
+
+Move up to Standard if any of these are true:
+
+- users, data, security, permissions, operations, or architecture are affected — no;
+- a trust decision about a dependency, model, or API changed — no;
+- a failure could be silent, delayed, costly, or hard to undo — no;
+- the AI had the power to write, run commands, use the network, or approve actions, beyond
+  just drafting under review — no (the agent drafted documentation, ran read-only
+  verification commands, and used web search only to verify public citations; it changed no
+  product code, held no credentials, and the merge decision stays with a human via PR
+  review, matching the accepted `runtime-enforcement-doctrine` Quick packet, also an
+  AI-prepared docs change);
+- the proof will not fit in one small `proof.md` — false.
+
+None apply. Quick stands. (If a follow-up adds validator code or a new gate, re-classify to
+Standard.)
+
+## Required links
+
+- Packet: `.nuclear/changes/context-window-discipline/`
+- Related PR/issue: Extract verified context-engineering mechanics from external research report
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md` (Tier 9)
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public graded-rigor and software-assurance concepts
+mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/docs/00-standards-foundation/source-map.md
+++ b/docs/00-standards-foundation/source-map.md
@@ -181,6 +181,32 @@ These sources direct how work is led and how teams stay honest. They do not add 
 
 ---
 
+## Tier 9 — Context-Engineering Mechanics Sources
+
+These sources shape how we budget, order, compress, and retrieve an agent's context window,
+and how we name context failure modes. They are supporting context only. The doctrine built
+from them — `docs/02-operating-system/context-window-discipline.md` — is original and
+tool-agnostic. Benchmark numbers from these papers are their claims on their benchmarks, not
+promises about any workload. No compliance claim is made.
+
+| Source | Public link | Classification | Status | Role in Nuclear-grade | Confidence | Direct repo use |
+|---|---|---:|---|---|---:|---|
+| Anthropic, Effective context engineering for AI agents | https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents | Supporting | supporting-context | Attention budget; context rot; smallest set of high-signal tokens; compaction, structured notes, sub-agents; just-in-time retrieval. | High | Concept lineage for context-window discipline and context-pack budgets; no compliance claim. |
+| LangChain context-engineering documentation | https://docs.langchain.com/oss/python/langchain/context-engineering | Supporting | supporting-context | Context lifetimes (runtime config vs per-run state vs cross-run store); write/select/compress/isolate strategies; model vs tool vs lifecycle context. | High | Lifetime-separation vocabulary in `context-window-discipline.md`; no framework dependency or compliance claim. |
+| Neo4j, What is context engineering in AI agents? A practical guide | https://neo4j.com/blog/agentic-ai/what-is-context-engineering/ | Supporting | supporting-context | Select/structure/deliver framing; traceable retrieval paths (graph traversals as citable evidence). | Medium-high | Background framing only; no graph-database dependency. |
+| Breunig, How Long Contexts Fail | https://www.dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html | Supporting | supporting-context | Failure-mode taxonomy: context poisoning, distraction, confusion, clash. | High | Failure-mode names in `context-window-discipline.md`; no compliance claim. |
+| Chroma, Context Rot research report | https://research.trychroma.com/context-rot | Supporting | supporting-context | Measured recall degradation as input token count grows, even on simple tasks. | High | Evidence behind the finite-context premise; no compliance claim. |
+| Liu et al., Lost in the Middle (arXiv 2307.03172, TACL) | https://arxiv.org/abs/2307.03172 | Supporting | verified-public | Position effects: recall is strongest at the start and end of long contexts, weakest in the middle. | High | Lineage for placement-and-ordering rules; no compliance claim. |
+| Agentic Context Engineering (ACE) (arXiv 2510.04618) | https://arxiv.org/abs/2510.04618 | Supporting | verified-public | Contexts as evolving playbooks; names brevity bias and context collapse; incremental delta updates beat wholesale rewrites. | High | Lineage for the append-only-deltas rule on durable records; no compliance claim. |
+| LLMLingua family (LLMLingua / LongLLMLingua / LLMLingua-2) | https://github.com/microsoft/LLMLingua | Supporting | supporting-context | Prompt compression up to ~20x on benchmarks with small accuracy loss; query-aware reordering for long contexts. | High | Evidence that prose compresses well; caveat lineage for compress-with-care; no tooling dependency. |
+| cAST: structural chunking via Abstract Syntax Tree (arXiv 2506.15655) | https://arxiv.org/abs/2506.15655 | Supporting | verified-public | AST-aligned chunking (one function/class per retrieval unit) improves code retrieval and generation. | High | Lineage for retrieve-code-by-structure guidance; no indexing-stack requirement. |
+| LongCodeZip (arXiv 2510.00446) | https://arxiv.org/abs/2510.00446 | Supporting | verified-public | Function/block-boundary code compression; much lower safe compression ratios for code than for prose. | High | Caveat lineage: code and exact logic are loss-sensitive under compression; no compliance claim. |
+
+These sources shape how an agent's working context is budgeted and kept honest. Nothing more.
+They add no framework, vendor, or database dependency, and no governance or compliance machinery.
+
+---
+
 ## Context-Only / Do-Not-Overweight Sources
 
 | Source family | Classification | Status | Why |

--- a/docs/02-operating-system/context-packs.md
+++ b/docs/02-operating-system/context-packs.md
@@ -16,6 +16,8 @@ role + mode + packet state + affected files + required evidence + approval gates
 
 It exists because Nuclear-grade is a way to control the raw power of an AI or LLM. Powerful agents should not get endless context and vague authority. They should get a focused packet, clear limits, and a duty to prove their work.
 
+The research grounding — why small, ordered context outperforms big context, and the named ways a context window fails — is in [`context-window-discipline.md`](context-window-discipline.md).
+
 ---
 
 ## 2. Activation threshold

--- a/docs/02-operating-system/context-window-discipline.md
+++ b/docs/02-operating-system/context-window-discipline.md
@@ -1,0 +1,182 @@
+# Context-Window Discipline
+
+**Purpose:** This file explains *why* the smallest honest context wins, names the ways an
+agent's context window fails, and maps each failure to the Nuclear-grade control that already
+answers it. It is the mechanics behind `context-packs.md` and `token-burn-control.md`.
+
+**Status:** Operating doctrine grounded in public research. The findings cited here are the
+source papers' claims on their benchmarks, not promises about your workload. No compliance
+claim is made.
+
+---
+
+## 1. Core idea
+
+A context window is a finite, degradable resource — not a bucket you fill.
+
+Public research keeps converging on the same three facts:
+
+- **Attention is a budget.** As input grows, a transformer's ability to use any one fact in
+  it shrinks. Anthropic's engineering guidance calls this the *attention budget* and frames
+  good context engineering as "the smallest possible set of high-signal tokens" that gets the
+  task done ([Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)).
+- **Recall decays with length even on easy tasks.** Chroma's *context rot* report measured
+  models degrading on simple retrieval as input token count grows
+  ([Context Rot](https://research.trychroma.com/context-rot)).
+- **Position matters.** Models use information at the start and end of a long context far
+  better than information buried in the middle
+  ([Lost in the Middle, Liu et al.](https://arxiv.org/abs/2307.03172)).
+
+Nuclear-grade already acts on this: the context pack is a deliberately small briefing, and
+the packet — not the chat transcript — is the source of truth. This page is the reasoning a
+reviewer can point to when someone asks why an agent was *not* given the whole repo.
+
+---
+
+## 2. Context lifetimes
+
+Mixing information with different lifetimes is the quiet cause of most context failures.
+Orchestration frameworks separate at least three lifetimes (see
+[LangChain's context-engineering docs](https://docs.langchain.com/oss/python/langchain/context-engineering)):
+fixed run configuration, mutable per-run state, and persistent cross-run memory.
+Nuclear-grade has a native home for each:
+
+| Lifetime | What lives there | Nuclear-grade home |
+|---|---|---|
+| Fixed for the run | Role, authority limits, forbidden actions, stop rules | Context pack header; `.nuclear/charter.md`; agent authority model |
+| Working state for one change | Intermediate results, open gaps, the resume point | The packet: `.nuclear/changes/<slug>/` |
+| Long-lived across changes | Approved baselines, lessons learned, deficiencies | `baselines`, OPEX records, the deficiency register |
+| One model call | Whatever this step actually needs | The per-phase context pack selection |
+
+Two leakage rules follow:
+
+- **Run-scoped facts do not get promoted silently.** A scratchpad conclusion becomes durable
+  only by being written into the packet with evidence, or into a lesson with a citation —
+  never by surviving in a transcript.
+- **Durable artifacts are not edited from inside a run as a side effect.** Charter and
+  baseline changes go through their own packet.
+
+---
+
+## 3. Named failure modes
+
+Practitioners have converged on a short vocabulary for how context windows fail
+([Breunig, How Long Contexts Fail](https://www.dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html);
+[Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents);
+the [ACE paper](https://arxiv.org/abs/2510.04618)). Name the failure, and the existing
+control that answers it becomes obvious:
+
+| Failure mode | What it looks like | Nuclear-grade control |
+|---|---|---|
+| Context poisoning | A hallucinated or wrong "fact" lands in context early and gets re-cited as if verified. | Evidence status labels; "confidence is not a source"; the Observe step writes only *verified, cited* facts back to the packet. |
+| Context distraction | History grows so long the agent fixates on its own transcript instead of the task. | Mission anchor in the context pack; compaction into the packet; "single next action" framing. |
+| Context confusion | Too many tools or irrelevant documents in scope; the agent picks the wrong one. | Minimal authority: the pack lists what the agent may read, edit, and run — and what to ignore. |
+| Context clash | Two sources in context contradict each other and the agent oscillates or loops. | Precedence is explicit (charter > pack > transcript); conflicts halt work and surface as a question, not a guess. |
+| Context rot | Slow quality decay as tokens accumulate across turns. | Context budgets by mode; the packet, not the transcript, is the unit of truth; refresh the pack on phase change. |
+| Context collapse | Iterative re-summarizing of a long-lived document erodes its detail until the useful content is gone. | Durable records grow by **appended, discrete entries** (lessons, deficiencies, decisions), never by wholesale rewrites. |
+| Brevity bias | Compression keeps the fluent prose and drops the load-bearing specifics (commands, limits, exact wording). | Proof commands, authority boundaries, and boundary wording are linked or quoted exactly — never paraphrased to save tokens. |
+
+*Context collapse* and *brevity bias* are the two named by the Agentic Context Engineering
+(ACE) paper, which found that contexts maintained by **incremental delta updates** — small,
+itemized additions and corrections — outperform contexts maintained by repeated full
+rewrites ([arXiv 2510.04618](https://arxiv.org/abs/2510.04618)). That is the same shape as
+this repo's lessons-learned discipline: append the entry, cite the evidence, leave the rest
+of the record alone.
+
+---
+
+## 4. Placement and ordering
+
+Because position affects recall (section 1), the order of a context pack is part of its
+correctness:
+
+- **Stable content first.** Role, charter excerpts, and authority limits lead. This also
+  makes prompt caching effective, since the static prefix does not churn.
+- **Hard constraints at the edges.** Forbidden actions and stop rules belong near the start
+  or the end — never buried in the middle of retrieved material.
+- **The next action last.** The pack schema already ends with `Next action:`; keep it there.
+  The last thing the model reads should be the one thing it must do.
+- **Retrieved evidence in the middle, trimmed.** The middle is the lowest-attention zone, so
+  it gets the material that is supporting, not governing.
+
+---
+
+## 5. Compress with care
+
+A summary is a claim like any other: it asserts "nothing load-bearing was dropped." Treat it
+that way.
+
+- Compression of redundant natural-language prose is well supported — the LLMLingua family
+  reports up to ~20x compression with small accuracy loss on its benchmarks
+  ([microsoft/LLMLingua](https://github.com/microsoft/LLMLingua)).
+- Code and exact logic are far more loss-sensitive. Code-aware methods compress along
+  function and block boundaries and report much lower safe ratios (~5.6x for
+  [LongCodeZip](https://arxiv.org/abs/2510.00446)) than prose methods.
+- Some things are never compressed, only linked or quoted exactly: proof commands, evidence
+  links, authority limits, legal and boundary wording, and anything a validator checks.
+
+When you compact a long thread into a packet, record what the compaction dropped ("details of
+the abandoned approach are in the PR thread, not carried forward") so the loss is a decision,
+not an accident.
+
+---
+
+## 6. Retrieving code by structure
+
+When an agent must pull code into context, retrieval units should match the units developers
+reason in:
+
+- **Chunk by syntax, not by lines.** Splitting on fixed token windows slices functions in
+  half; AST-based chunking (one function or class per retrieval unit) measurably improves
+  retrieval and downstream generation ([cAST](https://arxiv.org/abs/2506.15655)).
+- **Prefer just-in-time retrieval over pre-loading.** Loading "everything that might matter"
+  spends the attention budget before work starts; fetching on demand keeps the working set
+  small ([Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)).
+- **Combine search modes.** Lexical search catches exact identifiers and stack traces that
+  embeddings miss; semantic search catches concepts that grep misses. Use both before
+  trusting either.
+
+This repo stays tool-agnostic: these are selection rules for whoever builds the pack, not a
+required indexing stack.
+
+---
+
+## 7. Multi-agent state hygiene
+
+When more than one agent works a change:
+
+- **Reads fan out; writes funnel in.** Any agent may read the shared packet, but one
+  designated owner writes updates back. Parallel writers are how packets get corrupted and
+  how context clash is manufactured.
+- **Hand off by turnover, not by transcript.** The incoming agent gets a fresh context pack
+  and restates objective, authority, required evidence, and stop criteria — it does not
+  inherit a poisoned or rotted history.
+- **Close the loop each cycle.** After a tool acts, extract the verified fact with its
+  citation and write it to the packet; discard the raw output. The packet stays small and
+  clean while the transcript is allowed to be messy and disposable.
+
+---
+
+## 8. Exit criteria
+
+You are practicing context-window discipline when:
+
+1. Every agent briefing names what to read **and what to ignore**.
+2. Facts enter durable records only with evidence attached (no poisoning path).
+3. Long-lived records grow by appended deltas, not rewrites (no collapse path).
+4. Proof commands and boundary wording are never paraphrased (no brevity-bias path).
+5. Constraints sit at the edges of the prompt and the next action sits last.
+6. A handoff replaces the transcript instead of forwarding it.
+
+---
+
+## Source-lineage note
+
+This page is an original Nuclear-grade operating doctrine. It draws on public
+context-engineering sources — Anthropic's engineering guidance, LangChain's
+context-engineering documentation, Neo4j's practical guide, Breunig's failure-mode taxonomy,
+Chroma's context-rot report, and the Lost-in-the-Middle, ACE, LLMLingua, cAST, and
+LongCodeZip papers — mapped in
+[`../00-standards-foundation/source-map.md`](../00-standards-foundation/source-map.md)
+(Tier 9). Benchmark numbers quoted here are those papers' claims on their benchmarks. This
+page creates no compliance, certification, or fitness claim.

--- a/docs/02-operating-system/token-burn-control.md
+++ b/docs/02-operating-system/token-burn-control.md
@@ -4,6 +4,8 @@
 
 **Thesis:** More rigor should cut down on costly back-and-forth, not pile up prompt clutter. The packet is the line that bounds the context.
 
+This is not just cost control: model recall measurably degrades as context grows, so the smallest honest context is also the most reliable one. The evidence and the failure-mode names are in [`context-window-discipline.md`](context-window-discipline.md).
+
 ---
 
 ## Context rule

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 | Place authority and declare intent | [`02-operating-system/authority-and-intent.md`](02-operating-system/authority-and-intent.md) |
 | Scale rigor by risk tier | [`02-operating-system/risk-tiers-and-modes.md`](02-operating-system/risk-tiers-and-modes.md) |
 | See how controls enforce, not just advise | [`02-operating-system/runtime-enforcement.md`](02-operating-system/runtime-enforcement.md) |
+| Budget and order an agent's context window | [`02-operating-system/context-window-discipline.md`](02-operating-system/context-window-discipline.md) |
 | Classify the kind of change (work type) | [`02-operating-system/work-type-lens.md`](02-operating-system/work-type-lens.md) |
 | Run an incident, track deficiencies | [`02-operating-system/incident-response.md`](02-operating-system/incident-response.md), [`02-operating-system/deficiency-register.md`](02-operating-system/deficiency-register.md) |
 | Understand CLI behavior | [`05-reference/cli-reference.md`](05-reference/cli-reference.md) |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,6 +20,13 @@ Plain-language decoding of Nuclear-grade terms and idioms. The skills and docs u
 | Turnover | Handing unfinished work to another agent or person with state, remaining scope, authority limits, and open evidence. |
 | Context pack | A focused briefing for an agent: role, authority, evidence obligations, forbidden actions, stop conditions. |
 | Source lineage | A note saying which public sources influenced a concept, without claiming compliance with them. |
+| Attention budget | The finite capacity a model has to use what is in its context window; every token spends some of it. |
+| Context rot | Slow decay in a model's recall and focus as its context window fills up across turns. |
+| Context poisoning | A wrong or hallucinated "fact" enters the context early and keeps getting cited as if verified. |
+| Context confusion | Too many tools or irrelevant documents in scope, so the agent picks the wrong one. |
+| Context clash | Two sources in the context contradict each other and the agent oscillates or loops. |
+| Context collapse | Re-summarizing a long-lived document over and over until its useful detail is gone. |
+| Brevity bias | Compression that keeps fluent prose but drops the load-bearing specifics (commands, limits, exact wording). |
 
 ## Idioms used in the skills
 


### PR DESCRIPTION
## What this does

Extracts the verifiable core of an external "Nuclear-Grade Context Engineering: A Technical Blueprint for Enterprise Agentic Workflows" research report into repo doctrine. Every citation was independently re-verified against a public URL before inclusion — the report itself cited only two distinct public pages (repeated as [1]–[7]) and carried several unverifiable numbers, so extraction followed the repo's own `checking-source-claims` discipline.

## What was added

- **`docs/02-operating-system/context-window-discipline.md`** (new) — the mechanics behind the existing context-pack and token-burn doctrine:
  - why small, ordered context outperforms big context (attention budget, context rot, lost-in-the-middle), with linked public evidence;
  - context lifetimes (fixed-for-the-run / per-change state / long-lived memory / one model call) mapped to existing repo homes, with two leakage rules;
  - seven named failure modes — poisoning, distraction, confusion, clash, rot, collapse, brevity bias — each mapped to the existing Nuclear-grade control that answers it;
  - placement/ordering rules (constraints at the edges, next action last, stable prefix first);
  - compress-with-care rules (a summary is a claim; code is loss-sensitive; never paraphrase proof commands or boundary wording);
  - structure-aware code retrieval and multi-agent state hygiene (reads fan out, writes funnel in; hand off by turnover, not transcript).
- **`source-map.md` Tier 9** — Context-Engineering Mechanics Sources: Anthropic, LangChain docs, Neo4j guide, Breunig, Chroma context-rot report, Lost in the Middle (arXiv 2307.03172), ACE (arXiv 2510.04618), microsoft/LLMLingua, cAST (arXiv 2506.15655), LongCodeZip (arXiv 2510.00446). All re-verified 2026-06-10.
- **Cross-links**: one index row in `docs/README.md`, one grounding sentence each in `context-packs.md` and `token-burn-control.md`, seven plain-language glossary rows.
- **Quick packet** `.nuclear/changes/context-window-discipline/` (risk + proof).

## What was deliberately NOT adopted from the report

- Per-tool "context waste" percentages (Aider 4.3–6.5%, Cursor ~14.7%, Cline ~17.5%) — no traceable public source.
- "Forward-Deployed Context Engineer" / GCC enterprise-talent framing — marketing, not engineering.
- The report's specific ACE efficiency percentages and garbled formula fragments — replaced with the papers' own hedged headline claims.
- Vendor-specific middleware patterns — the doctrine stays tool-agnostic.

## Evidence

- `python -m pytest` → 142 passed
- `python -m ruff check .` → clean
- `python tools/ng.py doctor .` / `tokens .` → OK
- `python tools/ng.py validate .nuclear/changes/context-window-discipline` → OK
- 33 internal links across the five touched docs all resolve

All edits to existing files are additive; no code, validator, gate, or permission change.

https://claude.ai/code/session_017kB6USqNcnk9wFXN4BmzHt

---
_Generated by [Claude Code](https://claude.ai/code/session_017kB6USqNcnk9wFXN4BmzHt)_