### PR TITLE
test: add release readiness eval case

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -9,6 +9,7 @@ situations.
 | `U02-agent-workspace-boundary` | Agent file-write authority is bounded, controlled items are named, adversarial proof claims are stated, and release wording avoids production-sandbox overclaiming. | A change gives an agent tool or filesystem authority. |
 | `U04-public-assurance-wording` | Public claims separate source inspiration, license permission, assurance, self-checks, cross-document impact, and prohibited-claim scans. | Docs, marketing, README, or release notes could imply compliance, certification, formal QA, safety, security, or regulatory adequacy. |
 | `U07-payment-webhook-idempotency` | Money-moving changes escalate mode, bound credentials/API access, prove duplicate/replay behavior, and name rollback, monitoring, and risk ownership. | An agent touches payments, billing state, ledgers, or similarly trust-bearing side effects. |
+| `U09-release-readiness-cut` | Release decisions name controlled release artifacts, evidence beyond green CI, handoff owners, rollback, monitoring, and the accepted baseline. | A PR, tag, package, or public release is about to become the version users trust. |
 
 ## Add or remove a case
 

--- a/evals/cases/U09-release-readiness-cut.json
+++ b/evals/cases/U09-release-readiness-cut.json
@@ -1,0 +1,28 @@
+{
+  "id": "U09",
+  "title": "Release readiness cut",
+  "artifact": "docs/03-worked-examples/skill-workflow-comparison/trial-records/release-readiness-cut.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    {
+      "name": "Names release controlled items beyond the commit SHA",
+      "all": ["Controlled items:", "the version", "the changelog", "the package metadata", "the docs", "the examples", "the CI result", "the release notes"]
+    },
+    {
+      "name": "Requires evidence for install, examples, changelog, CI, and public-claim safety",
+      "all": ["the install command works", "the examples pass the validator", "the changelog matches the changes", "CI passes", "no banned assurance claims"]
+    },
+    {
+      "name": "Keeps release as a decision, not a green-CI reflex",
+      "all": ["Release decision:", "ship, defer, block, or ship with leftover risk"]
+    },
+    {
+      "name": "Hands off accepted state, leftover risk, monitoring, and rollback to owners",
+      "all": ["release owner", "support owner", "accepted file state", "leftover risk", "monitoring", "rollback notes"]
+    },
+    {
+      "name": "Baselines and watches the release after shipment",
+      "all": ["Baseline:", "the release tag", "accepted file state", "Monitoring:", "watch issues and discussions", "smoke-test the package install"]
+    }
+  ]
+}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -163,9 +163,9 @@ def test_redundancy_index_ignores_shared_code_snippets(tmp_path):
 def test_cost_per_signal_matches_eval_cases():
     per_signal = tokens.cost_per_signal(ROOT)
 
-    # Three worked examples ship with eval cases (U02, U04, U07); each yields a
-    # positive tokens-per-signal ratio.
-    assert set(per_signal) == {"U02", "U04", "U07"}
+    # Shipped worked examples with eval cases each yield a positive
+    # tokens-per-signal ratio.
+    assert set(per_signal) == {"U02", "U04", "U07", "U09"}
     for cost in per_signal.values():
         assert cost > 0
 


### PR DESCRIPTION
## Summary
- Adds U09 `release-readiness-cut` to the lightweight eval cases.
- Updates the eval index and expected CLI coverage count from 15/15 to 20/20.

## Why this is the best 1% move
Release work is where a green checkmark can be mistaken for a decision. This PR turns an existing worked example into an automated decision-signal check for controlled release artifacts, evidence beyond CI, handoff, rollback, monitoring, and the accepted baseline.

## Sharpness guardrail
This does not add a new doctrine page, template, or workflow. It adds one small scored case over an artifact already in the repo, keeping the method auditable without expanding the framework.

## Verification
- `git diff --check`
- `python tools/ng.py eval .`
- `python -m pytest tests/test_efficacy.py -q`
- `python -m pytest tests/test_public_docs.py tests/test_ng_cli.py -q`

## Reversibility
Easy: delete `evals/cases/U09-release-readiness-cut.json`, remove the index row, and restore the expected coverage count to 15/15.
