### PR TITLE
test: guard local Markdown links

### DIFF
--- a/.nuclear/changes/local-markdown-link-guard/proof.md
+++ b/.nuclear/changes/local-markdown-link-guard/proof.md
@@ -1,0 +1,40 @@
+# Proof — local Markdown link guard
+
+## Proof summary
+
+- Change slug: `local-markdown-link-guard`
+- Proof owner: Hermes scheduled maintenance run
+- Date: 2026-08-02
+- Risk record: [`risk.md`](risk.md)
+
+## Claim proven
+
+The generic local-link guard accepts the repository's current Markdown corpus and adds no lint, packet-validation, or whitespace failure.
+
+## Method and result
+
+- **pass** — `python -m pytest tests/test_public_docs.py -q`: 16 tests passed.
+- **pass** — `python -m pytest -q`: full configured suite passed.
+- **pass** — `python -m ruff check .`: all checks passed.
+- **pass** — `python tools/ng.py doctor .` and `python tools/ng.py tokens .`.
+- **pass** — both this packet and the flagship worked-example packet validated.
+- **pass** — `git diff --check`.
+
+The change actor ran and summarized deterministic local checks. PR CI can reproduce them; that same-actor coupling is accepted for this small, reversible test guard.
+
+## Reviewer note
+
+Quick mode remains valid. Review should focus on whether the intentionally narrow regex could reject a valid link shape used in this repository.
+
+## Required links
+
+- Changed item: [`tests/test_public_docs.py`](../../../tests/test_public_docs.py)
+- Risk: [`risk.md`](risk.md)
+
+## Exit criteria
+
+The targeted and full checks pass, the result is reproducible in CI, and review can decide from this packet without unrelated context.
+
+## Source-lineage note
+
+This proof records deterministic repository checks within the public boundaries mapped in [`source-map.md`](../../../docs/00-standards-foundation/source-map.md). No compliance claim is made.

--- a/.nuclear/changes/local-markdown-link-guard/risk.md
+++ b/.nuclear/changes/local-markdown-link-guard/risk.md
@@ -1,0 +1,31 @@
+# Risk — local Markdown link guard
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why:** A dependency-free CI assertion is low consequence, immediately detectable, and removable in one commit. It changes no runtime, authority, dependency, public claim, or release behavior.
+
+## Decision
+
+Scan every tracked Markdown document during the existing public-doc test and fail when a relative link resolves to no repository path. Ignore URL, email, and same-document anchor targets.
+
+The main risk is rejecting unusual but valid Markdown syntax. Keep the parser deliberately narrow, use the current corpus as its fixture, and report both the source document and target when it fails.
+
+## Required proof
+
+- `python -m pytest tests/test_public_docs.py -q`
+- `python -m ruff check tests/test_public_docs.py`
+- `git diff --check`
+
+## Required links
+
+- Changed item: [`tests/test_public_docs.py`](../../../tests/test_public_docs.py)
+- Proof: [`proof.md`](proof.md)
+
+## Exit criteria
+
+The current Markdown corpus passes, failure output identifies the broken reference, and no third-party checker or workflow is added.
+
+## Source-lineage note
+
+This repository-local maintenance control stays within the public source boundaries mapped in [`source-map.md`](../../../docs/00-standards-foundation/source-map.md). It makes no compliance or efficacy claim.

--- a/tests/test_public_docs.py
+++ b/tests/test_public_docs.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -50,6 +51,20 @@ NEGATIVE_CONTEXT = (
 def test_public_top_level_docs_exist():
     for public_doc in PUBLIC_DOCS:
         assert (ROOT / public_doc).exists(), f"missing {public_doc}"
+
+
+def test_local_markdown_links_resolve():
+    """Keep file moves from silently breaking the repository's navigation."""
+    for doc in ROOT.rglob("*.md"):
+        text = doc.read_text(encoding="utf-8")
+        for raw_target in re.findall(r"\]\(([^)]+)\)", text):
+            target = raw_target.strip().split(maxsplit=1)[0].strip("<>")
+            path = unquote(target.split("#", 1)[0])
+            if not path or path.startswith(("http://", "https://", "mailto:")):
+                continue
+
+            resolved = ROOT / path.lstrip("/") if path.startswith("/") else doc.parent / path
+            assert resolved.exists(), f"{doc.relative_to(ROOT)} links to missing {target}"
 
 
 def test_public_docs_contain_no_internal_residue():


### PR DESCRIPTION
## Summary
- add a dependency-free test that walks repository Markdown links
- fail with the source document and missing local target after file moves or renames
- record the low-risk change in a compact Quick packet

## Why this is the best 1% move
The repository now has hundreds of linked Markdown records but only hand-picked reference checks. A 15-line generic guard turns silent navigation drift into an immediate, reproducible CI failure without adding a service, action, or package.

## Sharpness guardrail
This adds no doctrine, role, template, workflow, or adoption requirement. It reuses the existing public-doc test and deliberately checks only local path existence—not external URL health or a broader documentation governance layer.

## Verification
- `python -m pytest -q` — passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — passed
- `python tools/ng.py tokens .` — passed
- flagship worked-example strict-custody validation — passed
- new Quick packet validation — passed
- `git diff --check` — passed

## Reversibility
One commit; revert it to remove the test and its Quick packet. No migration or persisted state is involved.
