### PR TITLE
docs: align PR template with mode floor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,11 @@
 
 ## Mode
 
-<!-- Quick / Standard / stronger. One line on why a lower mode is insufficient. -->
+<!-- Administrative floor / Quick / Standard / stronger. Name why this is the lightest honest mode. -->
 
 ## Change packet
 
-<!-- For non-trivial changes, link .nuclear/changes/<slug>/. For trivial docs-only changes, write N/A and explain why. -->
+<!-- Link .nuclear/changes/<slug>/, or write N/A when the administrative floor applies and explain why. -->
 
 ## Proof command + result
 

--- a/.nuclear/changes/pr-template-mode-alignment/proof.md
+++ b/.nuclear/changes/pr-template-mode-alignment/proof.md
@@ -1,0 +1,36 @@
+# PR template mode alignment — proof
+
+## Claim
+
+The pull-request template now permits the repository's documented administrative floor and no longer treats “docs-only” as the condition for omitting a packet.
+
+## Method
+
+- Environment: disposable clone of `origin/main`, Python 3.12.
+- Inspect the focused diff and compare the template wording with the mode guidance in `README.md` and `AGENTS.md`.
+- Run `python -m pytest tests/test_public_docs.py -q`, `python tools/ng.py doctor .`, and `git diff --check`.
+- Evidence is reproducible from checked-in files; the AI-assisted author selected and summarized it, while CI and reviewer reruns provide separate execution paths.
+
+## Result
+
+- Evidence status: pass
+- Actual result: 15 targeted public-doc tests and the full pytest suite passed; Ruff passed; repository doctor returned `OK`; packet validation and `git diff --check` passed.
+
+## Reviewer note
+
+Confirm that the wording closes the mismatch without making the administrative floor easier to misuse or adding a new review ritual.
+
+## Required links
+
+- Changed item: [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+- Risk record: [`risk.md`](risk.md)
+
+## Exit criteria
+
+- The diff is limited to the template and its Quick packet.
+- All listed checks pass.
+- A reviewer can revert the change in one commit.
+
+## Source-lineage note
+
+The proof compares checked-in repository guidance and uses checked-in tests and tooling. It does not create a safety, security, compliance, or assurance claim; broader lineage conventions remain in [`source-map.md`](../../../docs/00-standards-foundation/source-map.md).

--- a/.nuclear/changes/pr-template-mode-alignment/risk.md
+++ b/.nuclear/changes/pr-template-mode-alignment/risk.md
@@ -1,0 +1,41 @@
+# PR template mode alignment — risk
+
+## Selected mode
+
+- **Mode:** Quick
+- **Why this mode:** This is a small, reversible correction to contributor guidance. It changes no runtime behavior, dependency, permission, public claim, or release stance.
+
+## Change
+
+- Slug: `pr-template-mode-alignment`
+- Owner: FlyFission
+- Date: 2026-08-03
+- Summary: Let contributors select the documented administrative floor in the pull-request template and tie packet omission to that mode rather than to a file type.
+
+## Scope and risk
+
+- Affected item: `.github/PULL_REQUEST_TEMPLATE.md`
+- Failure addressed: the template currently starts at Quick even though repository guidance permits an administrative floor, and it implies that being docs-only is enough to omit a packet.
+- Main risk: contributors could overuse the floor. The revised wording requires them to name why it is the lightest honest mode; existing mode triggers remain unchanged.
+- Reversibility: one normal revert.
+
+## Required proof
+
+- Inspect the focused diff.
+- Run `python -m pytest tests/test_public_docs.py -q`, `python tools/ng.py doctor .`, and `git diff --check`.
+- Record results in `proof.md` before commit.
+
+## Exit criteria
+
+- The template names all documented mode levels.
+- Packet omission depends on the administrative-floor criteria, not on whether a change edits documentation.
+- No new gate, artifact, or mode is introduced.
+
+## Required links
+
+- Changed item: [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+- Proof record: [`proof.md`](proof.md)
+
+## Source-lineage note
+
+This change reconciles the repository's own contributor surfaces. It invokes no outside standard and makes no efficacy, compliance, or safety claim; broader lineage conventions remain in [`source-map.md`](../../../docs/00-standards-foundation/source-map.md).


### PR DESCRIPTION
## Summary
- Add the documented administrative floor to the PR template's mode choices.
- Tie packet omission to that mode instead of implying that any docs-only change is trivial.

## Why this is the best 1% move
The contributor template lagged behind the repository's graded-mode guidance. This removes a small but real ambiguity at the exact point where contributors choose rigor, without adding a new mode or artifact.

## Sharpness guardrail
This is a two-line guidance correction. It adds no workflow stage, role, gate, checklist item, or management framework; the Quick packet exists only to make the controlled-template change auditable.

## Verification
- `python -m pytest tests/test_public_docs.py -q` — 15 passed
- `python -m pytest -q` — passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — OK
- `python tools/ng.py validate .nuclear/changes/pr-template-mode-alignment` — OK
- `git diff --check` — passed

## Reversibility
One focused commit; revert it to restore the prior template wording.
