### PR TITLE
docs: clarify pytest requirement scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.n
 # OK: the record links claims to evidence and discloses custody/coupling (or a named gap).
 ```
 
-Want to watch that evidence regenerate? The example ships the test behind that workspace-boundary claim. This step needs `pytest` (`pip install pytest`); nothing else in the repo does:
+Want to watch that evidence regenerate? The example ships the test behind that workspace-boundary claim. This step needs `pytest` (`pip install pytest`); the one-command validator above does not:
 
 ```bash
 python -m pytest docs/03-worked-examples/ai-agent-tool-permissions/tests/test_workspace_guard.py -v


### PR DESCRIPTION
## Summary
- Replace the README's repo-wide claim that only the worked-example command needs `pytest` with the narrower, accurate contrast: the dependency-free validator command above does not need it.

## Why this is the best 1% move
The existing sentence conflicts with `pyproject.toml`, `CONTRIBUTING.md`, and CI, all of which use `pytest`. Narrowing the claim removes setup ambiguity without adding doctrine, artifacts, or process.

## Sharpness guardrail
This is one sentence changed in place. It adds no framework concept, template, gate, or explanatory section; the administrative-floor commit is the complete record.

## Verification
- `git diff --check` — passed
- `python -m pytest -q` — passed (238 tests)
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — passed
- `python tools/ng.py tokens .` — passed
- `python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions --strict-custody` — passed

## Reversibility
Revert the single commit; no data, behavior, or generated artifact changes.
