### PR TITLE
Positioning compass and high-consequence builder entry point

### DIFF
--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -1,0 +1,105 @@
+# What Nuclear-grade is for
+
+This page settles a question the project kept dodging: who is this for, what does
+it compete on, and what would keep it relevant in five years instead of leaving it
+buried under a faster tool.
+
+It is a working compass, not a marketing page. When a decision about scope, audience,
+or voice comes up, this page breaks the tie.
+
+## The short version
+
+Nuclear-grade is the ported discipline for building software when getting it wrong
+causes real harm and cannot be quietly undone. It starts with the people who already
+live by that standard: engineers in nuclear and other high-consequence fields who are
+now using AI agents to build software and tools. It is written so any engineer can
+take one habit and use it that day.
+
+The discipline is the product. The repo is how the discipline travels.
+
+## What it refuses to compete on
+
+There is a loud race in AI-assisted coding. It runs under a new name every year:
+prompt engineering, then context engineering, then loop engineering, then harness
+engineering. The race is always the same thing underneath. Get the agent to produce
+more, faster, with less human watching.
+
+Nuclear-grade does not run that race. That race belongs to the model labs and the
+tool vendors who own the surface the agent runs on. They have more money, more
+distribution, and a new release every few weeks. Anyone trying to out-build them on
+speed loses, and deserves to.
+
+We work a different axis. Not how much the agent produces, but whether you can stand
+behind what it shipped. As the agent gets cheaper and faster, that question grows more
+valuable, not less. And one fact does not soften as models improve: liability never
+transfers to the model. When an unattended agent ships something that hurts someone,
+the vendor is not the one who answers for it. A person is. That is the ground this
+project stands on, and no model release moves it.
+
+## Who it is for, in three rings
+
+**Ring 1, the core.** People building software and AI tools in fields where a mistake
+reaches the physical world or the public trust. Nuclear first, because that is where
+the author worked and where the standard is already in the blood. Also aerospace,
+medical devices, energy, industrial control, regulated finance: anywhere a bad change
+is worse than a rollback. This ring is small, and it is the source of everything. The
+credibility, the real workflows, and the language all come from here. If the work is
+not undeniable to this ring, nothing downstream is real.
+
+**Ring 2, the middle.** Enterprise and regulated software in general. Teams that have
+to answer to an auditor, a customer, or a court for what their code does. They do not
+carry high-consequence culture by instinct, but they carry the same liability. The
+core's discipline generalizes to them one step out.
+
+**Ring 3, the edge.** Any engineer, any builder, anyone curious. They get value by
+taking a single habit, the questioning attitude, proof before a claim, a named release
+decision, and using it on an ordinary Tuesday. They are not the target. They are the
+wake the boat leaves. The influence reaches them because the core made it credible,
+not because the project aimed at them.
+
+The order is the whole strategy. Depth at the core earns reach at the edge. Run it
+backwards, write for everyone first, and the one thing that makes this project
+distinct, a real high-consequence pedigree, gets thrown away. What is left is generic
+safety content competing with better-funded voices, and it loses.
+
+## What this means in practice
+
+- Spend the scarce effort at the core. One undeniable worked example from inside a
+  high-consequence build is worth more than ten generic ones.
+- Package on-ramps for the edge. Do not rewrite the substance for it. The quickstart,
+  the starter kit, and single-skill entry points let an outsider take one piece without
+  the whole system. They are doors, not a second product.
+- Frame each habit as something that lets you move faster because you can trust the
+  output, never as a tax that slows you down. A discipline that only slows people down
+  gets routed around by everyone who is not already under a regulator's eye.
+- Say no to edge-first content even when it would get more attention this week. That
+  restraint is the strategy, not a side effect of it.
+
+## How we know it is working
+
+- The core ring forks it. People building high-consequence AI tools copy these
+  workflows and skills into their own repos and adapt them. That is how a real standard
+  starts: from the bottom, in a field that needs it, not from a press release.
+- The vocabulary spreads on its own. When someone outside the core says "prove the
+  claim" or "name the release decision" without knowing where it came from, the
+  influence ring is working.
+- The author's field treats it as native. If a nuclear engineer building software reads
+  this and says "this is one of us, and this is the playbook I did not have," the core
+  is real.
+
+What we do not count as success: raw stars, broad reach, or how many people who will
+never face real consequence skimmed the README. Those are vanity if the core is hollow.
+
+## The boundary holds
+
+Naming a high-consequence audience raises the bar on honesty. It does not grant the
+project authority it does not have. Everything here stays inside
+[`DISCLAIMER.md`](DISCLAIMER.md): Nuclear-grade is an educational, public-source
+project. It is not a compliance framework, not certification, not a safety case, and
+not a substitute for qualified engineering, legal, security, or safety review.
+
+## Source-lineage note
+
+This positioning describes where an original, public-source-inspired project is aimed.
+It is not a promise to meet any external standard. See
+[`DISCLAIMER.md`](DISCLAIMER.md) and [`ROADMAP.md`](ROADMAP.md).

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -31,10 +31,11 @@ speed loses, and deserves to.
 
 We work a different axis. Not how much the agent produces, but whether you can stand
 behind what it shipped. As the agent gets cheaper and faster, that question grows more
