### PR TITLE
Sharpen agent control-flow doctrine: hold point and pre-fetch complement

### DIFF
--- a/.nuclear/changes/glean-agent-control-flow/proof.md
+++ b/.nuclear/changes/glean-agent-control-flow/proof.md
@@ -1,0 +1,70 @@
+# Quick Proof Template
+
+**Purpose:** Capture the smallest believable evidence record for a Quick change.
+
+**Activation threshold:** Use with `risk.md` when a change is low-stakes, easy to undo, easy to check, and does not trip Standard mode.
+
+**Minimum useful version:** one proof command, check, or eval; the result; an evidence link; and a reviewer note.
+
+**Overhead trap:** Do not paste long logs. Link to the evidence and quote only the result that matters.
+
+---
+
+## Proof summary
+
+- Change slug: glean-agent-control-flow
+- Proof owner: FlyFission
+- Date/time: 2026-07-03
+- Risk record: `risk.md`
+
+## Claim proven
+
+> The three doctrine refinements are additive, internally linked, source-grounded, and pass every repo gate; no external source is named in the changed files.
+
+Claim: The two applied value-adds (decision→action hold point; pre-fetch complement) and the reinforcing skill edit keep the full test suite, doctor, token budget, and structural validation green, and introduce no reference to the external material that prompted the review.
+
+## Method
+
+- Command/check/eval/review: `python -m pytest tests/`; `python tools/ng.py doctor`; `python tools/ng.py tokens`; `python tools/ng.py validate .nuclear/changes/glean-agent-control-flow`; plus a diff grep for external-source names.
+- Environment: repo checkout on the change's working branch; Python 3.11; pytest 9.1.1.
+- Inputs/fixtures: the working-tree diff to `runtime-enforcement.md`, `context-window-discipline.md`, `double-checking-before-acting/SKILL.md`, and this packet.
+- Expected result: suite passes; doctor OK; token budget OK; packet validates; grep of the changed doctrine/skill files returns no external-source name.
+- Self-check used? yes; target: the three files named in `risk.md` Scope.
+- Reproducible by the reviewer (command/artifact), not just the author's narration? yes; the commands above are deterministic and run in CI (`.github/workflows/ci.yml`).
+
+## Result
+
+- Status: pass
+- Actual result: all gates green, itemized below.
+  - `pytest tests/` → **186 passed, 1 skipped**.
+  - `ng doctor` → **OK: Nuclear-grade doctor**.
+  - `ng tokens` → **OK: token budget** (edited skill `double-checking-before-acting` within budget; no violation).
+  - `ng validate .nuclear/changes/glean-agent-control-flow` → passes once `proof.md` is present.
+  - Diff grep of the changed doctrine and skill files → no external-source name present (the only in-tree occurrences of the string are the git-assigned branch name, kept out of committed file text).
+- Evidence link or artifact path: CI run on the working branch; commands reproducible locally.
+- If failed/gap: none.
+
+## Reviewer note
+
+- Reviewer: pending human review
+- Review note: Confirm both additions read as native doctrine and refine rather than duplicate; confirm the "Review scope" table's already-covered mappings are accurate.
+- Is Quick mode still valid after proof? yes — no Standard trigger surfaced during the change.
+
+## Required links
+
+- Related PR/issue: the working branch for this change
+- Relevant changed files: `docs/02-operating-system/runtime-enforcement.md`, `docs/02-operating-system/context-window-discipline.md`, `skills/double-checking-before-acting/SKILL.md`
+- CI run / test output / eval report / screenshot / log: `python -m pytest tests/` (186 passed, 1 skipped); `.github/workflows/ci.yml`
+- If AI-assisted: this change was drafted by an agent under review; the proof commands are independently reproducible by a human reviewer.
+
+## Exit criteria
+
+- The evidence matches the claim in `risk.md` directly.
+- The actual result is compared to the expected result you named before the proof.
+- The result status is stated plainly.
+- Any failure or gap has a next action or an escalation.
+- The reviewer can decide whether the Quick change is acceptable without reading unrelated docs.
+
+## Source-lineage note
+
+Original Nuclear-grade proof record. It documents test, structural-validation, and token evidence for an additive doctrine change grounded in public sources mapped in `docs/00-standards-foundation/source-map.md`. No compliance claim is made.

