### PR TITLE
fix: parse standard claim IDs in trust checks

### DIFF
--- a/nuclear_grade/propagation.py
+++ b/nuclear_grade/propagation.py
@@ -39,7 +39,13 @@ STATUS_RANK: dict[str, int | None] = {
 
 PROMOTABLE_RANK = 3  # only an all-pass packet promotes
 
-_CLAIM_ID = re.compile(r"^[A-Z]-?\d+$")
+_CLAIM_ID = re.compile(r"^(?P<id>[A-Z][A-Z0-9]*-?\d+)(?:\s|$)")
+
+
+def _claim_id(cell: str) -> str | None:
+    """Return the leading claim id, allowing a short description after it."""
+    match = _CLAIM_ID.match(cell)
+    return match.group("id") if match else None
 
 
 def parse_claim_statuses(verification_text: str) -> list[tuple[str, str]]:
@@ -54,13 +60,13 @@ def parse_claim_statuses(verification_text: str) -> list[tuple[str, str]]:
         if "|" not in line:
             continue
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        if len(cells) < 2 or not _CLAIM_ID.match(cells[0]):
+        if len(cells) < 2 or (claim_id := _claim_id(cells[0])) is None:
             continue
         status = next(
             (c.lower() for c in cells[1:] if c.lower() in STATUS_RANK), None
         )
         if status is not None:
-            results.append((cells[0], status))
+            results.append((claim_id, status))
     return results
 
 
@@ -73,7 +79,7 @@ def _deferred_section_ids(verification_text: str) -> set[str]:
             in_deferred = "deferred" in line.lower()
             continue
         if in_deferred:
-            ids.update(re.findall(r"[A-Z]-?\d+", line))
+            ids.update(re.findall(r"\b[A-Z][A-Z0-9]*-?\d+\b", line))
     return ids
 
 

--- a/nuclear_grade/two_party.py
+++ b/nuclear_grade/two_party.py
@@ -50,7 +50,12 @@ def parse_claim_status(verification_text: str) -> dict[str, str]:
             continue
         status = next((c.lower() for c in cells[1:] if c.lower() in known), None)
         if status is not None:
-            out[claim_id] = status
+            # When a base row and a qualified row share a normalized id (e.g.
+            # `REQ-001` and `REQ-001 (live install)`), keep the load-bearing
+            # `pass` so a weaker later row cannot silently drop the independence
+            # check this module exists to enforce.
+            if claim_id not in out or status == "pass":
+                out[claim_id] = status
     return out
 
 

--- a/nuclear_grade/two_party.py
+++ b/nuclear_grade/two_party.py
@@ -29,7 +29,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-_CLAIM_ID = re.compile(r"^[A-Z]-?\d+$")
+_CLAIM_ID = re.compile(r"^(?P<id>[A-Z][A-Z0-9]*-?\d+)(?:\s|$)")
+
+
+def _claim_id(cell: str) -> str | None:
+    """Return the leading claim id, allowing a short description after it."""
+    match = _CLAIM_ID.match(cell)
+    return match.group("id") if match else None
 
 
 def parse_claim_status(verification_text: str) -> dict[str, str]:
@@ -40,11 +46,11 @@ def parse_claim_status(verification_text: str) -> dict[str, str]:
         if "|" not in line:
             continue
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        if len(cells) < 2 or not _CLAIM_ID.match(cells[0]):
+        if len(cells) < 2 or (claim_id := _claim_id(cells[0])) is None:
             continue
         status = next((c.lower() for c in cells[1:] if c.lower() in known), None)
         if status is not None:
-            out[cells[0]] = status
+            out[claim_id] = status
     return out
 
 
@@ -63,9 +69,9 @@ def parse_authorship(verification_text: str) -> dict[str, tuple[str, str]]:
         if not in_section or "|" not in line:
             continue
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        if len(cells) < 3 or not _CLAIM_ID.match(cells[0]):
+        if len(cells) < 3 or (claim_id := _claim_id(cells[0])) is None:
             continue
-        out[cells[0]] = (cells[1].lower(), cells[2].lower())
+        out[claim_id] = (cells[1].lower(), cells[2].lower())
     return out
 
 

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -36,8 +36,12 @@ def test_effective_status_is_the_minimum():
 
 
 def test_parse_reads_claim_and_status():
-    text = TABLE_HEADER + "| C-001 | m | c | pass | e | - |\n"
-    assert parse_claim_statuses(text) == [("C-001", "pass")]
+    text = (
+        TABLE_HEADER
+        + "| C-001 | m | c | pass | e | - |\n"
+        + "| REQ-002 keeps writes bounded | m | c | gap | e | tbd |\n"
+    )
+    assert parse_claim_statuses(text) == [("C-001", "pass"), ("REQ-002", "gap")]
 
 
 def test_all_pass_promotes(tmp_path):
@@ -79,6 +83,17 @@ def test_acknowledged_deferred_promotes(tmp_path):
         tmp_path,
         "| C-001 | m | c | pass | e | None |\n| C-002 | m | c | deferred | e | later |\n",
         deferred="## Deferred items\n\n- C-002: parked pending vendor data; tracked in issue 12.\n",
+    )
+    messages: list[str] = []
+    check_promotion(pkt, messages)
+    assert messages == []
+
+
+def test_multi_letter_deferred_id_is_acknowledged(tmp_path):
+    pkt = _packet(
+        tmp_path,
+        "| REQ-003 integration | m | c | planned | e | later |\n",
+        deferred="## Deferred items\n\n- REQ-003: waiting for schema normalization.\n",
     )
     messages: list[str] = []
     check_promotion(pkt, messages)