-valuable, not less. And one fact does not soften as models improve: liability never
-transfers to the model. When an unattended agent ships something that hurts someone,
-the vendor is not the one who answers for it. A person is. That is the ground this
-project stands on, and no model release moves it.
+valuable, not less. And one thing does not change as models improve: accountability for
+the work stays with the people and the organization that put the agent to work. It does
+not pass to the model. When an unattended agent ships something that causes harm, the
+team that ran it still owns the result. That is the ground this project stands on, and
+no model release moves it.
 
 ## Who it is for, in three rings
 

--- a/docs/01-field-guide/for-high-consequence-builders.md
+++ b/docs/01-field-guide/for-high-consequence-builders.md
@@ -1,0 +1,120 @@
+# For Builders in High-Consequence Fields
+
+**Purpose:** Speak to the engineer in nuclear, aerospace, medical, energy, industrial
+control, or regulated finance who is now using AI agents to build software and tools.
+This is the entry point written in your language. The mechanics live in the linked
+Core and operating-system docs; this page is the reason to walk through that door.
+
+**Boundary.** This is an original software-workflow translation. It does not create
+compliance, formal assurance, safety, security, certification, or regulatory adequacy,
+and it does not reproduce any proprietary manual or standard. See
+[`../../DISCLAIMER.md`](../../DISCLAIMER.md).
+
+---
+
+## You already carry the standard
+
+You work somewhere a mistake does not stay on the screen. A bad change can injure a
+person, defeat a barrier that was supposed to hold, fail a procedure in the middle of
+an event, or invalidate a safety case that took a year and a team to build. So you
+already run habits most software teams never had to learn. You question the thing that
+looks fine. You prove a claim before you rely on it. You keep the approved version
+under control. You refuse to let the standard slip one quiet step at a time.
+
+Now you are building software with AI agents. The agent writes files, runs commands,
+calls tools, swaps a dependency, and drafts the evidence for its own work. It moves
+faster than the review habits you built for human-paced work. That speed is the whole
+opportunity and the whole hazard, and they arrive together.
+
+## The one failure mode to watch
+
+Complex systems rarely fail in one loud step. They fail when authority outruns
+evidence, one reasonable-looking shortcut at a time. You have seen this in the physical
+world. AI agents reproduce it in software, faster, because the agent holds real
+authority over the work and very little ceremony stands between intent and action.
+
+Three shapes it takes:
+
+- **A check the agent can edit is not a control.** If the agent has write access to the
+  test, the prompt, the CI script, or the approval rule that decides whether its work is
+  acceptable, it can satisfy the check by changing the check. Move the gate outside the
+  agent's writable set. See
+  [`../04-adoption/agent-authority-model.md`](../04-adoption/agent-authority-model.md).
+- **An unattended loop makes mistakes unattended.** Running an agent on a schedule with
+  no one reading is the software version of an unmonitored evolution. The point of
+  splitting the agent that does the work from the agent that checks it is to make "it is
+  done" mean something. See
+  [`../../skills/proving-claims/SKILL.md`](../../skills/proving-claims/SKILL.md).
+- **A green pipeline is not a release decision.** CI passing says the checks that exist
+  did not fail. It does not say ship. A release decision names the residual risk, the
+  rollback, the monitoring, and what would force you to pull it back. See
+  [`../../skills/checking-release-readiness/SKILL.md`](../../skills/checking-release-readiness/SKILL.md).
+
+## What to actually do
+
+The full system is large. You do not need most of it to start. Run the same loop you
+already run in the field, ported to AI-speed software. Five moves, in order:
+
+1. **Plan.** Before the agent builds, ask the question that decides everything: what
+   does this change have to prove, and what single fact would change your decision?
+   ([`questioning-attitude`](../../skills/questioning-attitude/SKILL.md))
+2. **Run.** Let the agent move fast while the work is cheap and reversible. Exploration
+   is supposed to be cheap. Spend nothing guarding a draft you will throw away.
+3. **Observe.** Weigh the evidence the agent produced against the claim it is making.
+   Every claim maps to evidence, a named gap, or an explicit non-claim. Treat agent
+   output as a hypothesis to be proven, never as authority.
+   ([`proving-claims`](../../skills/proving-claims/SKILL.md))
+4. **Verdict.** Decide on purpose. Ship, block, defer, or ship with a named risk, and
+   stand behind it. This is the step the system never lets you fold away, the same
+   instinct as signing the work in your field.
+   ([`checking-release-readiness`](../../skills/checking-release-readiness/SKILL.md))
+5. **Educate.** Ship, then learn from how it runs. Every surprise, near miss, escaped
+   bug, or bad handoff should change a control: a test, a template, a prompt, a monitor,
+   or a baseline. A lesson that changes nothing disappears.
+   ([`learning-from-experience`](../../skills/learning-from-experience/SKILL.md))
+
+Match the rigor to the stakes. Thirty seconds of thought on a throwaway edit. A full
+change record when the work becomes a promise someone will rely on. The decision matrix
+in [`../../CORE.md`](../../CORE.md) tells you which is which.
+
+## Where the field instinct helps, and where it misleads
+
+The discipline ports well. The reflexes do not all transfer cleanly, and pretending
+they do is its own hazard.
+
+- **Do not formalize everything.** The instinct to put a procedure on every task will
+  tax cheap, reversible work until your team routes around the whole system. Keep the
+  ceremony for the promise. Stay light where failure is cheap.
+- **An agent is not a qualified operator.** Its confident "I intend to..." is a proposal
+  to review, not evidence it understood, and it can be steered by a prompt injected in a
+  file or page it read. Review the reasoning. Verify independently, ideally with a
+  different model or a fresh context, because a same-model second pass inherits the same
+  blind spots.
+- **Automation bias is the dominant risk, not under-delegation.** "A human watches the
+  agent" decays into rubber-stamp review unless that human has real time, real
+  authority, and a real decision criterion. Design the gate so a tired reviewer still
+  catches the thing that matters.
+- **The name is the standard of care, not the vocabulary.** If "nuclear-grade" would
+  mis-calibrate your team, rename the local copy. Keep the discipline. See
+  [`../../DISCLAIMER.md`](../../DISCLAIMER.md).
+
+## Start here
+
+- Read the [`Core 7 and the decision matrix`](../../CORE.md). That is the whole working
+  spine on one page.
+- Open the worked example for giving an agent write and API authority:
+  [`../03-worked-examples/ai-agent-tool-permissions/`](../03-worked-examples/ai-agent-tool-permissions/).
+  It ships passing evidence for the claim that matters most and names the gaps still
+  open.
+- If you also lead a team running this work, read
+  [`leadership-and-high-reliability.md`](leadership-and-high-reliability.md) for the
+  operating-culture translation.
+
+---
+
+## Source-lineage note
+
+This page turns public ideas from high-consequence engineering into an original,
+software-native workflow. It is concept lineage, mapped in
+[`../00-standards-foundation/source-map.md`](../00-standards-foundation/source-map.md).
+It does not reproduce or claim to meet any source document or standard.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 
 | Need | Start |
 |---|---|
