### PR TITLE
fix: keep MCP extra on compatible v1

### DIFF
--- a/.nuclear/changes/integrations-cross-tool-install/basis.md
+++ b/.nuclear/changes/integrations-cross-tool-install/basis.md
@@ -47,7 +47,7 @@ What must not happen?
 |---|---|---|---|---|
 | Each tool auto-loads `SKILL.md` by description | fact | official docs for each tool | a tool drops the Agent Skills standard | FlyFission |
 | Each tool's skills directory is as documented | fact (except VS Code user path) | official docs; VS Code user path is best-known | a tool relocates its skills directory | FlyFission |
-| `mcp>=1.0` is installable and exposes FastMCP | fact | PyPI shows 1.0.0..1.27.2; verified in a clean venv | `mcp` removes FastMCP or changes the API | FlyFission |
+| `mcp>=1.0,<2` is installable and exposes FastMCP | local proof | the v2.0.0 release directs unmigrated users to keep a `<2` bound; verified with the latest matching v1 in a clean environment | the project deliberately migrates to `MCPServer` on v2 | FlyFission |
 
 ## Grounding status
 
@@ -73,7 +73,7 @@ Use this section only when activated.
 
 | Dependency/model/service | Intended use | Consequence if wrong/unavailable/compromised | Evidence or compensating control | Revalidation trigger |
 |---|---|---|---|---|
-| `mcp` (Python SDK) | run the optional MCP server | only MCP users affected; the base install is unaffected | optional extra; pinned `mcp>=1.0`; the `mcp-smoke` CI job | a new major of `mcp` or a FastMCP API change |
+| `mcp` (Python SDK) | run the optional MCP server | only MCP users affected; the base install is unaffected | optional extra; bounded to `mcp>=1.0,<2`; the `mcp-smoke` CI job | a deliberate v2 migration or a FastMCP API change on v1 |
 
 ## Derived requirements or claims
 

--- a/.nuclear/changes/integrations-cross-tool-install/opex.md
+++ b/.nuclear/changes/integrations-cross-tool-install/opex.md
@@ -1,0 +1,33 @@
+# OPEX Record — MCP v2 compatibility break
+
+## Event
+
+- Date: 2026-07-30
+- Source: MCP Python SDK v2.0.0 release and failed `mcp-smoke` on PR #89
+- Affected baseline: optional MCP integration introduced by PR #42
+- Summary: `pip install mcp` began resolving to v2, which renamed `FastMCP` to
+  `MCPServer`; the existing unbounded extra could no longer build the shipped server.
+
+## Learning and action
+
+| Finding | Weak or missing control | Impact | Action | Verification | Owner | Due / trigger |
+|---|---|---|---|---|---|---|
+| A lower bound did not preserve the v1 API contract across a major release. | The dependency declared `mcp>=1.0` without an upper compatibility bound. | Fresh optional-extra installs failed while the base package remained unaffected. | Bound the existing implementation to `mcp>=1.0,<2`; keep v2 migration separate. | Install the extra in a clean environment and run `tests/test_mcp_server.py`; require GitHub `mcp-smoke` to pass. | FlyFission | Revisit only with a deliberate v2 migration PR. |
+
+## Required links
+
+- Baseline record: `ship.md`
+- Related packet / issue / incident: this packet; PR #89 failed MCP smoke
+- Verification evidence: MCP Python SDK v2.0.0 release and this PR's `mcp-smoke`
+
+## Exit criteria
+
+- Fresh optional-extra installs resolve to a compatible v1 release.
+- The MCP smoke test passes without weakening or removing it.
+- Migration to v2 remains an explicit, separately reviewed compatibility change.
+
+## Source-lineage note
+
+This operating lesson records a dependency compatibility correction against the
+[MCP Python SDK v2.0.0 release](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0).
+It makes no claim of formal assurance, compliance, safety, security, or regulatory adequacy.

--- a/.nuclear/changes/integrations-cross-tool-install/opex.md
+++ b/.nuclear/changes/integrations-cross-tool-install/opex.md
@@ -16,9 +16,9 @@
 
 ## Required links
 
-- Baseline record: `ship.md`
-- Related packet / issue / incident: this packet; PR #89 failed MCP smoke
-- Verification evidence: MCP Python SDK v2.0.0 release and this PR's `mcp-smoke`
+- Baseline record: `.nuclear/changes/integrations-cross-tool-install/ship.md`
+- Related packet / issue / incident: `.nuclear/changes/integrations-cross-tool-install/`; PR #89 failed MCP smoke
+- Verification evidence: `.nuclear/changes/integrations-cross-tool-install/verification.md`; MCP Python SDK v2.0.0 release and this PR's `mcp-smoke`
 
 ## Exit criteria
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ nuclear-grade-mcp = "nuclear_grade.mcp_server:main"
 
 [project.optional-dependencies]
 mcp = [
-  "mcp>=1.0",
+  "mcp>=1.0,<2",
 ]
 dev = [
   "pytest>=8",


### PR DESCRIPTION
## Summary
- bound the existing FastMCP implementation to `mcp>=1.0,<2`
- record the v2 compatibility break as operating experience in the original MCP integration packet
- keep migration to v2's `MCPServer` as a separate compatibility decision

## Why this is the best 1% move
MCP Python SDK v2.0.0 made `pip install mcp` resolve to a breaking major release and renamed `FastMCP` to `MCPServer`. Fresh `nuclear-grade[mcp]` installs and the repository's MCP smoke check therefore failed. The SDK maintainers explicitly advise unmigrated projects to retain a `<2` upper bound.

## Sharpness guardrail
This does not add a compatibility layer, migration abstraction, new dependency, or new process. It restores the API boundary the shipped implementation actually supports and records the triggered lesson in the existing packet.

## Verification
- `mcp 1.29.0` resolved in a clean venv
- `python -m pytest tests/test_mcp_server.py -q` — 13 passed in that venv
- full `python -m pytest -q` — passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — passed
- `python tools/ng.py tokens .` — passed
- original MCP packet validation — passed
- flagship strict-custody validation — passed
- `git diff --check` — passed

## Reversibility
One focused commit. Reverting it restores the unbounded dependency and removes the OPEX update; no data or migration is involved.

Primary source: https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0
