### PR TITLE
docs: route agent verification choices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,18 @@ The idea is simple. Keep a questioning attitude. Use small habits from Human Per
 - Prefer links and short status labels over long, repeated text.
 - Run the right tests and checker commands before you say the work is done.
 
+## Verification routing
+
+Do not invent a new proof path for routine edits. Use the pre-PR commands in
+[`CONTRIBUTING.md`](CONTRIBUTING.md), then narrow only when the change is clearly
+smaller than a full run:
+
+- docs-only wording: `git diff --check` plus the nearest public-doc or token test;
+- template, skill, command, or checker behavior: the targeted pytest file plus `python tools/ng.py doctor .`;
+- worked-example evidence: re-run the example validator or example test named in the changed record.
+
+If you skip a full pre-PR run, say why the narrower proof still covers the files you changed.
+
 ## Authority boundaries
 
 Agents must not assume they may:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ smaller than a full run:
 
 - docs-only wording: `git diff --check` plus the nearest public-doc or token test;
 - template, skill, command, or checker behavior: the targeted pytest file plus `python tools/ng.py doctor .`;
-- worked-example evidence: re-run the example validator or example test named in the changed record.
+- worked-example evidence: re-run the example validator or example test named in the change record.
 
 If you skip a full pre-PR run, say why the narrower proof still covers the files you changed.
 


### PR DESCRIPTION
## Summary
- Adds a concise verification-routing section to `AGENTS.md`.
- Points agents to the existing `CONTRIBUTING.md` pre-PR commands while naming when a narrower proof is acceptable.

## Why this is the best 1% move
Agent-facing project files in Codex/Gemini-style repos commonly carry exact build/test guidance, not just behavior principles. This repo already has the right pre-PR commands, but `AGENTS.md` only said to run “the right tests”; the change reduces verification ambiguity without adding a new workflow.

## Sharpness guardrail
This is one short routing note in the existing agent guidance. It does not add a template, stage gate, checklist, or broader management framework; it tells agents to reuse existing proof paths and justify any narrower run.

## Verification
- `git diff --check`
- `python -m pytest tests/test_public_docs.py -q`
- `python tools/ng.py doctor .`

## Reversibility
Revert this one commit to remove the routing note; no package code, templates, or validator behavior changed.