+| Build in a high-consequence field (nuclear, aerospace, medical, energy) | [`01-field-guide/for-high-consequence-builders.md`](01-field-guide/for-high-consequence-builders.md) |
 | Pick a starter set (adopt lightly) | [`../CORE.md`](../CORE.md) |
 | Try the workflow | [`../QUICKSTART.md`](../QUICKSTART.md) |
 | Install or initialize | [`../INSTALL.md`](../INSTALL.md) |
@@ -35,7 +36,7 @@ These docs have two parts. First, learn how to use the workflow. Second, look up
 
 ```text
 00-standards-foundation/   public source map, citation safety, and boundary rules
-01-field-guide/            source-to-concept translation, leadership and high-reliability guide
+01-field-guide/            source-to-concept translation, high-consequence builder entry point, leadership and high-reliability guide
 02-operating-system/       lifecycle, HPI overlays, modes, packets, authority and intent, incidents, deficiencies, periodic self-assessment, critical systems
 03-worked-examples/        completed example packets and proof chains
 04-adoption/               team rollout, agent authority, reviewer playbook


### PR DESCRIPTION
## Why

A response to a strategy question: how does this project stay relevant and differentiated as the AI-coding conversation keeps renaming the same throughput race (prompt → context → loop → harness engineering)? The conclusion: don't run that race. Compete on whether you can stand behind what an agent shipped, anchored in an audience that already lives by that standard.

These two docs commit that strategy on paper before any marketing, so scope and voice stop getting pulled toward a broad, low-credibility audience the project can't win.

## What's here

- **`POSITIONING.md`** (root) — the working compass. Defines what the project is for, the axis it refuses to compete on, the three-ring audience model (high-consequence core → regulated enterprise → any engineer), what that means in practice, and how we'd know it's working. Breaks ties on scope and voice.
- **`docs/01-field-guide/for-high-consequence-builders.md`** — the beachhead entry point, written for engineers in nuclear, aerospace, medical, energy, and industrial control who are now building with AI agents. Frames the failure mode (authority outrunning evidence at AI speed) and the PROVE loop in their language, with honest notes on where the field instinct misleads. Maps to existing Core skills.
- **`docs/README.md`** — wires the new field-guide piece into the docs index.

All internal links verified to resolve. No claims beyond the existing `DISCLAIMER.md` boundary.

## Open questions for review

- Is the three-ring model the right commitment, or too restrictive on the broad audience?
- Tone check on the high-consequence piece: native to the field, or overreaching?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc5jei7yUSYhzEErsFiaC5)_