--- a/tests/test_two_party.py
+++ b/tests/test_two_party.py
@@ -50,6 +50,17 @@ def test_self_verified_claim_blocks(tmp_path):
     assert any("independent second party" in m for m in messages)
 
 
+def test_multi_letter_claim_with_description_is_checked(tmp_path):
+    pkt = _packet(
+        tmp_path,
+        "| REQ-001 workspace boundary | m | c | pass | e | - |\n",
+        AUTH_HEADER + "| REQ-001 workspace boundary | ben | ben |\n",
+    )
+    messages: list[str] = []
+    check_two_party(pkt, messages)
+    assert any("REQ-001" in m and "independent second party" in m for m in messages)
+
+
 def test_missing_authorship_table_is_flagged(tmp_path):
     pkt = _packet(tmp_path, "| C-001 | m | c | pass | e | - |\n")
     messages: list[str] = []

--- a/tests/test_two_party.py
+++ b/tests/test_two_party.py
@@ -61,6 +61,21 @@ def test_multi_letter_claim_with_description_is_checked(tmp_path):
     assert any("REQ-001" in m and "independent second party" in m for m in messages)
 
 
+def test_qualified_row_does_not_drop_base_pass_status(tmp_path):
+    # A base `pass` row and a later qualified row normalize to the same id;
+    # the weaker qualified status must not overwrite the load-bearing pass,
+    # or the independence check would be silently skipped.
+    pkt = _packet(
+        tmp_path,
+        "| REQ-001 | m | c | pass | e | - |\n"
+        "| REQ-001 (live install) | m | c | deferred | e | - |\n",
+        AUTH_HEADER + "| REQ-001 | ben | ben |\n",
+    )
+    messages: list[str] = []
+    check_two_party(pkt, messages)
+    assert any("REQ-001" in m and "independent second party" in m for m in messages)
+
+
 def test_missing_authorship_table_is_flagged(tmp_path):
     pkt = _packet(tmp_path, "| C-001 | m | c | pass | e | - |\n")
     messages: list[str] = []


### PR DESCRIPTION
## Summary
- parse standard multi-letter claim IDs such as `REQ-001` in the new propagation and two-party checks
- normalize IDs when the table cell includes a short description
- recognize the same IDs in deferred-item references
- add regression coverage for status, deferral, and authorship paths

## Why this is the best 1% move
PR #73 merged these currently inert trust checks today, but their single-letter regex silently skips the repository's own `REQ-###` schema. Fixing the parser now prevents a known false-negative path from becoming a future gate.

## Sharpness guardrail
This changes only claim-ID recognition and four focused tests. It adds no doctrine, packet, role, gate, dependency, or new management surface; the checks remain inert pending the existing integration decision.

## Verification
- `git diff origin/main...HEAD --check`
- `python -m pytest -q`
- `python -m ruff check .`
- `python tools/ng.py doctor .`
- `python tools/ng.py tokens .`
- strict-custody validation of the flagship worked example

All passed after rebasing onto current `origin/main`.

## Reversibility
One focused commit touching two standalone modules and their unit tests; a normal revert restores prior behavior with no migration or data impact.

Addresses review findings on #73, including https://github.com/FlyFission/nuclear-grade-context-engineering/pull/73#discussion_r3602772348.
