### PR TITLE
docs: add diff check to contributor preflight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,11 @@ python -m ruff check .
 python tools/ng.py doctor .
 python tools/ng.py tokens .
 python tools/ng.py validate docs/03-worked-examples/ai-agent-tool-permissions/.nuclear/changes/add-agent-tool-permissions --strict-custody
+git diff --check
 ```
 
-These are the fast local checks shared with CI; the workflow remains the source of truth.
+The first five commands are the fast local checks shared with CI; `git diff --check`
+catches whitespace errors in the proposed diff. The workflow remains the source of truth.
 
 Also scan new public docs for overclaiming. Lean on phrases like:
 


### PR DESCRIPTION
## Summary
- Add `git diff --check` to the documented contributor preflight.
- Distinguish the five CI-shared commands from this local proposed-diff check.

## Why this is the best 1% move
The PR template already asks contributors to confirm `git diff --check`, but `CONTRIBUTING.md` omitted it. Adding the exact local check catches Markdown and other whitespace errors before review without changing CI or introducing tooling.

## Sharpness guardrail
This documents one existing checklist command and adds no mode, packet, gate, dependency, role, or framework. The administrative floor applies: the commit is the record.

## Verification
- `git diff --check` — passed
- `python -m pytest -q` — 321 passed
- `python -m ruff check .` — passed
- `python tools/ng.py doctor .` — OK
- `python tools/ng.py tokens .` — OK
- flagship worked-example `validate --strict-custody` — OK

## Reversibility
One documentation-only commit; revert it to restore the prior preflight.
