### PR TITLE
docs: trigger completion details by consequence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,15 +49,16 @@ Load skills by trigger, not by inventory. First screen the work for risk, eviden
 
 ## Completion standard
 
-An agent is not done until it can name:
+Every completion report names:
 
 - the files it changed;
 - the change record or reasoning it used;
 - the evidence it ran;
-- the handoff, self-check, OPEX, or trust record it used, or why it did not need one;
-- the intent it declared and the decision rights or escalation it used for any critical action;
-- the gaps still open;
-- the boundary wording it checked.
+- the gaps still open.
+
+Add triggered details only when they apply: handoff, self-check, OPEX, or trust records when
+used or required; intent and decision rights for critical actions; and boundary wording for
+public claims. Do not pad routine completions with `not applicable` declarations.
 
 ## Boundary note
 

--- a/CORE.md
+++ b/CORE.md
@@ -147,10 +147,10 @@ Different files hold different layers of guidance. Keep each light.
 | Per-task context pack | Role, mode, allowed/forbidden actions, required proof, stop conditions | Per task |
 
 This repo's own [`AGENTS.md`](AGENTS.md) is the reference shape: its **completion standard**
-(an agent is not done until it can name files changed, the change record, the evidence, the
-handoff used or why it was not needed, the intent declared, the gaps still open, and the
-boundary wording it checked) is the strongest exportable artifact. The starter kits ship it
-trimmed and `<fill-in>`-marked.
+always requires changed files, reasoning or change record, evidence, and open gaps, then adds
+handoff, intent, decision-right, custody, and claim-boundary details only when triggered. This
+avoids performative `not applicable` reporting while keeping consequential work inspectable.
+The starter kits ship it trimmed and `<fill-in>`-marked.
 
 ---
 

--- a/starter-kit/core/AGENTS.md
+++ b/starter-kit/core/AGENTS.md
@@ -33,18 +33,22 @@ Hygiene) by trigger from the decision matrix in `CORE.md`.
 
 ## Completion standard
 
-An agent is not done until it can name:
+Every completion report names:
 
 - the files it changed;
 - the change record or reasoning it used;
 - the evidence it ran;
-- who generated, selected, transformed, captured, retained, and presented any load-bearing evidence;
-- the actor/context/mechanism/authority/resource coupling profile and any residual gap;
-- the handoff, self-check, OPEX, or trust record it used, or why it did not need one;
-- the intent it declared and the decision rights or escalation it used for any critical action;
-- the gaps still open;
-- the boundary wording it checked;
-- `<fill-in: any project-specific completion criteria>`.
+- the gaps still open.
+
+Add triggered details only when they apply:
+
+- for load-bearing evidence, who controlled its path and any residual actor/context/mechanism/authority/resource coupling;
+- for a required handoff, self-check, OPEX, or trust record, which record was used;
+- for a critical action, the declared intent and decision rights or escalation;
+- for a public claim, the boundary wording checked;
+- `<fill-in: any project-specific completion criteria and its trigger>`.
+
+Do not pad routine completions with `not applicable` declarations.
 
 ## Boundary note
 


### PR DESCRIPTION
## Summary
- split the completion standard into four always-required facts and consequence-triggered details
- stop requiring routine agents to emit performative `not applicable` declarations
- align the reference guidance and Core starter kit

## Why this is the best 1% move
The current completion checklist makes every change report on handoffs, critical-action intent, and claim boundaries even when none exists. Trigger-gating those fields preserves the audit trail for consequential work while making the lightest mode honestly light.

## Sharpness guardrail
This adds no role, template, gate, or artifact. It removes universal ceremony and retains only changed files, reasoning, evidence, and open gaps as the minimum completion discipline.

## Verification
- `git diff --check`
- `python -m pytest -q` — passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — OK
- `python tools/ng.py tokens .` — OK
- strict-custody validation of the flagship worked example — OK

## Reversibility
Three small documentation edits in one commit; revert the commit to restore the prior checklist.
