### PR TITLE
ci: pin workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -68,10 +68,10 @@ jobs:
     needs: validate
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -122,10 +122,10 @@ jobs:
     needs: validate
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- pin every third-party GitHub Action in CI to a full 40-character commit SHA
- retain readable release comments (`checkout` v4.4.0 and `setup-python` v5.6.0)

## Why this is the best 1% move
CI is part of the evidence path, but moving major tags can change what executes without a repository diff. Immutable refs make the workflow reproducible and remove that silent dependency drift from all three jobs.

## Sharpness guardrail
This adds no policy document, tool, gate, or artifact. It is a six-line substitution in the existing workflow; dependency updates remain ordinary reviewable diffs.

## Verification
- `git diff --check` — passed
- `python -m pytest -q` — passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — OK
- `python tools/ng.py tokens .` — OK
- strict-custody validation of the flagship worked example — OK
- local action-pin assertion — all 6 `uses:` references are full 40-character SHAs

## Reversibility
One workflow-only commit; revert it to restore moving major tags.
