### PR TITLE
Add an official-directory listing guide

### DIFF
--- a/.nuclear/changes/list-in-official-directories/proof.md
+++ b/.nuclear/changes/list-in-official-directories/proof.md
@@ -1,0 +1,54 @@
+# Quick Proof Record
+
+## Proof summary
+
+- Change slug: list-in-official-directories
+- Proof owner: FlyFission (Ben Huffer)
+- Date/time: 2026-06-16
+- Risk record: `risk.md`
+
+## Claim proven
+
+> The listing doc records accurate steps, and the change keeps the repo green and submission-ready.
+
+Claim: the new listing/discovery doc captures verified submission steps, the repo still passes all gates, and the Claude plugin still validates.
+
+## Method
+
+- Command/check/eval/review: `pytest`, `ruff check .`, `ng doctor .`, `ng tokens .`, `ng validate .nuclear/changes/list-in-official-directories`, and `claude plugin validate .`.
+- Environment: Python 3.12 in the repo checkout; Claude Code CLI 2.1.178.
+- Inputs/fixtures: the repo at branch claude/listing-and-discovery (cut from current main).
+- Expected result: all green; the plugin validates.
+- Self-check used? yes; target: only the three documentation files change.
+
+## Result
+
+- Status: pass
+- Actual result: full suite green; ruff clean; doctor OK; token budget OK; this packet validates; `claude plugin validate .` passes.
+- Evidence link or artifact path: the listing PR's CI checks plus the local run recorded here.
+- If failed/gap: not applicable.
+
+## Reviewer note
+
+- Reviewer: FlyFission (listing PR review)
+- Review note: documentation-only addition; the directory submission itself is a manual owner action.
+- Is Quick mode still valid after proof? yes.
+
+## Required links
+
+- Related PR/issue: the official-directory listing PR (branch claude/listing-and-discovery)
+- Relevant changed files: `docs/04-adoption/listing-and-discovery.md`, `docs/04-adoption/README.md`, `INTEGRATIONS.md`
+- CI run / test output / eval report / screenshot / log: the listing PR's checks
+- If AI-assisted: link to AI scope or independent check note: see the listing PR description
+
+## Exit criteria
+
+- The evidence matches the claim in `risk.md` directly.
+- The actual result is compared to the expected result you named before the proof.
+- The result status is stated plainly.
+- Any failure or gap has a next action or an escalation.
+- The reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on software test documentation, verification, work records, and keeping the approved version under control, mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/list-in-official-directories/risk.md
+++ b/.nuclear/changes/list-in-official-directories/risk.md
@@ -1,0 +1,85 @@
+# Quick Risk Record
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** docs-only, additive, reversible; no code, dependency, security, or release-stance change.
+
+**Purpose:** Decide whether a small change can safely stay in Quick mode, and name the proof it needs.
+
+**Activation threshold:** Use for low-stakes changes you can undo and check easily, with no new line of user trust, no dependency trust decision, no effect on security or privacy, no change in release stance, and no change in AI power.
+
+**Minimum useful version:** Fill the short fields below. If any answer feels uncertain, move up to Standard.
+
+**Overhead trap:** Do not write a risk essay for a tiny diff. The goal is to catch hidden reasons to escalate, not to run a full design review.
+
+---
+
+## Change
+
+- Slug: list-in-official-directories
+- PR / issue: the official-directory listing PR (branch claude/listing-and-discovery)
+- Owner: FlyFission (Ben Huffer)
+- Date: 2026-06-16
+- Summary: Add `docs/04-adoption/listing-and-discovery.md` (verified steps to submit to the Claude Code community directory and the openai/skills catalog) and link it from the adoption README and `INTEGRATIONS.md`.
+
+## Scope
+
+- Affected files/configs/docs: `docs/04-adoption/listing-and-discovery.md` (new), `docs/04-adoption/README.md`, `INTEGRATIONS.md`.
+- User-visible behavior changed? no; documentation only.
+- Dependency/model/API/prompt/tool permission changed? no.
+- Release or rollback posture changed? no.
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | a doc lists a stale submission step; a reader follows an outdated link |
+| Reversibility | high; revert the doc |
+| Detectability | high; links and steps are checkable against the linked official sources |
+| Exposure | documentation only; no code or runtime surface |
+| Uncertainty | low; both directory processes were verified first-hand this session |
+| Why Quick is enough | additive docs with no code, dependency, security, or release change |
+
+## Required proof
+
+- Command/check/eval to run: full `pytest`, `ruff check .`, `ng doctor .`, `ng tokens .`, `ng validate` on this packet, and `claude plugin validate .`.
+- Expected result: all green; the plugin validates.
+- Evidence link/location: `proof.md`.
+
+## Critical-action self-check
+
+Use only if the Quick change could hit the wrong target.
+
+- Exact target: the three documentation files listed under Scope.
+- Expected result: only docs change; no code or manifest behavior changes.
+- Stop condition: stop if any non-doc file would change.
+
+## Escalation check
+
+Move up to Standard if any of these are true:
+
+- users, data, security, permissions, operations, or architecture are affected;
+- a trust decision about a dependency, model, or API changed;
+- a failure could be silent, delayed, costly, or hard to undo;
+- the AI had the power to write, run commands, use the network, or approve actions, beyond just drafting;
+- the proof will not fit in one small `proof.md`.
+
+None apply: this is additive documentation.
+
+## Required links
+
+- Packet: `.nuclear/changes/list-in-official-directories/`
+- Related PR/issue: the official-directory listing PR (branch claude/listing-and-discovery)
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md`
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade record inspired by public ideas on matching rigor to stakes, keeping the approved version under control (CM), software assurance, and secure development, mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -78,6 +78,15 @@ The cross-tool `skills` CLI also installs into these tools:
 npx skills add FlyFission/nuclear-grade-context-engineering
 ```
 
