### PR TITLE
docs: restore Discover in context-pack phase list

### DIFF
--- a/docs/02-operating-system/context-packs.md
+++ b/docs/02-operating-system/context-packs.md
@@ -69,7 +69,7 @@ Objective: <one paragraph>
 Mission anchor: <objective, success criteria, non-goals; survives context resets>
 Charter: <.nuclear/charter.md articles in play>
 Affected files: <paths>
-Current phase: Question / Specify / Plan / Execute / Verify / Review / Decide / Baseline / Operate / Learn
+Current phase: Question / Discover / Specify / Plan / Execute / Verify / Review / Decide / Baseline / Operate / Learn
 Last completed action: <resume point>
 Changed conditions: <what changed since the prior agent/context>
 Risk summary: <top risks and escalation triggers>


### PR DESCRIPTION
## Summary
- add the missing `Discover` phase to the context-pack schema
- align the fill-in field with the repository's canonical eleven-beat lifecycle

## Why this is the best 1% move
The schema is executable guidance: agents copy its phase list into task context. Omitting `Discover` can silently route work from questioning straight into specification even though the canonical lifecycle explicitly requires discovery.

## Sharpness guardrail
This adds no process, artifact, or concept. It removes a one-word inconsistency by making an existing schema match the existing lifecycle.

## Verification
- `git diff --check`
- `python -m pytest -q tests/test_public_docs.py` — 15 passed

A full pre-PR run was not necessary for this one-word docs correction; the targeted public-doc consistency suite plus whitespace validation covers the changed surface.

## Reversibility
One line, one word, and one commit; revert the commit to undo it.
