### PR TITLE
chore: make test imports repository-local

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Local test package; prevents imports from resolving to third-party ``tests`` packages."""


### PR DESCRIPTION
## Summary
- make the repository's `tests/` directory an explicit Python package
- prevent absolute imports such as `tests.test_ng_cli` from resolving to an unrelated installed `tests` package

## Why this is the best 1% move
The documented full-suite command failed during collection in the current agent environment because a third-party `tests` package won import resolution. One package marker makes the preflight reproducible without changing product behavior, dependencies, or test logic.

## Sharpness guardrail
This is one explanatory line, not a new workflow, checker, dependency, template, or policy. The administrative floor applies: the commit is the record for an instantly reversible package-boundary fix.

## Verification
- baseline `python -m pytest -q`: failed with 7 `ModuleNotFoundError` collection errors
- `python -c "import tests; print(tests.__file__)"`: now resolves to this checkout
- `python -m pytest -q`: passed (321 tests)
- `python -m ruff check .`: passed
- `python tools/ng.py doctor .`: OK
- `python tools/ng.py tokens .`: OK
- flagship strict-custody validation: OK
- `git diff --check`: passed

## Reversibility
Delete `tests/__init__.py` or revert this one-file commit.