+## Get listed in official directories
+
+Beyond installing from this repo, you can submit to official directories so others discover
+the skills. See [`docs/04-adoption/listing-and-discovery.md`](docs/04-adoption/listing-and-discovery.md)
+for the verified, step-by-step process. The two worth pursuing today are the **Claude Code
+community directory** (`claude plugin validate` already passes, so the repo is
+submission-ready) and the **`openai/skills`** catalog; the MCP Registry is deferred and VS
+Code/Copilot need full extension repackaging.
+
 ## Profiles and token cost
 
 - `--core` (default): the always-first `using-nuclear-grade` router plus the

--- a/docs/04-adoption/README.md
+++ b/docs/04-adoption/README.md
@@ -5,6 +5,7 @@ Most adopters should start one level up at [`../../CORE.md`](../../CORE.md) — 
 - `enterprise-rollout.md`
 - `agent-authority-model.md` — includes the self-modification boundary and the enforcement rung-ladder for agents with authority over their own working set.
 - `reviewer-playbook.md`
+- `listing-and-discovery.md` — how to submit the skills to official directories (the Claude Code community directory and the `openai/skills` catalog).
 
 ## Source-lineage note
 

--- a/docs/04-adoption/listing-and-discovery.md
+++ b/docs/04-adoption/listing-and-discovery.md
@@ -1,0 +1,68 @@
+# Listing and discovery
+
+How to get the Nuclear-grade skills into official, discoverable directories — beyond
+installing from this repo with `ng install` (see [`../../INTEGRATIONS.md`](../../INTEGRATIONS.md)).
+
+Two directories are worth submitting to today; the rest are deferred or not a fit. Steps
+marked **(repo)** are done here in this repository; steps marked **(you)** are manual
+actions only a repository owner can take — a web form, or a PR to a repo this project does
+not control.
+
+## Claude Code — community plugin directory
+
+Highest reach, lowest effort: this repo is already a valid Claude plugin marketplace.
+
+- **(repo, done)** `claude plugin validate .` passes — the same validation the review
+  pipeline runs — so no code change is needed to be submission-ready.
+- **(you)** Submit at <https://platform.claude.com/plugins/submit> (individual authors, via
+  the Console) or through claude.ai admin settings (Team/Enterprise). Choose a category in
+  the form. Directory: <https://github.com/anthropics/claude-plugins-community>.
+- After review and automated safety screening, the plugin is mirrored to the community
+  marketplace; users then install with:
+
+  ```bash
+  /plugin marketplace add anthropics/claude-plugins-community
+  /plugin install nuclear-grade@claude-community
+  ```
+
+## OpenAI Codex — openai/skills catalog
+
+Community skills live in `skills/.experimental/<name>/` and install by URL; OpenAI may
+later promote them to the curated tier. Codex reads only `name` + `description` for
+routing, and the flagship skill already complies.
+
+- **(you)** Fork <https://github.com/openai/skills>, then add a folder:
+
+  ```text
+  skills/.experimental/using-nuclear-grade/
+  ├── SKILL.md      # copy this repo's skills/using-nuclear-grade/SKILL.md (already compliant)
+  └── LICENSE.txt   # copy this repo's MIT LICENSE
+  ```
+
+- **(you)** Open a PR to `openai/skills` describing the skill and linking back here.
+- Start with the single router skill — it is the entry point. Follow up with the Core 7 if
+  it gets traction; submitting all skills at once fits their per-skill catalog poorly.
+
+> This project's tooling cannot open that PR for you — `openai/skills` is outside its
+> repository scope, so the fork and PR are your steps.
+
+## Deferred / not a fit
+
+- **MCP Registry** (registry.modelcontextprotocol.io, `mcp-publisher`): viable for the
+  optional MCP server, but it needs a published package (e.g. on PyPI) plus namespace
+  ownership and is still in preview. Revisit once the package is published.
+- **VS Code Marketplace**: requires repackaging as a full VS Code *extension* (`vsce`), not
+  skill files — out of proportion for this.
+- **GitHub Copilot**: no clear public submission path for standalone skills as of writing.
+
+## Verify before you submit
+
+- Re-confirm the Claude form's fields and the `openai/skills` layout against current docs;
+  both ecosystems move quickly.
+- `claude plugin validate .` should still pass at submission time.
+
+## Source-lineage note
+
+This page records the public submission processes of third-party directories, captured from
+their official docs and linked above. It makes no compliance, certification, or assurance
+claim; see [`../../DISCLAIMER.md`](../../DISCLAIMER.md).


