### PR TITLE
test: derive eval coverage count from cases

### DIFF
--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -149,10 +149,13 @@ def test_eval_command_reports_malformed_case_clearly(tmp_path):
 
 
 def test_eval_command_reports_full_coverage():
+    cases = efficacy.load_cases(CASES_DIR)
+    expected_signals = sum(len(case.signals) for case in cases)
+
     result = run_ng("eval", str(ROOT))
 
     assert result.returncode == 0, result.stderr
-    assert "Decision-signal coverage: 15/15" in result.stdout
+    assert f"Decision-signal coverage: {expected_signals}/{expected_signals}" in result.stdout
     assert "[ok]" in result.stdout
 
 

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -152,6 +152,15 @@ def test_eval_command_reports_full_coverage():
     cases = efficacy.load_cases(CASES_DIR)
     expected_signals = sum(len(case.signals) for case in cases)
 
+    # Deriving the total from the cases avoids a merge-conflict hotspot when new
+    # cases are added, but still guard the accepted baseline: adding cases may
+    # raise this total, but a drop below 15 means a signal was removed from
+    # evals/cases/*.json and must not pass silently.
+    assert expected_signals >= 15, (
+        f"decision-signal total {expected_signals} fell below the accepted baseline of 15; "
+        "a signal was likely dropped from evals/cases/*.json"
+    )
+
     result = run_ng("eval", str(ROOT))
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- derive the expected eval coverage total from the loaded case definitions
- remove the hard-coded `15/15` assertion

## Why this is the best 1% move
Two open eval-case PRs (#66 and #67) both have to edit the same hard-coded count. Computing it from the cases preserves the output contract while removing recurring maintenance and a needless merge-conflict hotspot.

## Sharpness guardrail
This adds no process, artifact, or abstraction. It replaces one brittle literal with the smallest expression of the existing invariant: every signal in every loaded case is covered.

## Verification
- `python -m pytest tests/test_efficacy.py -q` (15 passed)
- `python -m pytest -q` (191 passed)
- `python -m ruff check .` (passed)
- `python tools/ng.py doctor .` (passed)
- `python tools/ng.py tokens .` (passed)
- `git diff --check` (passed)

## Reversibility
One test-only commit; revert it to restore the fixed count.