--- a/.nuclear/changes/glean-agent-control-flow/proof.md
+++ b/.nuclear/changes/glean-agent-control-flow/proof.md
@@ -41,7 +41,7 @@ Claim: The two applied value-adds (decision→action hold point; pre-fetch compl
   - `ng tokens` → **OK: token budget** (edited skill `double-checking-before-acting` within budget; no violation).
   - `ng validate .nuclear/changes/glean-agent-control-flow` → passes once `proof.md` is present.
   - Diff grep of the changed doctrine and skill files → no external-source name present (the only in-tree occurrences of the string are the git-assigned branch name, kept out of committed file text).
-- Evidence link or artifact path: CI run on the working branch; commands reproducible locally.
+- Evidence link or artifact path: the changed files (`docs/02-operating-system/runtime-enforcement.md`, `docs/02-operating-system/context-window-discipline.md`, `skills/double-checking-before-acting/SKILL.md`) and this packet, on PR #58; CI on that PR ran `.github/workflows/ci.yml` jobs `validate (3.11)`, `validate (3.12)`, `mcp-smoke`, and `wheel-smoke`, all green. Commands are reproducible locally.
 - If failed/gap: none.
 
 ## Reviewer note
@@ -52,7 +52,7 @@ Claim: The two applied value-adds (decision→action hold point; pre-fetch compl
 
 ## Required links
 
-- Related PR/issue: the working branch for this change
+- Related PR/issue: #58
 - Relevant changed files: `docs/02-operating-system/runtime-enforcement.md`, `docs/02-operating-system/context-window-discipline.md`, `skills/double-checking-before-acting/SKILL.md`
 - CI run / test output / eval report / screenshot / log: `python -m pytest tests/` (186 passed, 1 skipped); `.github/workflows/ci.yml`
 - If AI-assisted: this change was drafted by an agent under review; the proof commands are independently reproducible by a human reviewer.

--- a/.nuclear/changes/glean-agent-control-flow/risk.md
+++ b/.nuclear/changes/glean-agent-control-flow/risk.md
@@ -18,7 +18,7 @@
 ## Change
 
 - Slug: glean-agent-control-flow
-- PR / issue: the working branch for this change
+- PR / issue: #58
 - Owner: FlyFission
 - Date: 2026-07-03
 - Summary: A review of public agent-engineering practice was screened for value-adds against the existing method. Only two items survived as genuinely additive; both are folded into existing doctrine and map to already-cited sources. (1) Name the **decision→action hold point** — the interval between an agent selecting an action and committing it — as the canonical location for an out-of-band gate. (2) Add **pre-fetch as the bounded complement to just-in-time retrieval**. Everything else reviewed was already covered by existing controls (see Review scope).
@@ -77,7 +77,7 @@ None of the Standard triggers are tripped: no users, data, security, permissions
 ## Required links
 
 - Packet: `.nuclear/changes/glean-agent-control-flow/`
-- Related PR/issue: the working branch for this change
+- Related PR/issue: #58
 - Proof record: `proof.md`
 - Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md` (DOE-HDBK-1028, Tier 1; Anthropic context-engineering, Tier 9)
 

--- a/.nuclear/changes/glean-agent-control-flow/risk.md
+++ b/.nuclear/changes/glean-agent-control-flow/risk.md
@@ -1,0 +1,92 @@
+# Quick Risk Template
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** Additive doctrine refinements to existing pages; reversible, no code, dependency, charter, or behavior change. Escalate to Standard if a reviewer judges the adoption consequence warrants a full basis/trace.
+
+**Purpose:** Decide whether a small change can safely stay in Quick mode, and name the proof it needs.
+
+**Activation threshold:** Use for low-stakes changes you can undo and check easily, with no new line of user trust, no dependency trust decision, no effect on security or privacy, no change in release stance, and no change in AI power.
+
+**Minimum useful version:** Fill the short fields below. If any answer feels uncertain, move up to Standard.
+
+**Overhead trap:** Do not write a risk essay for a tiny diff. The goal is to catch hidden reasons to escalate, not to run a full design review.
+
+---
+
+## Change
+
+- Slug: glean-agent-control-flow
+- PR / issue: the working branch for this change
+- Owner: FlyFission
+- Date: 2026-07-03
+- Summary: A review of public agent-engineering practice was screened for value-adds against the existing method. Only two items survived as genuinely additive; both are folded into existing doctrine and map to already-cited sources. (1) Name the **decision→action hold point** — the interval between an agent selecting an action and committing it — as the canonical location for an out-of-band gate. (2) Add **pre-fetch as the bounded complement to just-in-time retrieval**. Everything else reviewed was already covered by existing controls (see Review scope).
+
+## Scope
+
+- Affected files/configs/docs: `docs/02-operating-system/runtime-enforcement.md`, `docs/02-operating-system/context-window-discipline.md`, `skills/double-checking-before-acting/SKILL.md`
+- User-visible behavior changed? no
+- Dependency/model/API/prompt/tool permission changed? no
+- Release or rollback posture changed? no
+
+## Quick-mode screen
+
+| Question | Answer |
+|---|---|
+| Consequence if wrong | A doctrine paragraph misleads a reader; caught in review, reverted in one diff |
+| Reversibility | Full — additive prose; a single revert restores prior text |
+| Detectability | High — visible in the diff and rendered docs; link and contract tests run in CI |
+| Exposure | Public repo; adopters read the doctrine, but no interface or behavior changes |
+| Uncertainty | Low — both additions refine existing prose and map to already-mapped sources |
+| Why Quick is enough | Additive, reversible, no code/dependency/charter/behavior change; no Standard trigger tripped |
+
+## Required proof
+
+- Command/check/eval to run: `python -m pytest tests/`; `python tools/ng.py doctor`; `python tools/ng.py tokens`; `python tools/ng.py validate .nuclear/changes/glean-agent-control-flow`; and a diff grep confirming no external source is named.
+- Expected result: full suite passes; doctor and token budget green; packet validates; new internal links resolve; grep returns nothing.
+- Evidence link/location: `proof.md`
+
+## Review scope
+
+Screened against the existing method; each item below was found **already covered**, so it was
+deliberately not re-added (the same "skip what's covered" discipline as the
+`glean-nuclear-leadership` packet):
+
+| Reviewed idea | Already lives in |
+|---|---|
+| Own your prompts | `owning-prompts` skill; configuration management of prompts |
+| Own your context window | `context-window-discipline.md`, `context-packs.md` |
+| Tools as structured outputs / decouple decision from execution | tool and skill design; `validators.md` |
+| Unify execution and business state / stateless append-only thread | packet-as-source-of-truth; `agent-trace-evidence.md`; append-only-deltas rule |
+| Launch / pause / resume; trigger from anywhere | `handing-off-work`, turnover, outer-loop triggers |
+| Contact humans as a structured request | `declaring-intent`, `deciding-who-decides` |
+| Bounded self-correction on error / stop the retry loop | `staying-on-mission` / `ng-drift-check` (counted 3-attempt loop → stop) |
+| Small, focused agents | small-mission-work; `modes.md`; work-breakdown |
+
+## Critical-action self-check
+
+- Exact target: the three files named under Scope.
+- Expected result: additive-only diffs; all gates green.
+- Stop condition: any test, link, or validation failure halts the change rather than triggering a retry.
+
+## Escalation check
+
+None of the Standard triggers are tripped: no users, data, security, permissions, operations, or architecture are affected; no dependency/model/API trust decision changed; no failure path is silent, delayed, costly, or hard to undo; the AI only drafted doctrine prose; the proof fits in one `proof.md`.
+
+## Required links
+
+- Packet: `.nuclear/changes/glean-agent-control-flow/`
+- Related PR/issue: the working branch for this change
+- Proof record: `proof.md`
+- Relevant source-map/crosswalk if invoked: `docs/00-standards-foundation/source-map.md` (DOE-HDBK-1028, Tier 1; Anthropic context-engineering, Tier 9)
+
+## Exit criteria
+
+- The mode is justified as Quick.
+- The required proof is named before or during the change.
+- No trigger for Standard or Nuclear mode is hidden.
+
+## Source-lineage note
+
+Original Nuclear-grade change record. The two applied refinements draw on public human-performance hold-point and self-checking practice (DOE-HDBK-1028-2009) and public context-engineering guidance, both mapped in `docs/00-standards-foundation/source-map.md` and `docs/01-field-guide/source-to-concept-crosswalk.md`. No compliance claim is made.

--- a/docs/02-operating-system/context-window-discipline.md
+++ b/docs/02-operating-system/context-window-discipline.md
@@ -140,8 +140,8 @@ reason in:
   absolute. When a specific input is known in advance to be required, fetching it
   deterministically up front removes a model round-trip and keeps the transcript clean, rather
   than spending a turn asking the model to request what you already knew it would. The test is
-  *certainty*: pre-fetch the known, retrieve the uncertain on demand — the hybrid Anthropic's
-  guidance describes, not a return to pre-loading "everything that might matter." Record a
+  *certainty*: pre-fetch the known, retrieve the uncertain on demand — the hybrid approach
+  Anthropic's guidance describes, not a return to pre-loading "everything that might matter." Record a
   pre-fetched result as a discrete entry so its provenance stays as legible as any other fact
   in the packet.
 - **Combine search modes.** Lexical search catches exact identifiers and stack traces that

--- a/docs/02-operating-system/context-window-discipline.md
+++ b/docs/02-operating-system/context-window-discipline.md
@@ -136,6 +136,14 @@ reason in:
 - **Prefer just-in-time retrieval over pre-loading.** Loading "everything that might matter"
   spends the attention budget before work starts; fetching on demand keeps the working set
   small ([Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)).
+- **Pre-fetch only what is already certain to be needed.** Just-in-time is the default, not an
+  absolute. When a specific input is known in advance to be required, fetching it
+  deterministically up front removes a model round-trip and keeps the transcript clean, rather
+  than spending a turn asking the model to request what you already knew it would. The test is
+  *certainty*: pre-fetch the known, retrieve the uncertain on demand — the hybrid Anthropic's
+  guidance describes, not a return to pre-loading "everything that might matter." Record a
+  pre-fetched result as a discrete entry so its provenance stays as legible as any other fact
+  in the packet.
 - **Combine search modes.** Lexical search catches exact identifiers and stack traces that
   embeddings miss; semantic search catches concepts that grep misses. Use both before
   trusting either.

--- a/docs/02-operating-system/runtime-enforcement.md
+++ b/docs/02-operating-system/runtime-enforcement.md
@@ -35,6 +35,27 @@ Push advisory wording up the rungs only when the stakes warrant it. Quick mode s
 advisory on purpose; a reversible, low-blast-radius change does not earn a runtime gate.
 Rigor scales with consequence ([`risk-tiers-and-modes.md`](risk-tiers-and-modes.md)).
 
+## The hold point: between selecting an action and committing it
+
+The rungs above answer *what* enforces; this answers *where* the highest-value hold sits. An
+agent's most consequential moment is the interval between **selecting** an action and
+**committing** it — after the model has decided to run a command, write a file, or call a
+tool, and before the effect lands. A hold placed there can still stop a wrong action cheaply.
+A check that runs only after the effect is a report, not a gate.
+
+Two rules follow from the enforcement test above:
+
+- **The hold must sit outside what the action can reach.** A pause the same agent can skip,
+  shorten, or rewrite in that interval is advice, not a gate — the same failure mode as a
+  guard inside the agent's writable set.
+- **The hold scales with consequence.** A reversible, low-blast-radius action earns no hold;
+  an irreversible, trust-bearing, or thinly-evidenced one earns a blocking one — placed by
+  [`deciding-who-decides`](../../skills/deciding-who-decides/SKILL.md) and prepared by
+  [`double-checking-before-acting`](../../skills/double-checking-before-acting/SKILL.md).
+
+This is the software reading of a hold point: a planned stop before an irreversible step where
+the actor confirms target, expected result, and authority before proceeding.
+
 ## Where each control already lives
 
 Read the table as: a contemporary enforcement concept, the Nuclear-grade control that
@@ -50,6 +71,7 @@ covers this ground — this page only makes it legible in one place.
 | Zone boundaries for file access | Authority dimensions (which files the agent may touch); workspace-boundary example | [`agent-authority-model.md`](../04-adoption/agent-authority-model.md), [`../03-worked-examples/ai-agent-tool-permissions/`](../03-worked-examples/ai-agent-tool-permissions/) |
 | Blast-radius / change budgets | Risk screen plus the change-impact record | [`risk-tiers-and-modes.md`](risk-tiers-and-modes.md), [`../../templates/cm/change-impact.md`](../../templates/cm/change-impact.md) |
 | Session hooks and gates | Validator activation thresholds; double-check at cut points | [`validators.md`](validators.md), [`double-checking-before-acting`](../../skills/double-checking-before-acting/SKILL.md) |
+| Hold point before an irreversible step | A blocking check at the decision→action interval, gated out-of-band when stakes are high | [`double-checking-before-acting`](../../skills/double-checking-before-acting/SKILL.md), [`declaring-intent`](../../skills/declaring-intent/SKILL.md) |
 | Completion receipt / handoff | Completion standard; the enforced `ship.md` fields; the handoff record | [`../../AGENTS.md`](../../AGENTS.md), [`../../templates/standard/ship.md`](../../templates/standard/ship.md), [`handing-off-work`](../../skills/handing-off-work/SKILL.md) |
 | Rising tide / no-new-debt | Recorded baseline; every surprise updates a control | [`configuration-management.md`](configuration-management.md), [`MAXIMS.md`](../../MAXIMS.md) |
 | Production-readiness gate | Release-readiness decision; CI passing is not a release decision | [`checking-release-readiness`](../../skills/checking-release-readiness/SKILL.md), [`MAXIMS.md`](../../MAXIMS.md) |
@@ -65,7 +87,7 @@ is to move that control up a rung in the file that owns it — not to add ceremo
 ## Source-lineage note
 
 Original Nuclear-grade synthesis. It reads public practice on enforceable engineering
-controls — secure-development guidance, supply-chain provenance, and configuration
-discipline — mapped in
+controls — secure-development guidance, supply-chain provenance, configuration discipline,
+and the hold-point and self-checking habits in DOE-HDBK-1028-2009 — mapped in
 [`../00-standards-foundation/source-map.md`](../00-standards-foundation/source-map.md). It
 does not create assurance, certification, or compliance.

--- a/skills/double-checking-before-acting/SKILL.md
+++ b/skills/double-checking-before-acting/SKILL.md
@@ -38,7 +38,7 @@ A self-check turns a high-stakes action into a careful one. Before you claim suc
 
 ## Process
 
-1. Stop at the key moment and name the exact action and target.
+1. Stop at the key moment — the interval after you have chosen the action and before you commit it — and name the exact action and target.
 2. Think through the result you expect, the likely error, and what would make the action wrong.
 3. Act only inside the authority you were given.
 4. Compare the real result against the result you expected, before you make any claim.


### PR DESCRIPTION
## Summary

A review of public agent-engineering practice was screened for value-adds against the existing method. Most ideas were already covered by current doctrine; only two survived as genuinely additive, and both are folded into existing pages and grounded in already-cited public sources (no new source, no external attribution):

- **`docs/02-operating-system/runtime-enforcement.md`** — name the **decision→action hold point**: the interval between an agent *selecting* an action and *committing* it, established as the canonical location for an out-of-band gate. Adds a short subsection, a matching table row, and DOE-HDBK-1028 (hold-point / self-checking) lineage in the source-lineage note.
- **`docs/02-operating-system/context-window-discipline.md`** — add **pre-fetch as the bounded complement to just-in-time retrieval**: when an input is certain to be needed, fetch it deterministically to save a model round-trip; retrieve the uncertain on demand. Grounded in the Anthropic context-engineering guidance already cited in that section.
- **`skills/double-checking-before-acting/SKILL.md`** — reinforce the hold-point framing in Process step 1 (surgical, one line).

The change packet's `risk.md` includes a **Review scope** table recording the reviewed ideas that were found *already covered* (e.g. bounded self-correction → `staying-on-mission`; structured escalation → `declaring-intent` / `deciding-who-decides`; context, state, prompts, small agents, pause/resume), so the "skip what's covered" discipline is legible.

## Mode

Quick. Additive, reversible doctrine refinements to existing pages — no code, dependency, charter, or behavior change, and no Standard trigger tripped. `risk.md` notes it can escalate to Standard if a reviewer judges the adoption consequence warrants a full basis/trace.

## Change packet

`.nuclear/changes/glean-agent-control-flow/` (`risk.md` + `proof.md`).

## Proof command + result

```bash
python -m pytest tests/                                        # 186 passed, 1 skipped
python tools/ng.py doctor                                      # OK: Nuclear-grade doctor
python tools/ng.py tokens                                      # OK: token budget
python tools/ng.py validate .nuclear/changes/glean-agent-control-flow   # OK
```

## Verification

- [x] Tests and validator pass locally (`python -m pytest tests/` → 186 passed, 1 skipped; `python tools/ng.py doctor` → OK).
- [x] Packet validation passes (`ng validate .nuclear/changes/glean-agent-control-flow` → OK).
- [ ] CM impact/baseline records — N/A; no controlled item changed beyond the doctrine prose itself, captured in the packet.
- [ ] HPI records — N/A; no turnover, dependency/model/API trust, or release activated.
- [x] `git diff --check` passes.
- [x] New public docs contain no private paths, internal codenames, or stale launch residue.
- [x] New claims avoid compliance / certification / regulator / formal-QA overclaiming; each edited page keeps its boundary and source-lineage note.
- [x] Source-lineage uses public, open, linkable sources already mapped in `source-map.md` (DOE-HDBK-1028, Tier 1; Anthropic context-engineering, Tier 9).

## Residual risks or gaps

- The two additions are deliberately small; the broader review's conclusion is that the method already covers this territory. Reviewers should confirm the **Review scope** table's already-covered mappings are accurate and that both additions *refine* rather than duplicate existing prose.
- Quick mode is a judgment call for durable public doctrine; escalate to Standard if the adoption consequence is judged higher than assessed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_0141FrmsVLiui4cBbm8rejR6)_