### PR DESCRIPTION
**Docs-only** follow-up to the merged #42, now on a clean branch cut from current `main` (the earlier #45 was conflicted because it reused the squash-merged branch; closing that in favor of this).

## What
- **`docs/04-adoption/listing-and-discovery.md`** — the verified, step-by-step process to get the skills into official directories, with a clear **repo-step vs owner-step** split:
  - **Claude Code community directory** (`anthropics/claude-plugins-community`): `claude plugin validate .` already passes (the same check the review pipeline runs), so the repo is submission-ready. Submission is the owner's form at platform.claude.com.
  - **`openai/skills` `.experimental/`**: fork + add `skills/.experimental/using-nuclear-grade/{SKILL.md,LICENSE.txt}` + PR. The flagship skill's frontmatter is already compliant.
  - MCP Registry deferred; VS Code/Copilot skipped (need full extension repackaging) — each with a reason.
- Linked from `docs/04-adoption/README.md` and a new "Get listed in official directories" section in `INTEGRATIONS.md`.

## Notes
- No code or manifest change was needed — `claude plugin validate .` passes as-is.
- The two submissions themselves (a web form and a PR to `openai/skills`) are **owner actions outside this project's tool scope**; this PR makes the repo ready and records the exact steps.
- Dogfooded as a **Quick** `.nuclear/changes/list-in-official-directories/` record (docs-only, additive).

## Verification
`ruff` clean, full `pytest` green, `ng doctor .` + `ng tokens .` OK, the packet validates, and `claude plugin validate .` passes.

https://claude.ai/code/session_014aWJKkyps7Z7M4VFiy6yfY

---
_Generated by [Claude Code](https://claude.ai/code/session_014aWJKkyps7Z7M4VFiy6yfY)_