### PR TITLE
docs: sharpen context and scope boundaries

### DIFF
--- a/.nuclear/changes/sharpen-scope-boundaries/proof.md
+++ b/.nuclear/changes/sharpen-scope-boundaries/proof.md
@@ -1,0 +1,67 @@
+# Quick Proof Record
+
+**Purpose:** Capture the smallest believable evidence record for this Quick documentation change.
+
+**Activation threshold:** Use with `risk.md` because the change is low-stakes, easy to undo, easy to check, and does not trip Standard mode.
+
+**Minimum useful version:** one proof command, the result, an evidence link, and a reviewer note.
+
+**Overhead trap:** Do not paste long logs. Link to the evidence and quote only the result that matters.
+
+---
+
+## Proof summary
+
+- Change slug: `sharpen-scope-boundaries`
+- Proof owner: Hermes Agent
+- Date/time: 2026-07-01
+- Risk record: `risk.md`
+
+## Claim proven
+
+Claim: The README now adds only narrow scope-sharpening language, and the Quick change packet is complete enough for the repository validator.
+
+## Method
+
+- Command/check/eval/review: inspect `git diff`; run `git diff --check`; run `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries`
+- Environment: WSL checkout at `/mnt/e/Hermes/03_Projects/nuclear-grade-context-engineering`, branch `docs/sharpen-scope-boundaries`
+- Inputs/fixtures: `README.md`, `.nuclear/changes/sharpen-scope-boundaries/risk.md`, `.nuclear/changes/sharpen-scope-boundaries/proof.md`
+- Expected result: Diff is limited to README plus this Quick packet; whitespace check passes; validator returns OK.
+- Self-check used? yes; target if yes: stop if the diff touches code, templates, permissions, dependencies, or release posture.
+- Reproducible by the reviewer (command/artifact), not just the author's narration? yes; rerun the commands above from the repo root.
+
+## Result
+
+- Status: pass
+- Actual result: `git diff --check` returned no whitespace errors; `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries` returned `OK: .nuclear/changes/sharpen-scope-boundaries`.
+- Evidence link or artifact path: this `proof.md`; terminal command output from `git diff --check` and `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries`
+- If failed/gap: not applicable.
+
+## Reviewer note
+
+- Reviewer: human reviewer or PR reviewer
+- Review note: Review the README wording for sharpness: it should reduce scope creep, not invite a broader runtime/framework build-out.
+- Is Quick mode still valid after proof? yes
+
+## Required links
+
+- Related PR/issue: not opened yet
+- Relevant changed files: `README.md`, `.nuclear/changes/sharpen-scope-boundaries/risk.md`, `.nuclear/changes/sharpen-scope-boundaries/proof.md`
+- CI run / test output / eval report / screenshot / log: local validation commands above
+- If AI-assisted: this Quick packet records scope, target, and proof; independent reviewer can rerun commands and inspect diff.
+
+## Final validation note
+
+Final local check passed: `git diff --check` returned no whitespace errors, and `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries` returned `OK: .nuclear/changes/sharpen-scope-boundaries`.
+
+## Exit criteria
+
+- The evidence matches the claim in `risk.md` directly.
+- The actual result is compared to the expected result named before the proof.
+- The result status is stated plainly.
+- Any failure or gap has a next action or an escalation.
+- The reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade template inspired by public ideas on software test documentation, verification, work records, and keeping the approved version under control, mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/.nuclear/changes/sharpen-scope-boundaries/risk.md
+++ b/.nuclear/changes/sharpen-scope-boundaries/risk.md
@@ -1,0 +1,85 @@
+# Quick Risk Record
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** README-only wording update that narrows scope and clarifies boundaries; easy to review and revert; no code, dependency, security, release, permission, or runtime behavior changes.
+
+**Purpose:** Keep the repository sharp by making minimum sufficient context and runtime/tooling boundaries explicit.
+
+**Activation threshold:** Low-stakes public documentation change with a clear proof path: inspect the diff and run the repository validator on this Quick packet.
+
+**Minimum useful version:** This record names the changed files, the scope boundary, and the proof commands.
+
+**Overhead trap:** Keep this record short; the change exists to reduce framework creep, not create more process around it.
+
+---
+
+## Change
+
+- Slug: `sharpen-scope-boundaries`
+- PR / issue: not opened yet
+- Owner: Hermes Agent
+- Date: 2026-07-01
+- Summary: Add concise README language for minimum sufficient context, agent context files as operating-envelope items, and a clear boundary that the repo is not an agent runtime/task manager/approval/observability platform.
+
+## Scope
+
+- Affected files/configs/docs: `README.md`, `.nuclear/changes/sharpen-scope-boundaries/risk.md`, `.nuclear/changes/sharpen-scope-boundaries/proof.md`
+- User-visible behavior changed? no
+- Dependency/model/API/prompt/tool permission changed? no
+- Release or rollback posture changed? no
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | Confusing or over-broad README wording; reversible by editing/removing the paragraphs. |
+| Reversibility | High; single docs diff can be reverted. |
+| Detectability | High; reviewers can inspect the exact README diff. |
+| Exposure | Public docs only; no code/runtime effect. |
+| Uncertainty | Low; requested change is scope/wording clarification aligned with prior discussion. |
+| Why Quick is enough | The change reduces claims and scope rather than adding authority, dependencies, or behavior. |
+
+## Required proof
+
+- Command/check/eval to run: `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries`; `git diff --check`
+- Expected result: Quick packet validates; diff has no whitespace errors.
+- Evidence link/location: `proof.md`
+
+## Critical-action self-check
+
+Use only if the Quick change could hit the wrong target.
+
+- Exact target: `README.md` and this Quick packet only.
+- Expected result: Docs clarify scope without changing CLI/templates/workflows.
+- Stop condition: Any code, template, command, permission, dependency, or release-posture change appears in the diff.
+
+## Escalation check
+
+Move up to Standard if any of these are true:
+
+- users, data, security, permissions, operations, or architecture are affected;
+- a trust decision about a dependency, model, or API changed;
+- a failure could be silent, delayed, costly, or hard to undo;
+- the AI had the power to write, run commands, use the network, or approve actions, beyond just drafting;
+- the proof will not fit in one small `proof.md`.
+
+None are true for this docs-only boundary clarification.
+
+## Required links
+
+- Packet: `.nuclear/changes/sharpen-scope-boundaries/`
+- Related PR/issue: not opened yet
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: not invoked; no new source-lineage or compliance claim added.
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade template inspired by public ideas on matching rigor to stakes, keeping the approved version under control (CM), software assurance, and secure development, mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The discipline is borrowed from how high-consequence engineering is run: questio
 
 An agent can try ideas and throw them away cheaply, so let it. But the rules tighten as soon as the work turns into a claim, a file you have to keep under control, a public statement, an approved version, a release call, or a change to what the agent is allowed to do.
 
