### PR TITLE
docs: align contributor preflight with CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,13 @@ Run:
 
 ```bash
 python -m pytest -q
+python -m ruff check .
 python tools/ng.py doctor .
+python tools/ng.py tokens .
 python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions
 ```
+
+These are the fast local checks shared with CI; the workflow remains the source of truth.
 
 Also scan new public docs for overclaiming. Lean on phrases like:
 


### PR DESCRIPTION
## Summary
- Add the existing CI lint and token-budget checks to the contributor preflight.
- State that the workflow remains the source of truth.

## Why this is the best 1% move
`CONTRIBUTING.md` omitted two fast checks that CI already requires, so a contributor or coding agent could follow the documented preflight and still open an avoidably failing PR. Aligning the commands removes that ambiguity with four documentation lines.

## Sharpness guardrail
This adds no workflow, template, gate, or dependency. It exposes checks the repository already runs instead of inventing new process.

## Verification
- `python -m pytest -q`
- `python -m ruff check .`
- `python tools/ng.py doctor .`
- `python tools/ng.py tokens .`
- `python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions`
- `git diff --check`

All passed.

## Reversibility
One documentation-only commit; revert it to restore the previous three-command preflight. No runtime or CI behavior changes.
