### PR TITLE
test: add prompt model baseline eval case

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -8,6 +8,7 @@ situations.
 | --- | --- | --- |
 | `U02-agent-workspace-boundary` | Agent file-write authority is bounded, controlled items are named, adversarial proof claims are stated, and release wording avoids production-sandbox overclaiming. | A change gives an agent tool or filesystem authority. |
 | `U04-public-assurance-wording` | Public claims separate source inspiration, license permission, assurance, self-checks, cross-document impact, and prohibited-claim scans. | Docs, marketing, README, or release notes could imply compliance, certification, formal QA, safety, security, or regulatory adequacy. |
+| `U05-prompt-model-baseline` | Prompt/model changes are treated as controlled behavior changes, with impacted context surfaces, a known-good baseline, local evidence, re-check triggers, and bounded release/defer logic. | A change alters an agent prompt, model, eval set, tool power, or public claim about model behavior. |
 | `U07-payment-webhook-idempotency` | Money-moving changes escalate mode, bound credentials/API access, prove duplicate/replay behavior, and name rollback, monitoring, and risk ownership. | An agent touches payments, billing state, ledgers, or similarly trust-bearing side effects. |
 | `U09-release-readiness-cut` | Release decisions name controlled release artifacts, evidence beyond green CI, handoff owners, rollback, monitoring, and the accepted baseline. | A PR, tag, package, or public release is about to become the version users trust. |
 

--- a/evals/cases/U05-prompt-model-baseline.json
+++ b/evals/cases/U05-prompt-model-baseline.json
@@ -1,0 +1,28 @@
+{
+  "id": "U05",
+  "title": "Prompt/model baseline",
+  "artifact": "docs/03-worked-examples/skill-workflow-comparison/trial-records/prompt-model-baseline.md",
+  "section": "## Nuclear-Grade Trial",
+  "signals": [
+    {
+      "name": "Treats prompt and model settings as controlled items",
+      "all": ["the model name", "the prompt version", "the eval set"]
+    },
+    {
+      "name": "Screens impacts beyond the prompt text",
+      "all": ["impact screen:", "context packs"]
+    },
+    {
+      "name": "Records a known-good baseline with re-check triggers",
+      "all": ["the version everyone agreed is correct", "re-check triggers"]
+    },
+    {
+      "name": "Separates provider/model claims from local evidence",
+      "all": ["model and provider claims apart", "local eval evidence"]
+    },
+    {
+      "name": "Ties release decision to behavior evidence or named gaps",
+      "all": ["behavior evidence backs", "defer with the gaps named"]
+    }
+  ]
+}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -165,7 +165,7 @@ def test_cost_per_signal_matches_eval_cases():
 
     # Shipped worked examples with eval cases each yield a positive
     # tokens-per-signal ratio.
-    assert set(per_signal) == {"U02", "U04", "U07", "U09"}
+    assert set(per_signal) == {"U02", "U04", "U05", "U07", "U09"}
     for cost in per_signal.values():
         assert cost > 0
 


### PR DESCRIPTION
## Summary
- Adds a U05 prompt/model baseline eval case for the existing trial record.
- Lists the case in `evals/README.md` and updates the expected harness coverage to 20/20.

## Why this is the best 1% move
Prompt, model, tool-power, and eval-set changes are now recurring agent-control surfaces across Codex, Claude Code, Gemini CLI, Copilot, and Cursor-style workflows. This repo already had the U05 trial record, but the mechanical eval harness did not guard it against drift.

## Sharpness guardrail
This is one small eval case over an existing artifact, not a new framework, process tier, or broad agent-governance doctrine. It makes the existing minimum-discipline spine more testable without expanding ceremony for users.

## Verification
- `python -m pytest tests/test_efficacy.py -q`
- `python tools/ng.py eval .`
- `git diff --check`

## Reversibility
Easy: remove `evals/cases/U05-prompt-model-baseline.json`, remove the one README row, and restore the expected coverage count in `tests/test_efficacy.py`.
