### PR TITLE
docs: add trigger-based skill loading rule

### DIFF
--- a/.nuclear/changes/agents-skill-loading-rule/basis.md
+++ b/.nuclear/changes/agents-skill-loading-rule/basis.md
@@ -1,0 +1,54 @@
+# Basis — agents-skill-loading-rule
+
+## Decision basis
+
+Today's daily 1% cron recommended a small `AGENTS.md` simplification: make skill loading selective so Nuclear-grade does not feel like a giant checklist. The recommendation was based on external AGENTS.md/context-file research and the current target repo state.
+
+## Relevant facts
+
+- `AGENTS.md` currently has a flat 17-item recommended-skills list.
+- The repo's sharpness goal is minimum discipline that lets agents do serious work without turning every change into vibes.
+- Skill loading is part of context engineering: more context is not automatically better.
+- The existing default behavior and authority boundaries already contain important escalation safeguards.
+
+## Alternatives considered
+
+| Alternative | Decision | Reason |
+|---|---|---|
+| Do nothing | Rejected | Leaves the flat list open to checklist interpretation. |
+| Group skills under trigger headings | Rejected after review | Could create new mini-checklists or imply groups are exclusive modes. |
+| Add one short skill-loading rule and keep the list flat | Accepted | Smallest change that addresses the issue while preserving all links. |
+| Add eval README or Copilot instructions too | Deferred | Valuable candidates, but would expand this PR beyond one 1% move. |
+
+## Independent review inputs
+
+- Codex CLI: supported a short trigger-based rule and warned not to load whole groups.
+- Claude CLI: warned grouping and skip-reason requirements could add bloat; recommended one sentence/short section above the flat list.
+- AGY CLI: unavailable due account `PERMISSION_DENIED`; fallback red-team review emphasized trigger screening before minimization and safeguards for ambiguous triggers.
+
+## Decision
+
+Add a concise `## Skill loading rule` section to `AGENTS.md`, keep all recommended skills present, and do not add grouping or new artifacts beyond this packet.
+
+## Open gaps
+
+- No behavioral eval proves agents will load fewer or better skills after this wording change.
+- The PR relies on reviewer judgment and future agent behavior observation.
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Independent review notes: local CLI output files under `/tmp/nuclear-grade-*-review.out` during implementation
+
+## Exit criteria
+
+- The guidance update is limited to the skill-loading rule.
+- Existing skill links remain present.
+- Validation commands pass locally.
+- The PR body states residual gaps and the human maintainer owns the merge decision.
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/.nuclear/changes/agents-skill-loading-rule/plan.md
+++ b/.nuclear/changes/agents-skill-loading-rule/plan.md
@@ -1,0 +1,81 @@
+# Plan — agents-skill-loading-rule
+
+## Goal
+
+Sharpen `AGENTS.md` so agents treat the recommended skills as a routing aid, not a checklist, and load the smallest useful skill set only after screening for real triggers.
+
+## Value check
+
+Today's daily 1% cron found that repository-level agent instruction files can add cost and confusion when they carry unnecessary requirements. In this repo, the flat 17-item recommended-skills list can be misread as “load everything.” The valuable update is not a new workflow; it is a short rule that keeps skill loading evidence-driven.
+
+## Non-goals
+
+- Do not add new skills.
+- Do not add a new agent runtime, command, hook, or template family.
+- Do not add `.github/copilot-instructions.md` or `evals/README.md` in this PR.
+- Do not rewrite the whole agent policy.
+- Do not overclaim based on one research paper or one cron run.
+
+## Initial proposal
+
+The first proposal was to add a skill-loading rule and group the existing skills under three trigger headings.
+
+## Independent review input received
+
+- **Codex CLI independent review:** keep the short skill-loading rule; make it trigger-based; add “not a checklist”; avoid extra scope.
+- **Claude CLI adversarial review:** avoid grouping because it may create new mini-checklists; do not require agents to document every skipped skill; keep the flat list and add one sharp rule.
+- **AGY CLI red-team attempt:** `agy models` returned `PERMISSION_DENIED (code 403)`, and print mode returned no review text. Because the requested CLI was unavailable, a fallback red-team subagent reviewed the plan and warned against letting “smallest useful” become a reason to skip escalation or evidence.
+
+## Incorporated approach
+
+Use the simpler version:
+
+1. Add one `## Skill loading rule` section before `## Recommended skills`.
+2. Keep the current skill list flat.
+3. Say skills are loaded by trigger, not inventory.
+4. Require trigger screening before minimizing.
+5. State that the list is a routing aid, not a checklist.
+6. Preserve a hard guardrail: if a trigger is present or ambiguous, load the matching skill or state the specific evidence showing why it is not needed.
+
+## Files expected to change
+
+- `AGENTS.md`
+- `.nuclear/changes/agents-skill-loading-rule/risk.md`
+- `.nuclear/changes/agents-skill-loading-rule/basis.md`
+- `.nuclear/changes/agents-skill-loading-rule/plan.md`
+- `.nuclear/changes/agents-skill-loading-rule/trace.md`
+- `.nuclear/changes/agents-skill-loading-rule/verification.md`
+- `.nuclear/changes/agents-skill-loading-rule/ship.md`
+
+## Validation plan
+
+- Inspect `git diff` to confirm the change is limited to `AGENTS.md` and this packet.
+- Run `git diff --check`.
+- Run `python tools/ng.py validate .nuclear/changes/agents-skill-loading-rule`.
+- Run `python tools/ng.py doctor .`.
+
+## Acceptance criteria
+
+- `AGENTS.md` makes trigger-based skill loading explicit.
+- Existing skill links remain present.
+- The change reduces checklist behavior without weakening escalation, evidence, or trust-boundary safeguards.
+- Packet validation passes.
+- PR body names the cron source, review inputs, and validation commands.
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Independent review notes: local CLI output files under `/tmp/nuclear-grade-*-review.out` during implementation
+
+## Exit criteria
+
+- The guidance update is limited to the skill-loading rule.
+- Existing skill links remain present.
+- Validation commands pass locally.
+- The PR body states residual gaps and the human maintainer owns the merge decision.
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/.nuclear/changes/agents-skill-loading-rule/risk.md
+++ b/.nuclear/changes/agents-skill-loading-rule/risk.md
@@ -1,0 +1,64 @@
+# Risk — agents-skill-loading-rule
+
+## Selected mode
+
+- **Mode:** Standard
+- **Why this mode:** This is a small Markdown change, but it changes `AGENTS.md`, a controlled agent-guidance file that can affect how agents select safeguards. Standard mode is warranted because the change touches AI behavior and evidence discipline.
+
+## Change
+
+- Slug: `agents-skill-loading-rule`
+- Owner: Hermes Agent
+- Date: 2026-07-01
+- Summary: Add a short rule telling agents to load skills by trigger, not by inventory, and to minimize only after screening for risk/evidence/escalation triggers.
+
+## Risk statement
+
+The current flat recommended-skills list may be read as a checklist to load wholesale. That can increase context, cost, and process feel. The opposite failure is also possible: a “smallest skill set” rule could become a license to skip safeguards before understanding the work.
+
+## Scope
+
+- Affected files: `AGENTS.md` and this change packet.
+- Controlled item changed: repo-level agent guidance.
+- Runtime/code behavior changed: no.
+- Public claim/compliance posture changed: no.
+- Dependency/model/API/tool permission changed: no.
+- Release posture changed: no.
+
+## Must not break
+
+- Agents must still screen for trust boundaries, public claims, release decisions, incidents, hard-to-reverse steps, and evidence needs.
+- Existing recommended skill links must remain present.
+- The change must not add a new workflow, new artifact family, or new runtime surface.
+- The wording must not imply that confidence or familiarity is a reason to skip evidence.
+
+## Main failure modes
+
+| Failure mode | Control |
+|---|---|
+| Agents load the whole skill list by default | State that the list is a routing aid, not a checklist. |
+| Agents under-load safeguards | Require trigger screening before minimizing. |
+| Agents use “smallest useful” to skip escalation | If a trigger is present or ambiguous, load the matching skill or state specific evidence showing why it is not needed. |
+| Change becomes process-heavy | Keep the AGENTS.md edit to one short section and keep the skill list flat. |
+
+## Escalation check
+
+No code, dependency, credential, network, production-facing, release, or compliance claim changes are included. The reason this remains Standard rather than Quick is the controlled agent-guidance impact.
+
+## Exit criteria
+
+- Diff is limited to `AGENTS.md` and the packet.
+- `git diff --check` passes.
+- Packet validation passes.
+- `python tools/ng.py doctor .` passes.
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Source map: `docs/00-standards-foundation/source-map.md`
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/.nuclear/changes/agents-skill-loading-rule/ship.md
+++ b/.nuclear/changes/agents-skill-loading-rule/ship.md
@@ -1,0 +1,55 @@
+# Ship — agents-skill-loading-rule
+
+## Decision
+
+Planned for PR review.
+
+## Release decision
+
+Defer to human maintainer. This PR is ready to be considered after local validation and CI pass, but merge is not approved by the agent.
+
+## Evidence status
+
+- Local validation: planned in `verification.md`.
+- Independent review: Codex and Claude CLI input received; AGY CLI unavailable; fallback red-team review completed.
+- CI: to be run by GitHub after PR is opened.
+
+## Residual risk
+
+- The wording may still be interpreted too permissively or too broadly; reviewer should inspect whether it preserves escalation safeguards without becoming another checklist.
+- There is no behavioral eval for skill-loading quality in this PR.
+
+## Rollback
+
+Revert the `AGENTS.md` section and this packet if the wording increases confusion or causes agents to under-load safeguards.
+
+## Monitoring / follow-up
+
+Watch future agent PRs and cron outputs for either failure mode:
+
+- agents loading all skills by default;
+- agents skipping needed safeguards under the “smallest useful” rationale.
+
+If either appears, update `AGENTS.md` with a tighter trigger table or add a small eval case.
+
+## Apply clearance
+
+This PR changes documentation and agent guidance only. Merge decision belongs to the human maintainer after PR review and CI.
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Independent review notes: local CLI output files under `/tmp/nuclear-grade-*-review.out` during implementation
+
+## Exit criteria
+
+- The guidance update is limited to the skill-loading rule.
+- Existing skill links remain present.
+- Validation commands pass locally.
+- The PR body states residual gaps and the human maintainer owns the merge decision.
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/.nuclear/changes/agents-skill-loading-rule/trace.md
+++ b/.nuclear/changes/agents-skill-loading-rule/trace.md
@@ -1,0 +1,48 @@
+# Trace — agents-skill-loading-rule
+
+## Change trace
+
+| Requirement / risk | Implementation | Evidence |
+|---|---|---|
+| Make skills trigger-based, not inventory-based | Added `## Skill loading rule` to `AGENTS.md` | `AGENTS.md` diff |
+| Prevent under-loading safeguards | Rule says to screen for risk, evidence, decision-rights, public-claim, trust-boundary, handoff, release, incident, or hard-to-reverse triggers before minimizing | `AGENTS.md` diff |
+| Avoid a new checklist | Rule says the list is a routing aid, not a checklist; existing list remains flat | `AGENTS.md` diff |
+| Keep existing skill links | No recommended skill links removed | `git diff` review |
+| Keep the PR small | No new skills, commands, runtime features, eval README, or Copilot instructions added | `git diff --stat` |
+
+## Review trace
+
+| Reviewer | Input incorporated |
+|---|---|
+| Codex CLI | Added “trigger, not inventory” / “routing aid, not checklist” framing. |
+| Claude CLI | Dropped the grouping idea and avoided requiring documentation of every skipped skill. |
+| AGY CLI | Attempted, but unavailable with account permission error. |
+| Fallback red-team review | Added trigger screening before minimization and ambiguity guardrail. |
+
+## Files changed
+
+- `AGENTS.md`
+- `.nuclear/changes/agents-skill-loading-rule/risk.md`
+- `.nuclear/changes/agents-skill-loading-rule/basis.md`
+- `.nuclear/changes/agents-skill-loading-rule/plan.md`
+- `.nuclear/changes/agents-skill-loading-rule/trace.md`
+- `.nuclear/changes/agents-skill-loading-rule/verification.md`
+- `.nuclear/changes/agents-skill-loading-rule/ship.md`
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Independent review notes: local CLI output files under `/tmp/nuclear-grade-*-review.out` during implementation
+
+## Exit criteria
+
+- The guidance update is limited to the skill-loading rule.
+- Existing skill links remain present.
+- Validation commands pass locally.
+- The PR body states residual gaps and the human maintainer owns the merge decision.
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/.nuclear/changes/agents-skill-loading-rule/verification.md
+++ b/.nuclear/changes/agents-skill-loading-rule/verification.md
@@ -1,0 +1,49 @@
+# Verification — agents-skill-loading-rule
+
+## Claims to verify
+
+| Claim | Status | Evidence |
+|---|---|---|
+| Diff is limited to `AGENTS.md` and this packet | planned | `git diff --stat` |
+| No whitespace errors | planned | `git diff --check` |
+| Packet validates | planned | `python tools/ng.py validate .nuclear/changes/agents-skill-loading-rule` |
+| Repo wiring remains healthy | planned | `python tools/ng.py doctor .` |
+
+## Commands
+
+```bash
+git diff --stat
+git diff --check
+python tools/ng.py validate .nuclear/changes/agents-skill-loading-rule
+python tools/ng.py doctor .
+```
+
+## Results
+
+- `git diff --stat`: `AGENTS.md | 4 ++++` plus this change packet.
+- `git diff --check`: passed with no whitespace errors.
+- `python tools/ng.py validate .nuclear/changes/agents-skill-loading-rule`: `OK: .nuclear/changes/agents-skill-loading-rule`.
+- `python tools/ng.py doctor .`: `OK: Nuclear-grade doctor`.
+
+## Known gaps
+
+- No automated behavioral eval measures whether future agents load fewer or better skills.
+- Reviewer judgment is required to decide whether the wording is sharp enough and not too permissive.
+
+## Required links
+
+- Packet: `.nuclear/changes/agents-skill-loading-rule/`
+- Changed guidance: `AGENTS.md`
+- Daily cron source: job `35dfea877788`, 2026-07-01 output
+- Independent review notes: local CLI output files under `/tmp/nuclear-grade-*-review.out` during implementation
+
+## Exit criteria
+
+- The guidance update is limited to the skill-loading rule.
+- Existing skill links remain present.
+- Validation commands pass locally.
+- The PR body states residual gaps and the human maintainer owns the merge decision.
+
+## Source-lineage note
+
+This change is informed by the daily repo-scouting output and external AGENTS.md/context-file research cited there. It stays within the repo's public source-lineage boundaries in `docs/00-standards-foundation/source-map.md` and makes no compliance, certification, safety, security, regulatory, or formal QA claim.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ Agents must not assume they may:
 - treat their own confidence or a fluent intent statement as evidence, or rubber-stamp another agent's output as an independent check;
 - overwrite change records or templates without saying so.
 