+**Minimum sufficient context.** Nuclear-grade is not about adding more process. It is about giving agents the smallest set of instructions, facts, limits, and evidence needed to do serious work without drifting into vibes. If a rule, template field, or artifact does not improve execution, verification, review, or decision quality, remove it.
+
 So the first question is the one that matters most: **what does this change have to prove, and what fact would change my decision?**
 
 That question has a shape, and the shape has a name.
@@ -180,7 +182,7 @@ One caution this loop has to defend against on purpose: the agent that builds th
 
 ## Keeping the approved version under control
 
-You already have git, CI, and branch protection. Keep them; this rides on top, it does not replace them. What they do not give you is the *decision*: a green pipeline says the suite passed on some commit, not that a human weighed the leftover risk and chose to ship, and not what would force a re-check. And they were never aimed at the things that now drive an AI system's behavior: the prompts, the model IDs, the eval sets, the agent's own permissions. Git versions your code; none of it records *why this is the version you trust*.
+You already have git, CI, and branch protection. Keep them; this rides on top, it does not replace them. What they do not give you is the *decision*: a green pipeline says the suite passed on some commit, not that a human weighed the leftover risk and chose to ship, and not what would force a re-check. And they were never aimed at the things that now drive an AI system's behavior: the prompts, the model IDs, the eval sets, the agent's own permissions. Agent context files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, Copilot instructions, skills, and prompt templates are part of the operating envelope; changing them is not documentation-only when it changes how an agent may act. Git versions your code; none of it records *why this is the version you trust*.
 
 A **baseline** closes that gap. It is the version everyone agreed is correct, plus the evidence behind the agreement. Changes never edit the baseline directly; they go through evidence and a decision first, and only an accepted change becomes the new baseline. That is configuration management, in one loop:
 
@@ -334,6 +336,8 @@ Two tools also have native plugin packages: **Claude Code** (the repo is its own
 ## What this is NOT
 
 Nuclear-grade is not a compliance program, a certification, a regulated quality-assurance system, a safety analysis, a production sandbox, a regulatory submission, legal advice, or a substitute for qualified engineering, legal, security, safety, or compliance review.
+
+It is also not an agent runtime, task manager, approval system, sandbox, observability platform, or replacement for the tools that already run your work. It provides the minimum records and review discipline that can sit above those tools.
 
 It does not claim that any system is safe, secure, compliant, approved, certified, or fit for regulated use.
 


### PR DESCRIPTION
## Summary
- Add a concise “Minimum sufficient context” principle to protect the repo from process creep
- Clarify that agent context files and prompt/skill templates are operating-envelope items when they change agent behavior
- Add an explicit boundary that Nuclear-grade is not an agent runtime, task manager, approval system, sandbox, or observability platform
- Record the docs-only change in a Quick packet

## Verification
- `git diff --check`
- `python tools/ng.py validate .nuclear/changes/sharpen-scope-boundaries`

## Notes
This is intentionally small: it sharpens the repo’s scope without adding a new workflow, runtime surface, or management layer.