+## Skill loading rule
+
+Load skills by trigger, not by inventory. First screen the work for risk, evidence, decision-rights, public-claim, trust-boundary, handoff, release, incident, or hard-to-reverse triggers. Then load the smallest skill set that can change the action, evidence, gate, decision right, claim wording, or handoff. The list below is a routing aid, not a checklist; do not load the whole list just because it is listed. If a trigger is present or ambiguous, load the matching skill or state the specific evidence showing why it is not needed. Confidence is not evidence.
+
 ## Recommended skills
 
 - `skills/questioning-attitude/SKILL.md`


### PR DESCRIPTION
## Summary
- Add a short `AGENTS.md` skill-loading rule: load skills by trigger, not by inventory
- Keep the existing recommended-skills list flat, but clarify it is a routing aid, not a checklist
- Add a Standard change packet because `AGENTS.md` is controlled agent guidance

## Daily cron source
This implements today's best 1% move from the daily research cron: make `AGENTS.md` reduce checklist behavior and preserve minimum sufficient context.

## Independent review input
- **Codex CLI:** supported the short trigger-based rule and recommended “routing aid, not checklist” wording.
- **Claude CLI:** adversarially warned that grouping skills could create new mini-checklists, so this PR keeps the flat list.
- **AGY CLI:** attempted, but the local AGY account returned `PERMISSION_DENIED (code 403)` / no print-mode output. I documented that in `plan.md` and used a fallback red-team review focused on under-loading safeguards.

## Verification
```bash
git diff --check
python tools/ng.py validate .nuclear/changes/agents-skill-loading-rule
python tools/ng.py doctor .
```

Results:
- `OK: .nuclear/changes/agents-skill-loading-rule`
- `OK: Nuclear-grade doctor`

## Residual risks or gaps
- No behavioral eval proves the new wording will improve skill routing; this is a small guidance improvement to observe in future agent work.
- Reviewer should check that the rule prevents checklist loading without letting agents skip escalation, evidence, or trust-boundary safeguards.
